### PR TITLE
fix: Fail to load app #328. Added aiofiles dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ arxiv==2.0.0
 PyMuPDF==1.23.6
 requests==2.31.0
 jinja2==3.1.2
+aiofiles==23.2.1


### PR DESCRIPTION
This PR adds aiofiles dependency to requeriments,txt. Installation from scratch does not work with python 3.11 or creating a new docker image. Close #328 