### PR TITLE
Support langchain documents

### DIFF
--- a/gpt_researcher/document/__init__.py
+++ b/gpt_researcher/document/__init__.py
@@ -1,3 +1,4 @@
 from .document import DocumentLoader
+from .langchain_document import LangChainDocumentLoader
 
-__all__ = ['DocumentLoader']
+__all__ = ['DocumentLoader', 'LangChainDocumentLoader']

--- a/gpt_researcher/document/langchain_document.py
+++ b/gpt_researcher/document/langchain_document.py
@@ -1,0 +1,24 @@
+import asyncio
+import os
+
+from langchain_core.documents import Document
+from typing import List, Dict
+
+
+# Supports the base Document class from langchain
+# - https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/documents/base.py
+class LangChainDocumentLoader:
+
+    def __init__(self, documents: List[Document]):
+        self.documents = documents
+
+    async def load(self, metadata_source_index="title") -> List[Dict[str, str]]:
+        docs = []
+        for document in self.documents:
+            docs.append(
+                {
+                    "raw_content": document.page_content,
+                    "url": document.metadata.get(metadata_source_index, ""),
+                }
+            )
+        return docs

--- a/gpt_researcher/master/agent.py
+++ b/gpt_researcher/master/agent.py
@@ -3,7 +3,8 @@ import time
 
 from gpt_researcher.config import Config
 from gpt_researcher.context.compression import ContextCompressor
-from gpt_researcher.document import DocumentLoader
+from gpt_researcher.document import DocumentLoader, LangChainDocumentLoader
+
 from gpt_researcher.master.actions import *
 from gpt_researcher.memory import Memory
 from gpt_researcher.utils.enum import ReportSource, ReportType
@@ -97,7 +98,8 @@ class GPTResearcher:
             self.context = await self.__get_context_by_search(self.query, document_data)
 
         elif self.report_source == ReportSource.LangChainDocuments.value:
-            self.context = await self.__get_context_by_search(self.query, self.documents)
+            langchain_documents_data = await LangChainDocumentLoader(self.documents).load()
+            self.context = await self.__get_context_by_search(self.query, langchain_documents_data)
 
         # Default web based research
         else:
@@ -159,6 +161,7 @@ class GPTResearcher:
 
         return report
 
+
     async def __get_context_by_urls(self, urls):
         """
             Scrapes and compresses the context from the given urls
@@ -170,6 +173,7 @@ class GPTResearcher:
                             self.websocket)
         scraped_sites = scrape_urls(new_search_urls, self.cfg)
         return await self.__get_similar_content_by_query(self.query, scraped_sites)
+
 
     async def __get_context_by_search(self, query, scraped_data: list = []):
         """

--- a/gpt_researcher/master/agent.py
+++ b/gpt_researcher/master/agent.py
@@ -8,6 +8,8 @@ from gpt_researcher.master.actions import *
 from gpt_researcher.memory import Memory
 from gpt_researcher.utils.enum import ReportSource, ReportType
 
+import sys
+
 
 class GPTResearcher:
     """
@@ -20,6 +22,7 @@ class GPTResearcher:
         report_type: str = ReportType.ResearchReport.value,
         report_source=ReportSource.Web.value,
         source_urls=None,
+        documents=None,
         config_path=None,
         websocket=None,
         agent=None,
@@ -55,6 +58,7 @@ class GPTResearcher:
         self.retriever = get_retriever(self.cfg.retriever)
         self.context = context
         self.source_urls = source_urls
+        self.documents = documents
         self.memory = Memory(self.cfg.embedding_provider)
         self.visited_urls: set[str] = visited_urls
         self.verbose: bool = verbose
@@ -91,6 +95,10 @@ class GPTResearcher:
         elif self.report_source == ReportSource.Local.value:
             document_data = await DocumentLoader(self.cfg.doc_path).load()
             self.context = await self.__get_context_by_search(self.query, document_data)
+
+        elif self.report_source == ReportSource.LangChainDocuments.value:
+            self.context = await self.__get_context_by_search(self.query, self.documents)
+
         # Default web based research
         else:
             self.context = await self.__get_context_by_search(self.query)

--- a/gpt_researcher/utils/enum.py
+++ b/gpt_researcher/utils/enum.py
@@ -10,3 +10,4 @@ class ReportType(Enum):
 class ReportSource(Enum):
     Web = 'web'
     Local = 'local'
+    LangChainDocuments = 'langchain_documents'


### PR DESCRIPTION
## Motivation

Rather than using documents within a local directory and use various loaders to generate langchain document instances, let's enable the researcher to use langchain documents directly.
This is useful when the existing langchain backend has already created embeddings, documents, and various retrievers.