### PR TITLE
Add "Copy to Clipboard" Button for Access Report

### DIFF
--- a/multi_agents/frontend/components/Task/AccessReport.js
+++ b/multi_agents/frontend/components/Task/AccessReport.js
@@ -18,14 +18,19 @@ export default function AccessReport({ accessData, report }) {
 
   return (
     <div className="flex justify-center mt-4">
-      <a id="downloadLink" 
-        href={getReportLink('pdf')} 
+      <button
+          onClick={copyToClipboard}
+          className="bg-purple-500 text-white active:bg-purple-600 font-bold uppercase text-sm px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150">
+          Copy to clipboard
+      </button>
+      <a id="downloadLink"
+        href={getReportLink('pdf')}
         className="bg-purple-500 text-white active:bg-purple-600 font-bold uppercase text-sm px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150"
         target="_blank">
         View as PDF
       </a>
-      <a id="downloadLink" 
-        href={getReportLink('docx')} 
+      <a id="downloadLink"
+        href={getReportLink('docx')}
         className="bg-purple-500 text-white active:bg-purple-600 font-bold uppercase text-sm px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150"
         target="_blank">
         Download DocX


### PR DESCRIPTION
This pull request introduces a new feature: a "Copy to Clipboard" button for the access report. This enhancement allows users to easily copy the contents of the access report for sharing or further analysis in markdown format.

![Screenshot from 2024-07-31 16-56-25](https://github.com/user-attachments/assets/6c76b31b-3eee-4bac-8b9c-f8a0add22d7c)
