### PR TITLE
Lazily import langchain-huggingface to avoid obligatory install

### DIFF
--- a/gpt_researcher/llm_provider/huggingface/huggingface.py
+++ b/gpt_researcher/llm_provider/huggingface/huggingface.py
@@ -1,7 +1,6 @@
 import os
 
 from colorama import Fore, Style
-from langchain_huggingface import ChatHuggingFace
 
 
 class HugginFaceProvider:
@@ -33,6 +32,8 @@ class HugginFaceProvider:
 
     def get_llm_model(self):
         # Initializing the chat model
+        from langchain_huggingface import ChatHuggingFace
+
         llm = ChatHuggingFace(
             model=self.model,
             temperature=self.temperature,


### PR DESCRIPTION
This could also be done for other providers, but huggingface is particularly heavy to install due to dependencies on torch &more, so kept it to that for now.