### PR TITLE
Fix ollamaprovider error

### DIFF
--- a/gpt_researcher/llm_provider/ollama/ollama.py
+++ b/gpt_researcher/llm_provider/ollama/ollama.py
@@ -9,13 +9,15 @@ class OllamaProvider:
         self,
         model,
         temperature,
-        max_tokens
+        max_tokens,
+        **kwargs  # Accept additional keyword arguments
     ):
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.base_url = self.get_base_url()
         self.llm = self.get_llm_model()
+        self.openai_api_key = kwargs.get('openai_api_key', None)  # Optionally handle openai_api_key
 
     def get_base_url(self):
         """

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -57,7 +57,7 @@ async def create_chat_completion(
         temperature: float = 1.0,
         max_tokens: Optional[int] = None,
         llm_provider: Optional[str] = None,
-        openai_api_key=None, 
+        openai_api_key=None,
         stream: Optional[bool] = False,
         websocket: Any | None = None,
         llm_kwargs: Dict[str, Any] | None = None,
@@ -84,8 +84,20 @@ async def create_chat_completion(
         raise ValueError(
             f"Max tokens cannot be more than 8001, but got {max_tokens}")
 
+    # Prepare kwargs for the provider
+    provider_kwargs = {
+        "model": model,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        **(llm_kwargs or {})
+    }
+
+    # Add openai_api_key if the provider is not OllamaProvider
+    if llm_provider != "OllamaProvider":
+        provider_kwargs["openai_api_key"] = openai_api_key
+
     # Get the provider from supported providers
-    provider = get_llm(llm_provider, model=model, temperature=temperature, max_tokens=max_tokens, openai_api_key=openai_api_key, **(llm_kwargs or {}))
+    provider = get_llm(llm_provider, **provider_kwargs)
 
     response = ""
     # create response

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -84,20 +84,8 @@ async def create_chat_completion(
         raise ValueError(
             f"Max tokens cannot be more than 8001, but got {max_tokens}")
 
-    # Prepare kwargs for the provider
-    provider_kwargs = {
-        "model": model,
-        "temperature": temperature,
-        "max_tokens": max_tokens,
-        **(llm_kwargs or {})
-    }
-
-    # Add openai_api_key if the provider is not OllamaProvider
-    if llm_provider != "OllamaProvider":
-        provider_kwargs["openai_api_key"] = openai_api_key
-
     # Get the provider from supported providers
-    provider = get_llm(llm_provider, **provider_kwargs)
+    provider = get_llm(llm_provider, model=model, temperature=temperature, max_tokens=max_tokens, openai_api_key=openai_api_key, **(llm_kwargs or {}))
 
     response = ""
     # create response


### PR DESCRIPTION
openai_api_key is not required for OllamaProvider. Currently, we get this error when using GPTR with Ollama:

```bash
INFO:     connection open
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/src/app/gpt_researcher/master/actions.py", line 91, in choose_agent
    response = await create_chat_completion(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/gpt_researcher/utils/llm.py", line 88, in create_chat_completion
    provider = get_llm(llm_provider, model=model, temperature=temperature, max_tokens=max_tokens, openai_api_key=openai_api_key, **(llm_kwargs or {}))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/gpt_researcher/utils/llm.py", line 51, in get_llm
    return llm_provider(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: OllamaProvider.__init__() got an unexpected keyword argument 'openai_api_key'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 244, in run_asgi
    result = await self.app(self.scope, self.asgi_receive, self.asgi_send)  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 70, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 151, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/cors.py", line 77, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 756, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 776, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 373, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 96, in app
    await wrap_app_handling_exceptions(app, session)(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 94, in app
    await func(session)
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 348, in app
    await dependant.call(**values)
  File "/usr/src/app/backend/server.py", line 88, in websocket_endpoint
    report = await manager.start_streaming(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/backend/websocket_manager.py", line 60, in start_streaming
    report = await run_agent(task, report_type, report_source, tone, websocket, headers)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/backend/websocket_manager.py", line 97, in run_agent
    report = await researcher.run()
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/backend/report_type/basic_report/basic_report.py", line 41, in run
    await researcher.conduct_research()
  File "/usr/src/app/gpt_researcher/master/agent.py", line 105, in conduct_research
    self.agent, self.role = await choose_agent(
                            ^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/gpt_researcher/master/actions.py", line 109, in choose_agent
    return await handle_json_error(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/gpt_researcher/master/actions.py", line 120, in handle_json_error
    json_string = extract_json_with_regex(response)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/gpt_researcher/master/actions.py", line 136, in extract_json_with_regex
    json_match = re.search(r"{.*?}", response, re.DOTALL)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/re/__init__.py", line 176, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
INFO:     connection closed
```

This should fix the error as openai_api_key is not passed when using Ollama. 