### PR TITLE
Fix serper retriever

### DIFF
--- a/gpt_researcher/master/functions.py
+++ b/gpt_researcher/master/functions.py
@@ -25,7 +25,7 @@ def get_retriever(retriever):
         case "searx":
             from gpt_researcher.retrievers import SearxSearch
             retriever = SearxSearch
-        case "serp":
+        case "googleSerp":
             from gpt_researcher.retrievers import SerpSearch
             retriever = SerpSearch
         case "duckduckgo":

--- a/gpt_researcher/master/functions.py
+++ b/gpt_researcher/master/functions.py
@@ -25,9 +25,13 @@ def get_retriever(retriever):
         case "searx":
             from gpt_researcher.retrievers import SearxSearch
             retriever = SearxSearch
+        case "serpapi":
+            raise NotImplementedError("SerpApiSearch is not fully implemented yet.")
+            from gpt_researcher.retrievers import SerpApiSearch
+            retriever = SerpApiSearch
         case "googleSerp":
-            from gpt_researcher.retrievers import SerpSearch
-            retriever = SerpSearch
+            from gpt_researcher.retrievers import SerperSearch
+            retriever = SerperSearch
         case "duckduckgo":
             from gpt_researcher.retrievers import Duckduckgo
             retriever = Duckduckgo

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -1,7 +1,8 @@
 from .tavily_search.tavily_search import TavilySearch
 from .duckduckgo.duckduckgo import Duckduckgo
 from .google.google import GoogleSearch
-from .serper.serper import SerpSearch
+from .serper.serper import SerperSearch
+from .serpapi.serpapi import SerpApiSearch
 from .searx.searx import SearxSearch
 
-__all__ = ["TavilySearch", "Duckduckgo", "SerpSearch", "GoogleSearch", "SearxSearch"]
+__all__ = ["TavilySearch", "Duckduckgo", "SerperSearch", "SerpApiSearch", "GoogleSearch", "SearxSearch"]

--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -1,4 +1,4 @@
-# Google Serper Retriever
+# SerpApi Retriever
 
 # libraries
 import os
@@ -6,30 +6,31 @@ import requests
 import json
 
 
-class SerperSearch():
+class SerpApiSearch():
     """
-    Google Serper Retriever
+    SerpApi Retriever
     """
     def __init__(self, query):
         """
-        Initializes the SerperSearch object
+        Initializes the SerpApiSearch object
         Args:
             query:
         """
+        raise NotImplementedError("SerpApiSearch is not fully implemented yet.")
         self.query = query
         self.api_key = self.get_api_key()
 
     def get_api_key(self):
         """
-        Gets the Serper API key
+        Gets the SerpApi API key
         Returns:
 
         """
         try:
-            api_key = os.environ["SERPER_API_KEY"]
+            api_key = os.environ["SERPAPI_API_KEY"]
         except:
-            raise Exception("Serper API key not found. Please set the SERPER_API_KEY environment variable. "
-                            "You can get a key at https://serper.dev/")
+            raise Exception("SerpApi API key not found. Please set the SERPAPI_API_KEY environment variable. "
+                            "You can get a key at https://serpapi.com/")
         return api_key
 
     def search(self, max_results=7):
@@ -39,19 +40,15 @@ class SerperSearch():
 
         """
         print("Searching with query {0}...".format(self.query))
-        """Useful for general internet search queries using the Serp API."""
+        """Useful for general internet search queries using SerpApi."""
 
 
-        # Search the query (see https://serper.dev/playground for the format)
-        url = "https://google.serper.dev/search"
-
-        headers = {
-        'X-API-KEY': self.api_key,
-        'Content-Type': 'application/json'
-        }
-        data = json.dumps({"q": self.query})
-
-        resp = requests.request("POST", url, headers=headers, data=data)
+        # Perform the search
+        # TODO: query needs to be url encoded, so the code won't work as is.
+        # Encoding should look something like this (but this is untested):
+        # url_encoded_query = self.query.replace(" ", "+")
+        url = "https://serpapi.com/search.json?engine=google&q=" + self.query + "&api_key=" + self.api_key
+        resp = requests.request("GET", url)
 
         # Preprocess the results
         if resp is None:
@@ -63,7 +60,7 @@ class SerperSearch():
         if search_results is None:
             return
 
-        results = search_results["organic"]
+        results = search_results["organic_results"]
         search_results = []
 
         # Normalize the results to match the format of the other search APIs

--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -1,33 +1,30 @@
-# Tavily API Retriever
+# Serper API Retriever
 
 # libraries
 import os
 import requests
 import json
-from tavily import TavilyClient
 
 
 class SerpSearch():
     """
-    Tavily API Retriever
+    Serper API Retriever
     """
     def __init__(self, query):
         """
-        Initializes the TavilySearch object
+        Initializes the SerpSearch object
         Args:
             query:
         """
         self.query = query
         self.api_key = self.get_api_key()
-        self.client = TavilyClient(self.api_key)
 
     def get_api_key(self):
         """
-        Gets the Tavily API key
+        Gets the Serper API key
         Returns:
 
         """
-        # Get the API key
         try:
             api_key = os.environ["SERP_API_KEY"]
         except:
@@ -43,9 +40,20 @@ class SerpSearch():
         """
         print("Searching with query {0}...".format(self.query))
         """Useful for general internet search queries using the Serp API."""
-        url = "https://serpapi.com/search.json?engine=google&q=" + self.query + "&api_key=" + self.api_key
-        resp = requests.request("GET", url)
 
+
+        # Search the query (see https://serper.dev/playground for the format)
+        url = "https://google.serper.dev/search"
+
+        headers = {
+        'X-API-KEY': self.api_key,
+        'Content-Type': 'application/json'
+        }
+        data = json.dumps({"q": self.query})
+
+        resp = requests.request("POST", url, headers=headers, data=data)
+
+        # Preprocess the results
         if resp is None:
             return
         try:
@@ -55,10 +63,10 @@ class SerpSearch():
         if search_results is None:
             return
 
-        results = search_results["organic_results"]
+        results = search_results["organic"]
         search_results = []
 
-        # Normalizing results to match the format of the other search APIs
+        # Normalize the results to match the format of the other search APIs
         for result in results:
             # skip youtube results
             if "youtube.com" in result["link"]:


### PR DESCRIPTION
Background: [PR 237](https://github.com/assafelovic/gpt-researcher/pull/237) introduced a mix-up, it replaced the correct code for the Google Serper retriever (serper.dev) with code for SerpApi (serpai.com). It looks like the author of the PR may have confused one for the other and thought that the existing correct code was a bug.

This PR:
- brings back the correct code (with small improvements)
- adds the SerApi code from PR 237 as a separate retriever (although that code appears to have an issue, as I noted in the code itself, thus for now I didn't fully enable that retriever)
- resolves a couple of naming issues (e.g. 'serp' vs 'googleSerp' as the name of the retriever)