### PR TITLE
Fix TypeError in custom reports due to missing 'tone' parameter

### DIFF
--- a/gpt_researcher/master/prompts.py
+++ b/gpt_researcher/master/prompts.py
@@ -126,7 +126,7 @@ def generate_resource_report_prompt(
 
 
 def generate_custom_report_prompt(
-    query_prompt, context, report_source: str, report_format="apa", total_words=1000
+    query_prompt, context, report_source: str, report_format="apa", tone=None, total_words=1000
 ):
     return f'"{context}"\n\n{query_prompt}'
 


### PR DESCRIPTION
    Resolved a `TypeError` that occurred when generating custom reports, caused by the `generate_custom_report_prompt()` function receiving an unexpected keyword argument 'tone'. The issue was due to the absence of the 'tone' parameter in the function definition, which has now been added to ensure correct functionality.