### PR TITLE
Move blocking operations to threads

### DIFF
--- a/gpt_researcher/context/compression.py
+++ b/gpt_researcher/context/compression.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 from .retriever import SearchAPIRetriever
 from langchain.retrievers import (
     ContextualCompressionRetriever,
@@ -46,4 +47,11 @@ class ContextCompressor:
         if cost_callback:
             cost_callback(estimate_embedding_cost(model=OPENAI_EMBEDDING_MODEL, docs=self.documents))
         relevant_docs = compressed_docs.invoke(query)
+        return self.__pretty_print_docs(relevant_docs, max_results)
+
+    async def async_get_context(self, query, max_results=5, cost_callback=None):
+        compressed_docs = self.__get_contextual_retriever()
+        if cost_callback:
+            cost_callback(estimate_embedding_cost(model=OPENAI_EMBEDDING_MODEL, docs=self.documents))
+        relevant_docs = await asyncio.to_thread(compressed_docs.invoke, query)
         return self.__pretty_print_docs(relevant_docs, max_results)

--- a/gpt_researcher/master/agent.py
+++ b/gpt_researcher/master/agent.py
@@ -300,7 +300,7 @@ class GPTResearcher:
         """
         # Get Urls
         retriever = self.retriever(sub_query)
-        search_results = retriever.search(
+        search_results = await asyncio.to_thread(retriever.search,
             max_results=self.cfg.max_search_results_per_query
         )
         new_search_urls = await self.__get_new_urls(
@@ -314,7 +314,7 @@ class GPTResearcher:
             )
 
         # Scrape Urls
-        scraped_content_results = scrape_urls(new_search_urls, self.cfg)
+        scraped_content_results = await asyncio.to_thread(scrape_urls, new_search_urls, self.cfg)
         return scraped_content_results
 
     async def __get_similar_content_by_query(self, query, pages):
@@ -330,7 +330,7 @@ class GPTResearcher:
             documents=pages, embeddings=self.memory.get_embeddings()
         )
         # Run Tasks
-        return context_compressor.get_context(
+        return await context_compressor.async_get_context(
             query=query, max_results=8, cost_callback=self.add_costs
         )
 


### PR DESCRIPTION
The agent calls a few blocking operations on the main event loop which makes the uvicorn server unresponsive. (can be witnessed by trying to load the Web UI in another tab while the agent is running) By moving these operations to threads, the event loop is kept free to take on other tasks.