### PR TITLE
[Fix] No module named 'json5'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ lxml_html_clean
 websockets
 unstructured
 json_repair
+json5
 
 # uncomment for testing
 # pytest


### PR DESCRIPTION
- To fix the json5 library not found, add the library to the requirements file.