### PR TITLE
add aiofiles to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ arxiv==2.0.0
 PyMuPDF==1.23.6
 requests==2.31.0
 jinja2==3.1.2
+aiofiles==23.2.1


### PR DESCRIPTION
Dependency on aiofiles missing from requirements.txt

Error with latest:

```
uvicorn main:app --reload
--> ModuleNotFoundError: No module named 'aiofiles'
```

Usage of aiofiles:
https://github.com/assafelovic/gpt-researcher/blob/22c27c399148d7851cd42b6e009b7c6c477128ea/backend/utils.py#L1

