### PR TITLE
Fixes: Default retriever, sanitizing

### DIFF
--- a/gpt_researcher/master/actions.py
+++ b/gpt_researcher/master/actions.py
@@ -64,10 +64,13 @@ def get_retriever(retriever):
             retriever = CustomRetriever
 
         case _:
-            from gpt_researcher.retrievers import TavilySearch
-            retriever = TavilySearch
+            retriever = None
 
     return retriever
+
+def get_default_retriever(retriever):
+    from gpt_researcher.retrievers import TavilySearch
+    return TavilySearch
 
 
 async def choose_agent(query, cfg, parent_query=None, cost_callback: callable = None, headers=None):

--- a/gpt_researcher/master/agent.py
+++ b/gpt_researcher/master/agent.py
@@ -61,7 +61,7 @@ class GPTResearcher:
         self.cfg = Config(config_path)
         self.retriever = get_retriever(self.headers.get("retriever")) or get_retriever(
             self.cfg.retriever
-        )
+        ) or get_default_retriever()
         self.context = context
         self.source_urls = source_urls
         self.documents = documents

--- a/multi_agents/agents/master.py
+++ b/multi_agents/agents/master.py
@@ -16,7 +16,7 @@ from . import \
 class ChiefEditorAgent:
     def __init__(self, task: dict, websocket=None, stream_output=None, tone=None, headers=None):
         self.task_id = int(time.time()) # Currently time based, but can be any unique identifier
-        self.output_dir = sanitize_filename(f"./outputs/run_{self.task_id}_{task.get('query')[0:40]}")
+        self.output_dir = "./outputs/" + sanitize_filename(f"run_{self.task_id}_{task.get('query')[0:40]}")
         self.task = task
         self.websocket = websocket
         self.stream_output = stream_output


### PR DESCRIPTION
### Default retriever
In the previous version, the default case in get_retriever() meant
that setting retriever from config (as opposed to the header) was
ignored, and instead, the default (tavily) retriever was chosen.
Added new function to get the default retriever.

### Corrected sanitizing
Sanitizing function replaces the slashes in the path, which is
most likely undesired. Discussed in 
https://github.com/assafelovic/gpt-researcher/pull/679#issuecomment-2235946414