### PR TITLE
ubuntu Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 FROM python:3.11.4-slim-bullseye as install-browser
 
 RUN apt-get update \
-    && apt-get satisfy -y \
-    "chromium, chromium-driver (>= 115.0)" \
-    && chromium --version && chromedriver --version
+    && apt-get install -y gnupg2 curl unzip
+
+# Add Google Chrome repository and install Chromium and Chromium driver
+RUN curl -sSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable chromium-driver
+
+# Verify versions of Chromium and Chromium driver
+RUN chromium --version \
+    && chromedriver --version
 
 FROM install-browser as gpt-researcher-install
 
@@ -25,5 +33,5 @@ USER gpt-researcher
 COPY --chown=gpt-researcher:gpt-researcher ./ ./
 
 EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Fixes the scraping capability via Docker for Ubuntu.

Unfortunately doesn't work for mac (crashes on "Docker-compose up --build")

The issue is that the currently Dockerfile doesn't accurately verifying that the Chromium & Chromium Driver Packages installed in the container will be the same

[GPT Discord Thread](https://discord.com/channels/1127851779011391548/1151140679171448934/1161604588978323477
)

Long-term: I would delegate the scraping to a package that specializes in scraping, like:

https://www.npmjs.com/package/node-spider

And create an endpoint which specializes just in scraping an individual page, parsing, and embedding chunks of the text in a Vector DB & returning the text back to the GPT-Agent ([Example here](https://github.com/pinecone-io/pinecone-vercel-starter/blob/main/src/app/api/crawl/seed.ts))