### PR TITLE
remove DOC_Path from docker-compose - rely on .env instead

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     environment: 
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       TAVILY_API_KEY: ${TAVILY_API_KEY}
-      DOC_PATH: "=./my-docs"
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     ports:
       - 8000:8000


### PR DESCRIPTION
Fix 'docker-compose up --build' command for docs