### PR TITLE
Adding Azure OpenAI Model Support

### DIFF
--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -9,7 +9,8 @@ class Config:
         """Initialize the config class."""
         self.config_file = config_file
         self.retriever = "tavily"
-        self.llm_provider = "ChatOpenAI"
+        self.llm_provider = "AzureChatOpenAI"
+        self.azure_embedding_model = "ada2"
         self.fast_llm_model = "gpt-3.5-turbo-16k"
         self.smart_llm_model = "gpt-4-1106-preview"
         self.fast_token_limit = 2000

--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -1,10 +1,12 @@
 from langchain.vectorstores import FAISS
 from langchain.embeddings import OpenAIEmbeddings
+from gpt_researcher.config import Config
+from langchain.embeddings import AzureOpenAIEmbeddings
 
 
 class Memory:
-    def __init__(self, **kwargs):
-        self._embeddings = OpenAIEmbeddings()
+    def __init__(self, cfg, **kwargs):
+        self._embeddings = AzureOpenAIEmbeddings(Config().azure_embedding_model, chunk_size=16)
 
     def get_embeddings(self):
         return self._embeddings

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -39,8 +39,9 @@ async def create_chat_completion(
 
     # create response
     for attempt in range(10):  # maximum of 10 attempts
+        deployment_name=model
         response = await send_chat_completion_request(
-            messages, model, temperature, max_tokens, stream, llm_provider, websocket
+            messages, deployment_name, temperature, max_tokens, stream, llm_provider, websocket
         )
         return response
 
@@ -56,7 +57,7 @@ async def send_chat_completion_request(
 ):
     if not stream:
         result = lc_openai.ChatCompletion.create(
-            model=model,  # Change model here to use different models
+            deployment_name=model,  # Change model here to use different models
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -64,7 +65,8 @@ async def send_chat_completion_request(
         )
         return result["choices"][0]["message"]["content"]
     else:
-        return await stream_response(model, messages, temperature, max_tokens, llm_provider, websocket)
+        deployment_name=model
+        return await stream_response(deployment_name, messages, temperature, max_tokens, llm_provider, websocket)
 
 
 async def stream_response(model, messages, temperature, max_tokens, llm_provider, websocket=None):
@@ -72,7 +74,7 @@ async def stream_response(model, messages, temperature, max_tokens, llm_provider
     response = ""
 
     for chunk in lc_openai.ChatCompletion.create(
-            model=model,
+            deployment_name=model,
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -104,7 +106,7 @@ def choose_agent(smart_llm_model: str, llm_provider: str, task: str) -> dict:
     """
     try:
         response = create_chat_completion(
-            model=smart_llm_model,
+            deployment_name=smart_llm_model,
             messages=[
                 {"role": "system", "content": f"{auto_agent_instructions()}"},
                 {"role": "user", "content": f"task: {task}"}],


### PR DESCRIPTION
Adding supoprt for Azure OpenAI model deployments.

Note: These are breaking changes that mean only Azure OpenAI models will working using them. To merge these in correctly logic will be required in both the memory embeddings and LLM functions so that when self.llm_provider = "AzureChatOpenAI" the correct Azure version of the code is used.