### PR TITLE
Implemented GroqProvider

### DIFF
--- a/gpt_researcher/llm_provider/__init__.py
+++ b/gpt_researcher/llm_provider/__init__.py
@@ -1,9 +1,11 @@
 from .google.google import GoogleProvider
 from .openai.openai import OpenAIProvider
 from .azureopenai.azureopenai import AzureOpenAIProvider
+from .groq.groq import GroqProvider
 
 __all__ = [
     "GoogleProvider",
     "OpenAIProvider",
-    "AzureOpenAIProvider"
+    "AzureOpenAIProvider",
+    "GroqProvider"
 ]

--- a/gpt_researcher/llm_provider/groq/groq.py
+++ b/gpt_researcher/llm_provider/groq/groq.py
@@ -1,0 +1,72 @@
+import os
+
+from colorama import Fore, Style
+from langchain_groq import ChatGroq
+
+
+class GroqProvider:
+
+    def __init__(
+        self,
+        model,
+        temperature,
+        max_tokens
+    ):
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.api_key = self.get_api_key()
+        self.llm = self.get_llm_model()
+
+    def get_api_key(self):
+        """
+        Gets the OpenAI API key
+        Returns:
+
+        """
+        try:
+            api_key = os.environ["GROQ_API_KEY"]
+        except KeyError:
+            raise Exception(
+                "Groq API key not found. Please set the GROQ_API_KEY environment variable.")
+        return api_key
+
+
+    def get_llm_model(self):
+        # Initializing the chat model
+        llm = ChatGroq(
+            model=self.model,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            api_key=self.api_key
+        )
+        
+        return llm
+
+    async def get_chat_response(self, messages, stream, websocket=None):
+        if not stream:
+            # Getting output from the model chain using ainvoke for asynchronous invoking
+            output = await self.llm.ainvoke(messages)
+            return output.content
+
+        else:
+            return await self.stream_response(messages, websocket)
+
+    async def stream_response(self, messages, websocket=None):
+        paragraph = ""
+        response = ""
+
+        # Streaming the response using the chain astream method from langchain
+        async for chunk in self.llm.astream(messages):
+            content = chunk.content
+            if content is not None:
+                response += content
+                paragraph += content
+                if "\n" in paragraph:
+                    if websocket is not None:
+                        await websocket.send_json({"type": "report", "output": paragraph})
+                    else:
+                        print(f"{Fore.GREEN}{paragraph}{Style.RESET_ALL}")
+                    paragraph = ""
+
+        return response

--- a/gpt_researcher/master/prompts.py
+++ b/gpt_researcher/master/prompts.py
@@ -21,7 +21,8 @@ def generate_search_queries_prompt(question: str, parent_query: str, report_type
     return f'Write {max_iterations} google search queries to search online that form an objective opinion from the following task: "{task}"' \
            f'Use the current date if needed: {datetime.now().strftime("%B %d, %Y")}.\n' \
            f'Also include in the queries specified task details such as locations, names, etc.\n' \
-           f'You must respond with a list of strings in the following format: ["query 1", "query 2", "query 3"].'
+           f'You must respond with a list of strings in the following format: ["query 1", "query 2", "query 3"].\n' \
+           f'The response should contain ONLY the list.'
 
 
 def generate_report_prompt(question: str, context, report_source: str, report_format="apa", total_words=1000):

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -27,6 +27,9 @@ def get_provider(llm_provider):
         case "google":
             from ..llm_provider import GoogleProvider
             llm_provider = GoogleProvider
+        case "groq":
+            from ..llm_provider import GroqProvider
+            llm_provider = GroqProvider
 
         case _:
             raise Exception("LLM provider not found.")

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -126,13 +126,14 @@ async def construct_subtopics(task: str, data: str, config, subtopics: list = []
 
         print(f"\n🤖 Calling {config.smart_llm_model}...\n")
 
-        if config.llm_provider == "openai":
-            model = ChatOpenAI(model=config.smart_llm_model)
-        elif config.llm_provider == "azureopenai":
-            from langchain_openai import AzureChatOpenAI
-            model = AzureChatOpenAI(model=config.smart_llm_model)
-        else:
-            return []
+        temperature = config.temperature
+        # temperature = 0 # Note: temperature throughout the code base is currently set to Zero
+        ProviderClass = get_provider(config.llm_provider)
+        provider = ProviderClass(model=config.smart_llm_model,
+                                 temperature=temperature,
+                                 max_tokens=config.smart_token_limit)
+        model = provider.llm
+
 
         chain = prompt | model | parser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ markdown
 langchain
 langchain-openai
 langchain-google-genai
+langchain-groq
 langchain_community
 tavily-python
 arxiv


### PR DESCRIPTION
Hi @assafelovic 

This pull request implements the `GroqProvider` class, following the coding patterns defined in `OpenAIProvider`. 

`GroqProvider` enables easy access to the below LLMs:

- Llama3-70b-8192
- Llama3-8b-8192
- Gemma-7b-it
- Mixtral-8x7b-32768


I have tested the changes using the local client and the examples/sample_report.py program with simple queries and can confirm positive results.

The __Llama3 models__ work well but are constrained by the current 8K token window.

__Gemma__ and __Mixtral__ also run to completion with satisfactory results on simple queries even though they refuse to generate valid JSON to establish the "agent_role_prompt." (Note: I tried minor modifications to the auto_agent_instructions prompt but did not get positive results.) 

Overall, the models work but are not close to the results generated by __gpt-4o__. However, they will continue to improve even in the short term. Given a larger context window and prompts customized to the nuances of the LLMs, I suspect Llama3 could be competitive with GPT-4 soon.

Thanks,
Dan