### PR TITLE
Add support for Searx API

### DIFF
--- a/actions/web_search.py
+++ b/actions/web_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 from duckduckgo_search import DDGS
 from tavily import Client
+from langchain.utilities import SearxSearchWrapper
 import os
 from config import Config
 
@@ -21,6 +22,11 @@ def web_search(query: str, num_results: int = 4) -> str:
         results = tavily_search.search(query, search_depth="basic").get("results", [])
         # Normalizing results to match the format of the other search APIs
         search_response = [{"href": obj["url"], "body": obj["content"]} for obj in results]
+    elif CFG.search_api == "searx":
+        searx = SearxSearchWrapper(searx_host=os.environ["SEARX_URL"])
+        results = searx.results(query, num_results)
+        # Normalizing results to match the format of the other search APIs
+        search_response = [{"href": obj["link"], "body": obj["snippet"]} for obj in results]
     elif CFG.search_api == "duckduckgo":
         ddgs = DDGS()
         search_response = ddgs.text(query)


### PR DESCRIPTION
This PR adds support for SearxNG API. It is supported in Langchain and since it's a dependency already, i've basically just added it from there.

The PR will allow `SEARCH_API` to be filled with `searx` and expects an additional option called `SEARX_URL`. You only need to point to the instance without an additional paths.

If you're unfamiliar with [SearxNG](https://github.com/searxng/searxng), it's a meta search engine. It allows you to customize your searches or desired search engines to a great detail. It supports a large list of sources. According to the [documentation](https://docs.searxng.org/user/configured_engines.html#configured-engines) it could be around 174 search engines. But most people will probably not configure it like this.

Technically it would also be a good way to provide privacy. But the catch about SearxNG is that most publically hosted instances aren't allowing API calls, which this project is aiming for. So in order to make use of the added feature in this PR, you would need to host an instance yourself. Due to this you'll be exposing your own IP to search engines anyways. 

Hosting your own instance on your local machine is as straight forward as it could be. Just get the Docker Compose file from their [Github](https://github.com/searxng/searxng-docker) and run it.