### PR TITLE
extract_headers() was throwing an exception when it was examining a l…

### DIFF
--- a/gpt_researcher/master/actions.py
+++ b/gpt_researcher/master/actions.py
@@ -327,7 +327,7 @@ def extract_headers(markdown_text: str):
     stack = []  # Initialize stack to keep track of nested headers
     for line in lines:
         # Check if the line starts with an HTML header tag
-        if line.startswith("<h") and len(line) > 1:
+        if line.startswith("<h") and len(line) > 2 and line[2].isdigit():
             level = int(line[2])  # Extract header level
             header_text = line[
                 line.index(">") + 1: line.rindex("<")


### PR DESCRIPTION
extract_headers() was throwing an exception when it was examining a line which read "hr".
This fix ensures only hN lines which have digits are parsed

```
> /gpt_researcher/master/actions.py(331)extract_headers()
-> level = int(line[2])  # Extract header level
(Pdb) p line
'<hr />'
(Pdb) 
```
