### PR TITLE
Update introduction.md fixing broken link

### DIFF
--- a/docs/docs/gpt-researcher/introduction.md
+++ b/docs/docs/gpt-researcher/introduction.md
@@ -54,4 +54,4 @@ More specifically:
 - 📂 Keeps track and context of visited and used web sources
 - 📄 Export research reports to PDF, Word and more...
 
-Let's get started [here](/gpt-researcher/getting-started/)!
+Let's get started [here](/docs/gpt-researcher/getting-started/)!


### PR DESCRIPTION
let's get started link was broken and led to:

https://docs.gptr.dev/gpt-researcher/getting-started 

this causes a 404 error, instead it should lead to:

https://docs.gptr.dev/docs/gpt-researcher/getting-started