### PR TITLE
adding support for Claude, Cohere and PaLM

### DIFF
--- a/agent/llm_utils.py
+++ b/agent/llm_utils.py
@@ -4,7 +4,7 @@ import json
 
 from fastapi import WebSocket
 import time
-
+from litellm import completion
 import openai
 from colorama import Fore, Style
 from openai.error import APIError, RateLimitError
@@ -69,7 +69,7 @@ def send_chat_completion_request(
     messages, model, temperature, max_tokens, stream, websocket
 ):
     if not stream:
-        result = openai.ChatCompletion.create(
+        result = completion(
             model=model,
             messages=messages,
             temperature=temperature,
@@ -114,7 +114,7 @@ def choose_agent(task: str) -> str:
     try:
         configuration = choose_agent_configuration()
 
-        response = openai.ChatCompletion.create(
+        response = completion(
             model=CFG.smart_llm_model,
             messages=[
                 {"role": "user", "content": f"{task}"}],

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pydantic
 fastapi
 python-multipart
 markdown
+litellm==0.1.2291


### PR DESCRIPTION
Hi @assafelovic @gregdrizz ,

Noticed y'all are calling just OpenAI. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

Added support for Anthropic, Llama2, Cohere and PaLM by replacing the raw openai.ChatCompletion.acreate endpoint with acompletion from litellm.

Would love to know if this helps.