### PR TITLE
Remove $ from terminal commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,25 +75,25 @@ Please see [here](https://docs.tavily.com/docs/gpt-researcher/getting-started) f
 > **Step 1** - Download the project
 
 ```bash
-$ git clone https://github.com/assafelovic/gpt-researcher.git
-$ cd gpt-researcher
+git clone https://github.com/assafelovic/gpt-researcher.git
+cd gpt-researcher
 ```
 
 <br />
 
 > **Step 2** - Install dependencies
 ```bash
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 <br />
 
 > **Step 3** - Create .env file with your OpenAI Key and Tavily API key or simply export it
 
 ```bash
-$ export OPENAI_API_KEY={Your OpenAI API Key here}
+export OPENAI_API_KEY={Your OpenAI API Key here}
 ```
 ```bash
-$ export TAVILY_API_KEY={Your Tavily API Key here}
+export TAVILY_API_KEY={Your Tavily API Key here}
 ```
 
 - **For LLM, we recommend [OpenAI GPT](https://platform.openai.com/docs/guides/gpt)**, but you can use any other LLM model (including open sources) supported by [Langchain Adapter](https://python.langchain.com/docs/guides/adapters/openai), simply change the llm model and provider in config/config.py. Follow [this guide](https://python.langchain.com/docs/integrations/llms/) to learn how to integrate LLMs with Langchain. 
@@ -105,7 +105,7 @@ $ export TAVILY_API_KEY={Your Tavily API Key here}
 > **Step 4** - Run the agent with FastAPI
 
 ```bash
-$ uvicorn main:app --reload
+uvicorn main:app --reload
 ```
 <br />
 


### PR DESCRIPTION
When I copy the command on the README file:
![image](https://github.com/assafelovic/gpt-researcher/assets/21064858/4aa8008a-90b3-4c63-837d-bf9cf7b2ef88)
I see the $ sign also gets copied to the clipboard:
![clipboard](https://github.com/assafelovic/gpt-researcher/assets/21064858/3c1feade-d1f6-4963-aa26-db2f096982ce)
This throws an error when you directly run the command in the terminal.

Removing the $ symbol makes the commands easier to copy-paste.