### PR TITLE
Fixes: can't run with firefox as selenium browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ RUN apt-get update \
     "chromium, chromium-driver (>= 115.0)" \
     && chromium --version && chromedriver --version
 
+RUN apt-get install -y firefox-esr wget \
+    && wget https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz \
+    && tar -xvzf geckodriver* \
+    && chmod +x geckodriver \
+    && mv geckodriver /usr/local/bin/
+
 FROM install-browser as gpt-researcher-install
 
 ENV PIP_ROOT_USER_ACTION=ignore

--- a/actions/web_scrape.py
+++ b/actions/web_scrape.py
@@ -7,10 +7,7 @@ from pathlib import Path
 from sys import platform
 
 from bs4 import BeautifulSoup
-from webdriver_manager.chrome import ChromeDriverManager
-from webdriver_manager.firefox import GeckoDriverManager
 from selenium import webdriver
-from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
@@ -132,8 +129,7 @@ def scrape_text_with_selenium(url: str) -> tuple[WebDriver, str]:
     options.add_argument("--enable-javascript")
 
     if CFG.selenium_web_browser == "firefox":
-        service = Service(executable_path=GeckoDriverManager().install())
-        driver = webdriver.Firefox(service=service, options=options)
+        driver = webdriver.Firefox(options=options)
     elif CFG.selenium_web_browser == "safari":
         # Requires a bit more setup on the users end
         # See https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari


### PR DESCRIPTION
Fixes #227 

- Adds firefox and geckodriver to the dockerfile
- Replaces `GeckoDriverManager().install()` with installing geckodriver in the dockerfile