### PR TITLE
Fix copy to clipboard not working

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -93,7 +93,7 @@
     <div class="margin-div">
         <h2>Research Report</h2>
         <div id="reportContainer"></div>
-        <button onclick="copyToClipboard()" class="btn btn-secondary mt-3">Copy to clipboard</button>
+        <button onclick="GPTResearcher.copyToClipboard()" class="btn btn-secondary mt-3">Copy to clipboard</button>
         <a id="downloadLink" href="#" class="btn btn-secondary mt-3" target="_blank">Download as PDF</a>
     </div>
 </main>


### PR DESCRIPTION
A missing `GPTResearcher.` before the function call prevented the copy to clipboard function from being called.