### PR TITLE
fix: Use total_words parameters in the prompts

### DIFF
--- a/gpt_researcher/master/prompts.py
+++ b/gpt_researcher/master/prompts.py
@@ -59,7 +59,7 @@ def generate_report_prompt(question, context, report_format="apa", total_words=1
             f"Assume that the current date is {datetime.now().strftime('%B %d, %Y')}"
 
 
-def generate_resource_report_prompt(question, context, report_format="apa", total_words=1000):
+def generate_resource_report_prompt(question, context, report_format="apa", total_words=700):
     """Generates the resource report prompt for the given question and research summary.
 
     Args:
@@ -75,7 +75,7 @@ def generate_resource_report_prompt(question, context, report_format="apa", tota
            'Focus on the relevance, reliability, and significance of each source.\n' \
            'Ensure that the report is well-structured, informative, in-depth, and follows Markdown syntax.\n' \
            'Include relevant facts, figures, and numbers whenever available.\n' \
-           'The report should have a minimum length of 700 words.\n' \
+           f'The report should have a minimum length of {total_words} words.\n' \
         'You MUST include all relevant source urls.'\
         'Every url should be hyperlinked: [url website](url)'
 
@@ -84,7 +84,7 @@ def generate_custom_report_prompt(query_prompt, context, report_format="apa", to
     return f'"{context}"\n\n{query_prompt}'
 
 
-def generate_outline_report_prompt(question, context, report_format="apa", total_words=1000):
+def generate_outline_report_prompt(question, context, report_format="apa", total_words=1200):
     """ Generates the outline report prompt for the given question and research summary.
     Args: question (str): The question to generate the outline report prompt for
             research_summary (str): The research summary to generate the outline report prompt for
@@ -94,7 +94,7 @@ def generate_outline_report_prompt(question, context, report_format="apa", total
     return f'"""{context}""" Using the above information, generate an outline for a research report in Markdown syntax' \
            f' for the following question or topic: "{question}". The outline should provide a well-structured framework' \
            ' for the research report, including the main sections, subsections, and key points to be covered.' \
-           ' The research report should be detailed, informative, in-depth, and a minimum of 1,200 words.' \
+           f' The research report should be detailed, informative, in-depth, and a minimum of {total_words} words.' \
            ' Use appropriate Markdown syntax to format the outline and ensure readability.'
 
 
@@ -210,6 +210,7 @@ def generate_subtopic_report_prompt(
     - The focus MUST be on the main topic! You MUST Leave out any information un-related to it!
     - Must NOT have any introduction, conclusion, summary or reference section.
     - You MUST include hyperlinks with markdown syntax ([url website](url)) related to the sentences wherever necessary.
+    - The report should have a minimum length of {total_words} words.
     """
 
 


### PR DESCRIPTION
While reviewing the prompts, I noticed that on a few prompts the parameter `total_words` is not being used.

Let me know if this is ok to merge or if it requires additional changes