### PR TITLE
Host on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-
 RUN apt update
 RUN wget https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb
 RUN apt install wget
-RUN dpkg -i google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_114.0.5735.198-1_amd64.deb
 RUN apt-get install -f
 RUN google-chrome --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-
 
 # Install broswer
 RUN apt update
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN wget https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb
 RUN apt install wget
 RUN dpkg -i google-chrome-stable_current_amd64.deb
 RUN apt-get install -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,28 @@
 FROM python:3.11.4
 
+RUN apt-get update
+RUN apt-get install -y fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcups2 libdbus-1-3 libdrm2 libgbm1 libgtk-3-0 libgtk-4-1 libnspr4 libnss3 libu2f-udev libvulkan1 libxcomposite1 libxdamage1 libxfixes3 libxkbcommon0 libxrandr2 xdg-utils
+
+# Install broswer
+RUN apt update
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt install wget
+RUN dpkg -i google-chrome-stable_current_amd64.deb
+RUN apt-get install -f
+RUN google-chrome --version
+
+# Install chrome driver
+RUN wget https://chromedriver.storage.googleapis.com/114.0.5735.90/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip
+RUN mv chromedriver /usr/bin/chromedriver
+RUN chown root:root /usr/bin/chromedriver
+RUN chmod +x /usr/bin/chromedriver
+
 WORKDIR /app
 
 COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 COPY ./ ./
-
 
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/actions/web_scrape.py
+++ b/actions/web_scrape.py
@@ -134,7 +134,7 @@ def scrape_text_with_selenium(url: str) -> tuple[WebDriver, str]:
             options.add_argument("--disable-dev-shm-usage")
             options.add_argument("--remote-debugging-port=9222")
         options.add_argument("--no-sandbox")
-        service = Service(executable_path=ChromeDriverManager().install())
+        service = Service(executable_path='/usr/bin/chromedriver')
         driver = webdriver.Chrome(
             service=service, options=options
         )

--- a/actions/web_scrape.py
+++ b/actions/web_scrape.py
@@ -134,7 +134,7 @@ def scrape_text_with_selenium(url: str) -> tuple[WebDriver, str]:
             options.add_argument("--disable-dev-shm-usage")
             options.add_argument("--remote-debugging-port=9222")
         options.add_argument("--no-sandbox")
-        service = Service(executable_path='/usr/bin/chromedriver')
+        service = Service(executable_path=ChromeDriverManager().install())
         driver = webdriver.Chrome(
             service=service, options=options
         )


### PR DESCRIPTION
The root Dockerfile is missing the Chrome & Chrome-Driver dependencies - so it will only run in dev mode (local machine). 

The fix in this branch will enable you to publish the Docker image on ubuntu. Without the fix, the scraper fails in Production.
From my research, Chrome & Chrome Driver should be the same version. (This branch contains the latest stable versions of both)

Tested locally on Windows - with VScode ssh-ed into server.
Tested on Ubuntu 22.10 - see image below for Digital Ocean droplet size.

You can view the demo with this branch at: https://gptresearcher.gptbud.com

![digital-ocean-droplet](https://github.com/assafelovic/gpt-researcher/assets/16700452/a3f64308-ff5f-4472-9087-dc2415ca69e7)

