### PR TITLE
.add_experimental_option exists only in ChromeDrive

### DIFF
--- a/actions/web_scrape.py
+++ b/actions/web_scrape.py
@@ -116,9 +116,6 @@ def scrape_text_with_selenium(url: str) -> tuple[WebDriver, str]:
     options = options_available[CFG.selenium_web_browser]()
     options.add_argument(CFG.user_agent)
     options.add_argument('--headless')
-    options.add_experimental_option(
-        "prefs", {"download_restrictions": 3}
-    )
 
     if CFG.selenium_web_browser == "firefox":
         service = Service(executable_path=GeckoDriverManager().install())
@@ -134,6 +131,9 @@ def scrape_text_with_selenium(url: str) -> tuple[WebDriver, str]:
             options.add_argument("--disable-dev-shm-usage")
             options.add_argument("--remote-debugging-port=9222")
         options.add_argument("--no-sandbox")
+        options.add_experimental_option(
+            "prefs", {"download_restrictions": 3}
+        )
         service = Service(executable_path=ChromeDriverManager().install())
         driver = webdriver.Chrome(
             service=service, options=options


### PR DESCRIPTION
.add_experimental_option exists only in chromeDrive, this line causes errors logged when users use other drivers e.g firefox.