### PR TITLE
Fix Pydantic validation of base_url assignment for ChatOpenAI model

### DIFF
--- a/gpt_researcher/llm_provider/openai/openai.py
+++ b/gpt_researcher/llm_provider/openai/openai.py
@@ -51,7 +51,7 @@ class OpenAIProvider:
             api_key=self.api_key
         )
         if self.base_url:
-            llm.base_url = self.base_url
+            llm.openai_api_base = self.base_url
 
         return llm
 


### PR DESCRIPTION
Pydantic alias 'base_url' for the field 'openai_api_base' is not working as expected for assignments outside the constructor, so changed the alias to the original field name for alternative OpenAI base_url.

Fix for the issue #511 