### PR TITLE
made use of azure_openai consistent (and not just in the base model, …

### DIFF
--- a/docs/docs/gpt-researcher/config.md
+++ b/docs/docs/gpt-researcher/config.md
@@ -19,7 +19,7 @@ You can also include your own external JSON file `config.json` by adding the pat
 Below is a list of current supported options:
 
 - **`RETRIEVER`**: Web search engine used for retrieving sources. Defaults to `tavily`. Options: `duckduckgo`, `bing`, `google`, `serper`, `searx`. [Check here](https://github.com/assafelovic/gpt-researcher/tree/master/gpt_researcher/retrievers) for supported retrievers
-- **`EMBEDDING_PROVIDER`**: Provider for embedding model. Defaults to `openai`. Options: `ollama`, `huggingface`, `azureopenai`, `custom`.
+- **`EMBEDDING_PROVIDER`**: Provider for embedding model. Defaults to `openai`. Options: `ollama`, `huggingface`, `azure_openai`, `custom`.
 - **`LLM_PROVIDER`**: LLM provider. Defaults to `openai`. Options: `google`, `ollama`, `groq` and much more!
 - **`FAST_LLM_MODEL`**: Model name for fast LLM operations such summaries. Defaults to `gpt-4o-mini`.
 - **`SMART_LLM_MODEL`**: Model name for smart operations like generating research reports and reasoning. Defaults to `gpt-4o`.

--- a/docs/docs/gpt-researcher/llms.md
+++ b/docs/docs/gpt-researcher/llms.md
@@ -1,7 +1,7 @@
 # Configure LLM
 As described in the [introduction](/docs/gpt-researcher/config), the default LLM is OpenAI due to its superior performance and speed. 
 With that said, GPT Researcher supports various open/closed source LLMs, and you can easily switch between them by adding the `LLM_PROVIDER` env variable and corresponding configuration params.
-Current supported LLMs are `openai`, `google` (gemini), `azureopenai`, `ollama`, `anthropic`, `mistral`, `huggingface` and `groq`.
+Current supported LLMs are `openai`, `google` (gemini), `azure_openai`, `ollama`, `anthropic`, `mistral`, `huggingface` and `groq`.
 
 Using any model will require at least updating the `LLM_PROVIDER` param and passing the LLM provider API Key. You might also need to update the `SMART_LLM_MODEL` and `FAST_LLM_MODEL` env vars.
 To learn more about support customization options see [here](/gpt-researcher/config).
@@ -47,7 +47,7 @@ OPENAI_EMBEDDING_MODEL="custom_model"
 ### Azure OpenAI
 
 ```bash
-EMBEDDING_PROVIDER="azureopenai"
+EMBEDDING_PROVIDER="azure_openai"
 AZURE_OPENAI_API_KEY="Your key"
 ```
 

--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -1,6 +1,8 @@
 from langchain_community.vectorstores import FAISS
 import os
+
 OPENAI_EMBEDDING_MODEL = "text-embedding-3-small"
+
 
 class Memory:
     def __init__(self, embedding_provider, headers=None, **kwargs):
@@ -9,23 +11,41 @@ class Memory:
         match embedding_provider:
             case "ollama":
                 from langchain_community.embeddings import OllamaEmbeddings
-                _embeddings = OllamaEmbeddings(model=os.environ["OLLAMA_EMBEDDING_MODEL"], base_url=os.environ["OLLAMA_BASE_URL"])
+
+                _embeddings = OllamaEmbeddings(
+                    model=os.environ["OLLAMA_EMBEDDING_MODEL"],
+                    base_url=os.environ["OLLAMA_BASE_URL"],
+                )
             case "custom":
                 from langchain_openai import OpenAIEmbeddings
-                _embeddings = OpenAIEmbeddings(model=os.environ.get("OPENAI_EMBEDDING_MODEL", "custom"),
-                                                   openai_api_key=headers.get("openai_api_key", os.environ.get("OPENAI_API_KEY", "custom")), 
-                                                   openai_api_base=os.environ.get("OPENAI_BASE_URL", "http://localhost:1234/v1"), #default for lmstudio
-                                                   check_embedding_ctx_length=False) #quick fix for lmstudio
+
+                _embeddings = OpenAIEmbeddings(
+                    model=os.environ.get("OPENAI_EMBEDDING_MODEL", "custom"),
+                    openai_api_key=headers.get(
+                        "openai_api_key", os.environ.get("OPENAI_API_KEY", "custom")
+                    ),
+                    openai_api_base=os.environ.get(
+                        "OPENAI_BASE_URL", "http://localhost:1234/v1"
+                    ),  # default for lmstudio
+                    check_embedding_ctx_length=False,
+                )  # quick fix for lmstudio
             case "openai":
                 from langchain_openai import OpenAIEmbeddings
-                _embeddings = OpenAIEmbeddings(openai_api_key=headers.get("openai_api_key") or os.environ.get("OPENAI_API_KEY"),
-                                               model=OPENAI_EMBEDDING_MODEL
-                                              )
-            case "azureopenai":
+
+                _embeddings = OpenAIEmbeddings(
+                    openai_api_key=headers.get("openai_api_key")
+                    or os.environ.get("OPENAI_API_KEY"),
+                    model=OPENAI_EMBEDDING_MODEL,
+                )
+            case "azure_openai":
                 from langchain_openai import AzureOpenAIEmbeddings
-                _embeddings = AzureOpenAIEmbeddings(deployment=os.environ["AZURE_EMBEDDING_MODEL"], chunk_size=16)
+
+                _embeddings = AzureOpenAIEmbeddings(
+                    deployment=os.environ["AZURE_EMBEDDING_MODEL"], chunk_size=16
+                )
             case "huggingface":
                 from langchain.embeddings import HuggingFaceEmbeddings
+
                 _embeddings = HuggingFaceEmbeddings()
 
             case _:


### PR DESCRIPTION
The last update changed the string that identifies Azure OpenAI resources from `azureopenai` to `azure_openai`, but just for the base model, not for embeddings.

This change makes it consistent for both base model and embedding model.