### PR TITLE
Add custom api base

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ $ pip install -r requirements.txt
 
 ```bash
 $ export OPENAI_API_KEY={Your API Key here}
+$ export OPENAI_API_BASE={Your API Base here} (required if you are using a custom API base)
 ```
 <br />
 
@@ -94,6 +95,7 @@ Follow instructions at https://docs.docker.com/engine/install/
 
 ```bash
 $ export OPENAI_API_KEY={Your API Key here}
+$ export OPENAI_API_BASE={Your API Base here} (required if you are using a custom API base)
 ```
 
 > **Step 3** - Run the application

--- a/agent/llm_utils.py
+++ b/agent/llm_utils.py
@@ -14,6 +14,7 @@ from config import Config
 CFG = Config()
 
 openai.api_key = CFG.openai_api_key
+openai.api_base = CFG.openai_api_base
 
 from typing import Optional
 import logging

--- a/config/config.py
+++ b/config/config.py
@@ -28,6 +28,7 @@ class Config(metaclass=Singleton):
         self.browse_chunk_max_length = int(os.getenv("BROWSE_CHUNK_MAX_LENGTH", 8192))
 
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.openai_api_base = os.getenv("OPENAI_API_BASE", openai.api_base)
         self.temperature = float(os.getenv("TEMPERATURE", "1"))
 
         self.user_agent = os.getenv(


### PR DESCRIPTION
I believe that including an option for a (free) third-party API (e.g., [chimeragpt](https://chimeragpt.adventblocks.cc/)) could be beneficial for those who have trouble paying for the openai api or just as an alternative for development.