### PR TITLE
feat: CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,93 @@
+"""
+Provides a command line interface for the GPTResearcher class.
+
+Usage:
+
+```shell
+python cli.py "<query>" --report_type <report_type>
+```
+
+"""
+import asyncio
+import argparse
+from argparse import RawTextHelpFormatter
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from gpt_researcher import GPTResearcher
+from gpt_researcher.utils.enum import ReportType
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+cli = argparse.ArgumentParser(
+    description="Generate a research report.",
+    # Enables the use of newlines in the help message
+    formatter_class=RawTextHelpFormatter)
+
+# =====================================
+# Arg: Query
+# =====================================
+
+cli.add_argument(
+    # Position 0 argument
+    "query",
+    type=str,
+    help="The query to conduct research on.")
+
+# =====================================
+# Arg: Report Type
+# =====================================
+
+choices = [report_type.value for report_type in ReportType]
+
+report_type_descriptions = {
+    ReportType.ResearchReport.value: "Summary - Short and fast (~2 min)",
+    ReportType.DetailedReport.value: "Detailed - In depth and longer (~5 min)",
+    ReportType.ResourceReport.value: "",
+    ReportType.OutlineReport.value: "",
+    ReportType.CustomReport.value: "",
+    ReportType.SubtopicReport.value: ""
+}
+
+cli.add_argument(
+    "--report_type",
+    type=str,
+    help="The type of report to generate. Options:\n" + "\n".join(
+        f"  {choice}: {report_type_descriptions[choice]}" for choice in choices
+    ),
+    # Deserialize ReportType as a List of strings:
+    choices=choices,
+    required=True)
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+async def main(args):
+    """ 
+    Conduct research on the given query, generate the report, and write
+    it as a markdown file to the output directory.
+    """
+    researcher = GPTResearcher(
+        query=args.query,
+        report_type=args.report_type)
+
+    await researcher.conduct_research()
+
+    report = await researcher.write_report()
+
+    # Write the report to a file
+    artifact_filepath = f"outputs/{uuid4()}.md"
+    with open(artifact_filepath, "w") as f:
+        f.write(report)
+
+    print(f"Report written to '{artifact_filepath}'")
+
+if __name__ == "__main__":
+    load_dotenv()
+    args = cli.parse_args()
+    asyncio.run(main(args))

--- a/examples/sample_report.py
+++ b/examples/sample_report.py
@@ -15,7 +15,7 @@ async def main():
     # Initialize the researcher
     researcher = GPTResearcher(query=query, report_type=report_type, config_path=None)
     # Conduct research on the given query
-    researcher.conduct_research()
+    await researcher.conduct_research()
     # Write the report
     report = await researcher.write_report()
     


### PR DESCRIPTION
## Summary

Adds a Command Line Interface which emulates the web functionality of defining a query and selecting a report type.

## Motivations

- Renders the web application unnecessary.
- Enables language-agnostic, programmatic invocation by third party software.

## Changes

N/A

## Fixes

- Awaiting `researcher.conduct_research` in the example