### PR TITLE
fix: add lxml with html_clean extra to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ htmldocx = "^0.0.6"
 python-docx = "^1.1.0"
 langchain-openai = "^0.1.0"
 langchain-google-genai = "^0.0.11"
-
+lxml = { version = ">=4.9.2", extras = ["html_clean"] }
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Currently, cannot start project if installed with `poetry install`