### PR TITLE
modified to new cheaper OpenAI embedding

### DIFF
--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -12,7 +12,7 @@ class Memory:
                 _embeddings = OllamaEmbeddings(model="llama2")
             case "openai":
                 from langchain_openai import OpenAIEmbeddings
-                _embeddings = OpenAIEmbeddings()
+                _embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
             case "azureopenai":
                 from langchain_openai import AzureOpenAIEmbeddings
                 _embeddings = AzureOpenAIEmbeddings(deployment=os.environ["AZURE_EMBEDDING_MODEL"], chunk_size=16)


### PR DESCRIPTION
Updated OpenAI embeddings to new `text-embedding-3-small` model.

Information about the new model from [OpenAI docs](https://openai.com/index/new-embedding-models-and-api-updates/):
text-embedding-3-small is our new highly efficient embedding model and provides a significant upgrade over its predecessor, the text-embedding-ada-002 model released in [December 2022](https://openai.com/index/new-and-improved-embedding-model/). 

**Stronger performance.** Comparing text-embedding-ada-002 to text-embedding-3-small, the average score on a commonly used benchmark for multi-language retrieval ([MIRACL](https://github.com/project-miracl/miracl)) has increased from 31.4% to 44.0%, while the average score on a commonly used benchmark for English tasks ([MTEB](https://github.com/embeddings-benchmark/mteb)) has increased from 61.0% to 62.3%.

**Reduced price.** text-embedding-3-small is also substantially more efficient than our previous generation text-embedding-ada-002 model. Pricing for text-embedding-3-small has therefore been reduced by 5X compared to text-embedding-ada-002, from a price per 1k tokens of $0.0001 to $0.00002.