### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ arxiv==2.0.0
 PyMuPDF==1.23.6
 requests==2.31.0
 jinja2==3.1.2
+aiofiles~=23.2.1


### PR DESCRIPTION
Currently, the dependencies listed in requirements.txt are insufficient to run the app. Docker container also doesn't start with error "ModuleNotFoundError: No module named 'aiofiles'". This PR fixes the problem.