### PR TITLE
Ability to select GPT models

### DIFF
--- a/agent/llm_utils.py
+++ b/agent/llm_utils.py
@@ -133,7 +133,8 @@ def choose_agent(task: str) -> str:
     except Exception as e:
         print(f"{Fore.RED}Error in choose_agent: {e}{Style.RESET_ALL}")
         return {"agent": "Default Agent",
-                "agent_role_prompt": "You are an AI critical thinker research assistant. Your sole purpose is to write well written, critically acclaimed, objective and structured reports on given text."}
+                "agent_role_prompt": "You are an AI critical thinker research assistant. Your sole purpose is to write well written, critically acclaimed, objective and structured reports on given text.",
+                "error": e}
 
 def choose_agent_configuration():
     configuration = [

--- a/agent/llm_utils.py
+++ b/agent/llm_utils.py
@@ -133,8 +133,7 @@ def choose_agent(task: str) -> str:
     except Exception as e:
         print(f"{Fore.RED}Error in choose_agent: {e}{Style.RESET_ALL}")
         return {"agent": "Default Agent",
-                "agent_role_prompt": "You are an AI critical thinker research assistant. Your sole purpose is to write well written, critically acclaimed, objective and structured reports on given text.",
-                "error": e}
+                "agent_role_prompt": "You are an AI critical thinker research assistant. Your sole purpose is to write well written, critically acclaimed, objective and structured reports on given text."}
 
 def choose_agent_configuration():
     configuration = [

--- a/client/index.html
+++ b/client/index.html
@@ -81,6 +81,21 @@
                 <option value="outline_report">Outline Report</option>
             </select>
         </div>
+        <div class="form-group">
+            <label for="llm_model" class="agent-question">Which language model would you like me to use?</label>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="llm_model" id="gpt-4" value="gpt-4" checked>
+                <label class="form-check-label" for="gpt-4">
+                    GPT-4
+                </label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="llm_model" id="gpt-3.5-turbo-16k" value="gpt-3.5-turbo-16k">
+                <label class="form-check-label" for="gpt-3.5-turbo-16k">
+                    GPT-3.5-Turbo-16k
+                </label>
+            </div>
+        </div>
         <input type="submit" value="Research" class="btn btn-primary button-padding">
     </form>
 

--- a/client/scripts.js
+++ b/client/scripts.js
@@ -22,6 +22,8 @@ const GPTResearcher = (() => {
           writeReport(data, converter);
         } else if (data.type === 'path') {
           updateDownloadLink(data);
+        } else if (data.type === 'error') {
+          addAgentResponse(data);
         }
       };
   
@@ -29,11 +31,13 @@ const GPTResearcher = (() => {
         const task = document.querySelector('input[name="task"]').value;
         const report_type = document.querySelector('select[name="report_type"]').value;
         const agent = document.querySelector('input[name="agent"]:checked').value;
-  
+        const llm_model = document.querySelector('input[name="llm_model"]:checked').value;
+
         const requestData = {
           task: task,
           report_type: report_type,
           agent: agent,
+          llm_model: llm_model
         };
   
         socket.send(`start ${JSON.stringify(requestData)}`);
@@ -42,7 +46,13 @@ const GPTResearcher = (() => {
   
     const addAgentResponse = (data) => {
       const output = document.getElementById("output");
-      output.innerHTML += '<div class="agent_response">' + data.output + '</div>';
+      let responseClass = "agent_response";
+    
+      if (data.type === 'error') {
+        responseClass += " error";
+      }
+    
+      output.innerHTML += `<div class="${responseClass}">${data.output}</div>`;
       output.scrollTop = output.scrollHeight;
       output.style.display = "block";
       updateScroll();

--- a/client/styles.css
+++ b/client/styles.css
@@ -129,3 +129,7 @@ footer {
     padding: 10px;
     border-radius: 12px;
 }
+
+.agent_response.error {
+    color: red;
+  }

--- a/config/config.py
+++ b/config/config.py
@@ -15,6 +15,13 @@ class Config(metaclass=Singleton):
     Configuration class to store the state of bools for different scripts access.
     """
 
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(Config, cls).__new__(cls, *args, **kwargs)
+        return cls._instance
+
     def __init__(self) -> None:
         """Initialize the Config class"""
         self.debug_mode = False


### PR DESCRIPTION
Since its a bit annoying to have to change to the GPT-3.5-model in code, it might be useful to change the gpt model between gpt-3.5-turbo and gpt-4 in the frontend. Might also be nice if someone wants to save some credits and thus wants to switch from 4 to 3.5.

* Uses radio buttons for selection.
* Shows an error on failure in the agent output box.
* I also changed the Config to use the Singleton pattern (one instance for the whole application), which a Configuration should be.