### PR TITLE
fix #423 Missing python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ mistune
 python-docx
 htmldocx
 langchain-google-genai
+lxml[html_clean]


### PR DESCRIPTION
fix #423 
Missing python package lxml[html_clean] to the requirements.txt