### PR TITLE
Add support for various embedding provider

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
             "allow_downloads": false,
             "selenium_web_browser": "chrome",
             "search_api": "tavily",
+            "embedding_provider": "openai",
             "llm_provider": "ChatOpenAI",
             "fast_llm_model": "gpt-3.5-turbo-16k",
             "smart_llm_model": "gpt-4",

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -10,6 +10,7 @@ class Config:
         """Initialize the config class."""
         self.config_file = config_file if config_file else os.getenv('CONFIG_FILE')
         self.retriever = os.getenv('SEARCH_RETRIEVER', "tavily")
+        self.embedding_provider = os.getenv('EMBEDDING_PROVIDER', 'openai')
         self.llm_provider = os.getenv('LLM_PROVIDER', "ChatOpenAI")
         self.fast_llm_model = os.getenv('FAST_LLM_MODEL', "gpt-3.5-turbo-16k")
         self.smart_llm_model = os.getenv('SMART_LLM_MODEL', "gpt-4-1106-preview")

--- a/gpt_researcher/master/agent.py
+++ b/gpt_researcher/master/agent.py
@@ -27,7 +27,7 @@ class GPTResearcher:
         self.retriever = get_retriever(self.cfg.retriever)
         self.context = []
         self.source_urls = source_urls
-        self.memory = Memory()
+        self.memory = Memory(self.cfg.embedding_provider)
         self.visited_urls = set()
 
     async def run(self):

--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -1,11 +1,28 @@
 from langchain.vectorstores import FAISS
-from langchain.embeddings import OpenAIEmbeddings
 
 
 class Memory:
-    def __init__(self, **kwargs):
-        self._embeddings = OpenAIEmbeddings()
+    def __init__(self, embedding_provider, **kwargs):
+
+        _embeddings = None
+        match embedding_provider:
+            case "ollama":
+                from langchain_community.embeddings import OllamaEmbeddings
+                _embeddings = OllamaEmbeddings(model="llama2")
+            case "openai":
+                from langchain.embeddings import OpenAIEmbeddings
+                _embeddings = OpenAIEmbeddings()
+            case "huggingface":
+                from langchain_community.embeddings import HuggingFaceEmbeddings
+                _embeddings = HuggingFaceEmbeddings()
+            case "mixtral":
+                from langchain_mistralai import MistralAIEmbeddingscase
+                _embeddings = MistralAIEmbeddingscase
+
+            case _:
+                raise Exception("Embedding provider not found.")
+
+        self._embeddings = _embeddings
 
     def get_embeddings(self):
         return self._embeddings
-


### PR DESCRIPTION
Introduce support for additional embedding models, such as Hugging Face, MixTRAL, Ollama, etc., allowing users to select their preferred model in the config.json file simply. Any model supported by [langchain embedding](https://python.langchain.com/docs/integrations/text_embedding) can be added easily.

Particularly beneficial for users who do not have access to the OpenAI API, like me XD.