### PR TITLE
fix: added missing langgraph to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ markdown
 langchain>=0.2,<0.3
 langchain_community>=0.2,<0.3
 langchain-openai>=0.1,<0.2
+langgraph
 tiktoken
 gpt-researcher
 arxiv


### PR DESCRIPTION
Discovered that a clean download of the current master brach bwill not allow running `python -m uvicorn main:app --reload` as `langhgraph` was missing.