### PR TITLE
use repair_json() on output of sub_queries to stop exceptions on local models

### DIFF
--- a/gpt_researcher/master/actions.py
+++ b/gpt_researcher/master/actions.py
@@ -7,6 +7,7 @@ from gpt_researcher.master.prompts import *
 from gpt_researcher.scraper.scraper import Scraper
 from gpt_researcher.utils.llm import *
 
+from json_repair import repair_json
 
 def get_retriever(retriever):
     """
@@ -108,9 +109,11 @@ async def get_sub_queries(query: str, agent_role_prompt: str, cfg, parent_query:
         cost_callback=cost_callback
     )
 
-    print("response : ", response)
+    repaired_response = repair_json(response)
+    #print("response : ", response)
+    print("repaired_response : ", repaired_response)
 
-    sub_queries = json.loads(response)
+    sub_queries = json.loads(repaired_response)
     return sub_queries
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ lxml[html_clean]
 websockets
 unstructured
 pandas
+json_repair
 
 # uncomment for testing
 # pytest


### PR DESCRIPTION
Many of my ollama models are outputting slightly malformed json which was causing exceptions during searches.

This was happening on over 50% of queries, but this small patch resolved