### PR TITLE
Fix[readme]: Page Not Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ By using LangGraph, the research process can be significantly improved in depth 
 
 An average run generates a 5-6 page research report in multiple formats such as PDF, Docx and Markdown.
 
-Check it out [here](https://github.com/assafelovic/gpt-researcher/tree/master/multi_agents) or head over to our [documentation](https://docs.gptr.dev/docs/gpt-researcher/agent_frameworks) for more information.
+Check it out [here](https://github.com/assafelovic/gpt-researcher/tree/master/multi_agents) or head over to our [documentation](https://docs.gptr.dev/docs/gpt-researcher/langgraph) for more information.
 
 ## 🚀 Contributing
 We highly welcome contributions! Please check out [contributing](https://github.com/assafelovic/gpt-researcher/blob/master/CONTRIBUTING.md) if you're interested.


### PR DESCRIPTION
Replace the URL giving **Page Not Found** with the correct URL.

[Incorrect URL](https://docs.gptr.dev/docs/gpt-researcher/agent_frameworks)

[Correct URL](https://docs.gptr.dev/docs/gpt-researcher/langgraph)