### PR TITLE
multi-agent approach should now use .env file for config of llm

### DIFF
--- a/multi_agents/agents/editor.py
+++ b/multi_agents/agents/editor.py
@@ -6,10 +6,7 @@ import asyncio
 import json
 
 from ..memory.draft import DraftState
-from . import \
-    ResearchAgent, \
-    ReviewerAgent, \
-    ReviserAgent
+from . import ResearchAgent, ReviewerAgent, ReviserAgent
 
 
 class EditorAgent:
@@ -33,14 +30,16 @@ class EditorAgent:
         human_feedback = research_state.get("human_feedback")
         max_sections = task.get("max_sections")
 
-        prompt = [{
-            "role": "system",
-            "content": "You are a research editor. Your goal is to oversee the research project"
-                       " from inception to completion. Your main task is to plan the article section "
-                       "layout based on an initial research summary.\n "
-        }, {
-            "role": "user",
-            "content": f"""Today's date is {datetime.now().strftime('%d/%m/%Y')}
+        prompt = [
+            {
+                "role": "system",
+                "content": "You are a research editor. Your goal is to oversee the research project"
+                " from inception to completion. Your main task is to plan the article section "
+                "layout based on an initial research summary.\n ",
+            },
+            {
+                "role": "user",
+                "content": f"""Today's date is {datetime.now().strftime('%d/%m/%Y')}
                                   Research summary report: '{initial_research}'
                                   {f'Human feedback: {human_feedback}. You must plan the sections based on the human feedback.'
             if include_human_feedback and human_feedback and human_feedback != 'no' else ''}
@@ -51,17 +50,23 @@ class EditorAgent:
                                   You must return nothing but a JSON with the fields 'title' (str) and 
                                   'sections' (maximum {max_sections} section headers) with the following structure:
                                   '{{title: string research title, date: today's date, 
-                                  sections: ['section header 1', 'section header 2', 'section header 3' ...]}}."""
-        }]
+                                  sections: ['section header 1', 'section header 2', 'section header 3' ...]}}.""",
+            },
+        ]
 
-        print_agent_output(f"Planning an outline layout based on initial research...", agent="EDITOR")
-        response = await call_model(prompt=prompt, model=task.get("model"), response_format="json", api_key=self.headers.get("openai_api_key"))
-        plan = json.loads(response)
+        print_agent_output(
+            f"Planning an outline layout based on initial research...", agent="EDITOR"
+        )
+        plan = await call_model(
+            prompt=prompt,
+            model=task.get("model"),
+            response_format="json",
+        )
 
         return {
             "title": plan.get("title"),
             "date": plan.get("date"),
-            "sections": plan.get("sections")
+            "sections": plan.get("sections"),
         }
 
     async def run_parallel_research(self, research_state: dict):
@@ -79,29 +84,43 @@ class EditorAgent:
 
         # set up edges researcher->reviewer->reviser->reviewer...
         workflow.set_entry_point("researcher")
-        workflow.add_edge('researcher', 'reviewer')
-        workflow.add_edge('reviser', 'reviewer')
-        workflow.add_conditional_edges('reviewer',
-                                       (lambda draft: "accept" if draft['review'] is None else "revise"),
-                                       {"accept": END, "revise": "reviser"})
+        workflow.add_edge("researcher", "reviewer")
+        workflow.add_edge("reviser", "reviewer")
+        workflow.add_conditional_edges(
+            "reviewer",
+            (lambda draft: "accept" if draft["review"] is None else "revise"),
+            {"accept": END, "revise": "reviser"},
+        )
 
         chain = workflow.compile()
 
         # Execute the graph for each query in parallel
         if self.websocket and self.stream_output:
-            await self.stream_output("logs", "parallel_research", f"Running parallel research for the following queries: {queries}", self.websocket)
+            await self.stream_output(
+                "logs",
+                "parallel_research",
+                f"Running parallel research for the following queries: {queries}",
+                self.websocket,
+            )
         else:
-            print_agent_output(f"Running the following research tasks in parallel: {queries}...", agent="EDITOR")
-        
+            print_agent_output(
+                f"Running the following research tasks in parallel: {queries}...",
+                agent="EDITOR",
+            )
+
         final_drafts = [
-            chain.ainvoke({
-                "task": research_state.get("task"),
-                "topic": query,  # + (f". Also: {human_feedback}" if human_feedback is not None else ""),
-                "title": title,
-                "headers": self.headers
-            })
+            chain.ainvoke(
+                {
+                    "task": research_state.get("task"),
+                    "topic": query,  # + (f". Also: {human_feedback}" if human_feedback is not None else ""),
+                    "title": title,
+                    "headers": self.headers,
+                }
+            )
             for query in queries
         ]
-        research_results = [result['draft'] for result in await asyncio.gather(*final_drafts)]
+        research_results = [
+            result["draft"] for result in await asyncio.gather(*final_drafts)
+        ]
 
         return {"research_data": research_results}

--- a/multi_agents/agents/human.py
+++ b/multi_agents/agents/human.py
@@ -1,12 +1,12 @@
 import json
-from .utils.views import print_agent_output
-from .utils.llms import call_model
+
 
 class HumanAgent:
     def __init__(self, websocket=None, stream_output=None, headers=None):
         self.websocket = websocket
         self.stream_output = stream_output
         self.headers = headers or {}
+
     async def review_plan(self, research_state: dict):
         print(f"HumanAgent websocket: {self.websocket}")
         print(f"HumanAgent stream_output: {self.stream_output}")
@@ -19,21 +19,29 @@ class HumanAgent:
             # Stream response to the user if a websocket is provided (such as from web app)
             if self.websocket and self.stream_output:
                 try:
-                    await self.stream_output("human_feedback", "request",
+                    await self.stream_output(
+                        "human_feedback",
+                        "request",
                         f"Any feedback on this plan of topics to research? {layout}? If not, please reply with 'no'.",
-                        self.websocket)
+                        self.websocket,
+                    )
                     response = await self.websocket.receive_text()
                     print(f"Received response: {response}", flush=True)
                     response_data = json.loads(response)
                     if response_data.get("type") == "human_feedback":
                         user_feedback = response_data.get("content")
                     else:
-                        print(f"Unexpected response type: {response_data.get('type')}", flush=True)
+                        print(
+                            f"Unexpected response type: {response_data.get('type')}",
+                            flush=True,
+                        )
                 except Exception as e:
                     print(f"Error receiving human feedback: {e}", flush=True)
             # Otherwise, prompt the user for feedback in the console
             else:
-                user_feedback = input(f"Any feedback on this plan? {layout}? If not, please reply with 'no'.\n>> ")
+                user_feedback = input(
+                    f"Any feedback on this plan? {layout}? If not, please reply with 'no'.\n>> "
+                )
 
         if user_feedback and "no" in user_feedback.strip().lower():
             user_feedback = None

--- a/multi_agents/agents/reviewer.py
+++ b/multi_agents/agents/reviewer.py
@@ -5,6 +5,7 @@ TEMPLATE = """You are an expert research article reviewer. \
 Your goal is to review research drafts and provide feedback to the reviser only based on specific guidelines. \
 """
 
+
 class ReviewerAgent:
     def __init__(self, websocket=None, stream_output=None, headers=None):
         self.websocket = websocket
@@ -18,7 +19,7 @@ class ReviewerAgent:
         :return:
         """
         task = draft_state.get("task")
-        guidelines = '- '.join(guideline for guideline in task.get("guidelines"))
+        guidelines = "- ".join(guideline for guideline in task.get("guidelines"))
         revision_notes = draft_state.get("revision_notes")
 
         revise_prompt = f"""The reviser has already revised the draft based on your previous review notes with the following feedback:
@@ -35,23 +36,27 @@ If the draft meets all the guidelines, please return None.
 
 Guidelines: {guidelines}\nDraft: {draft_state.get("draft")}\n
 """
-        prompt = [{
-            "role": "system",
-            "content": TEMPLATE
-        }, {
-            "role": "user",
-            "content": review_prompt
-        }]
+        prompt = [
+            {"role": "system", "content": TEMPLATE},
+            {"role": "user", "content": review_prompt},
+        ]
 
-        response = await call_model(prompt, model=task.get("model"), api_key=self.headers.get("openai_api_key"))
+        response = await call_model(prompt, model=task.get("model"))
 
         if task.get("verbose"):
             if self.websocket and self.stream_output:
-                await self.stream_output("logs", "review_feedback", f"Review feedback is: {response}...", self.websocket)
+                await self.stream_output(
+                    "logs",
+                    "review_feedback",
+                    f"Review feedback is: {response}...",
+                    self.websocket,
+                )
             else:
-                print_agent_output(f"Review feedback is: {response}...", agent="REVIEWER")
+                print_agent_output(
+                    f"Review feedback is: {response}...", agent="REVIEWER"
+                )
 
-        if 'None' in response:
+        if "None" in response:
             return None
         return response
 
@@ -64,7 +69,9 @@ Guidelines: {guidelines}\nDraft: {draft_state.get("draft")}\n
             print_agent_output(f"Reviewing draft...", agent="REVIEWER")
 
             if task.get("verbose"):
-                print_agent_output(f"Following guidelines {guidelines}...", agent="REVIEWER")
+                print_agent_output(
+                    f"Following guidelines {guidelines}...", agent="REVIEWER"
+                )
 
             review = await self.review_draft(draft_state)
         else:

--- a/multi_agents/agents/reviser.py
+++ b/multi_agents/agents/reviser.py
@@ -11,6 +11,7 @@ sample_revision_notes = """
 }
 """
 
+
 class ReviserAgent:
     def __init__(self, websocket=None, stream_output=None, headers=None):
         self.websocket = websocket
@@ -26,22 +27,29 @@ class ReviserAgent:
         review = draft_state.get("review")
         task = draft_state.get("task")
         draft_report = draft_state.get("draft")
-        prompt = [{
-            "role": "system",
-            "content": "You are an expert writer. Your goal is to revise drafts based on reviewer notes."
-        }, {
-            "role": "user",
-            "content": f"""Draft:\n{draft_report}" + "Reviewer's notes:\n{review}\n\n
+        prompt = [
+            {
+                "role": "system",
+                "content": "You are an expert writer. Your goal is to revise drafts based on reviewer notes.",
+            },
+            {
+                "role": "user",
+                "content": f"""Draft:\n{draft_report}" + "Reviewer's notes:\n{review}\n\n
 You have been tasked by your reviewer with revising the following draft, which was written by a non-expert.
 If you decide to follow the reviewer's notes, please write a new draft and make sure to address all of the points they raised.
 Please keep all other aspects of the draft the same.
 You MUST return nothing but a JSON in the following format:
 {sample_revision_notes}
-"""
-        }]
+""",
+            },
+        ]
 
-        response = await call_model(prompt, model=task.get("model"), response_format='json', api_key=self.headers.get("openai_api_key"))
-        return json.loads(response)
+        response = await call_model(
+            prompt,
+            model=task.get("model"),
+            response_format="json",
+        )
+        return response
 
     async def run(self, draft_state: dict):
         print_agent_output(f"Rewriting draft based on feedback...", agent="REVISOR")
@@ -49,9 +57,18 @@ You MUST return nothing but a JSON in the following format:
 
         if draft_state.get("task").get("verbose"):
             if self.websocket and self.stream_output:
-                await self.stream_output("logs", "revision_notes", f"Revision notes: {revision.get('revision_notes')}", self.websocket)
+                await self.stream_output(
+                    "logs",
+                    "revision_notes",
+                    f"Revision notes: {revision.get('revision_notes')}",
+                    self.websocket,
+                )
             else:
-                print_agent_output(f"Revision notes: {revision.get('revision_notes')}", agent="REVISOR")
+                print_agent_output(
+                    f"Revision notes: {revision.get('revision_notes')}", agent="REVISOR"
+                )
 
-        return {"draft": revision.get("draft"),
-                "revision_notes": revision.get("revision_notes")}
+        return {
+            "draft": revision.get("draft"),
+            "revision_notes": revision.get("revision_notes"),
+        }

--- a/multi_agents/agents/utils/llms.py
+++ b/multi_agents/agents/utils/llms.py
@@ -1,15 +1,50 @@
+import json5 as json
+import json_repair
 from langchain_community.adapters.openai import convert_openai_messages
-from langchain_openai import ChatOpenAI
+
+from gpt_researcher.config.config import Config
+from gpt_researcher.master.actions import handle_json_error
+from gpt_researcher.utils.llm import create_chat_completion
+
+from loguru import logger
 
 
-async def call_model(prompt: list, model: str, max_retries: int = 2, response_format: str = None, api_key: str = None) -> str:
+async def call_model(
+    prompt: list,
+    model: str,
+    response_format: str = None,
+):
 
     optional_params = {}
-    if response_format == 'json':
-        optional_params = {
-            "response_format": {"type": "json_object"}
-        }
+    if response_format == "json":
+        optional_params = {"response_format": {"type": "json_object"}}
 
+    cfg = Config()
     lc_messages = convert_openai_messages(prompt)
-    response = ChatOpenAI(model=model, max_retries=max_retries, model_kwargs=optional_params, api_key=api_key).invoke(lc_messages).content
-    return response
+
+    try:
+        response = await create_chat_completion(
+            model=model,
+            messages=lc_messages,
+            temperature=0,
+            llm_provider=cfg.llm_provider,
+            llm_kwargs=cfg.llm_kwargs,
+            # cost_callback=cost_callback,
+        )
+
+        if response_format == "json":
+            try:
+                cleaned_json_string = response.strip("```json\n")
+                return json.loads(cleaned_json_string)
+            except Exception as e:
+                print("⚠️ Error in reading JSON, attempting to repair JSON")
+                logger.error(
+                    f"Error in reading JSON, attempting to repair reponse: {response}"
+                )
+                return json_repair.loads(response)
+        else:
+            return response
+
+    except Exception as e:
+        print("⚠️ Error in calling model")
+        logger.error(f"Error in calling model: {e}")

--- a/multi_agents/agents/writer.py
+++ b/multi_agents/agents/writer.py
@@ -12,6 +12,7 @@ sample_json = """
 }
 """
 
+
 class WriterAgent:
     def __init__(self, websocket=None, stream_output=None, headers=None):
         self.websocket = websocket
@@ -25,7 +26,7 @@ class WriterAgent:
             "introduction": "Introduction",
             "table_of_contents": "Table of Contents",
             "conclusion": "Conclusion",
-            "references": "References"
+            "references": "References",
         }
 
     async def write_sections(self, research_state: dict):
@@ -35,71 +36,107 @@ class WriterAgent:
         follow_guidelines = task.get("follow_guidelines")
         guidelines = task.get("guidelines")
 
-        prompt = [{
-            "role": "system",
-            "content": "You are a research writer. Your sole purpose is to write a well-written "
-                       "research reports about a "
-                       "topic based on research findings and information.\n "
-        }, {
-            "role": "user",
-            "content": f"Today's date is {datetime.now().strftime('%d/%m/%Y')}\n."
-                       f"Query or Topic: {query}\n"
-                       f"Research data: {str(data)}\n"
-                       f"Your task is to write an in depth, well written and detailed "
-                       f"introduction and conclusion to the research report based on the provided research data. "
-                       f"Do not include headers in the results.\n"
-                       f"You MUST include any relevant sources to the introduction and conclusion as markdown hyperlinks -"
-                       f"For example: 'This is a sample text. ([url website](url))'\n\n"
-                       f"{f'You must follow the guidelines provided: {guidelines}' if follow_guidelines else ''}\n"
-                       f"You MUST return nothing but a JSON in the following format (without json markdown):\n"
-                       f"{sample_json}\n\n"
+        prompt = [
+            {
+                "role": "system",
+                "content": "You are a research writer. Your sole purpose is to write a well-written "
+                "research reports about a "
+                "topic based on research findings and information.\n ",
+            },
+            {
+                "role": "user",
+                "content": f"Today's date is {datetime.now().strftime('%d/%m/%Y')}\n."
+                f"Query or Topic: {query}\n"
+                f"Research data: {str(data)}\n"
+                f"Your task is to write an in depth, well written and detailed "
+                f"introduction and conclusion to the research report based on the provided research data. "
+                f"Do not include headers in the results.\n"
+                f"You MUST include any relevant sources to the introduction and conclusion as markdown hyperlinks -"
+                f"For example: 'This is a sample text. ([url website](url))'\n\n"
+                f"{f'You must follow the guidelines provided: {guidelines}' if follow_guidelines else ''}\n"
+                f"You MUST return nothing but a JSON in the following format (without json markdown):\n"
+                f"{sample_json}\n\n",
+            },
+        ]
 
-        }]
-
-        response = await call_model(prompt, task.get("model"), max_retries=2, response_format='json', api_key=self.headers.get("openai_api_key"))
-        return json.loads(response)
+        response = await call_model(
+            prompt,
+            task.get("model"),
+            response_format="json",
+        )
+        return response
 
     async def revise_headers(self, task: dict, headers: dict):
-        prompt = [{
-            "role": "system",
-            "content": """You are a research writer. 
-Your sole purpose is to revise the headers data based on the given guidelines."""
-        }, {
-            "role": "user",
-            "content": f"""Your task is to revise the given headers JSON based on the guidelines given.
+        prompt = [
+            {
+                "role": "system",
+                "content": """You are a research writer. 
+Your sole purpose is to revise the headers data based on the given guidelines.""",
+            },
+            {
+                "role": "user",
+                "content": f"""Your task is to revise the given headers JSON based on the guidelines given.
 You are to follow the guidelines but the values should be in simple strings, ignoring all markdown syntax.
 You must return nothing but a JSON in the same format as given in headers data.
 Guidelines: {task.get("guidelines")}\n
 Headers Data: {headers}\n
-"""
+""",
+            },
+        ]
 
-        }]
-
-        response = await call_model(prompt, task.get("model"), response_format='json', api_key=self.headers.get("openai_api_key"))
-        return {"headers": json.loads(response)}
+        response = await call_model(
+            prompt,
+            task.get("model"),
+            response_format="json",
+        )
+        return {"headers": response}
 
     async def run(self, research_state: dict):
         if self.websocket and self.stream_output:
-            await self.stream_output("logs", "writing_report", f"Writing final research report based on research data...", self.websocket)
+            await self.stream_output(
+                "logs",
+                "writing_report",
+                f"Writing final research report based on research data...",
+                self.websocket,
+            )
         else:
-            print_agent_output(f"Writing final research report based on research data...", agent="WRITER")
+            print_agent_output(
+                f"Writing final research report based on research data...",
+                agent="WRITER",
+            )
 
         research_layout_content = await self.write_sections(research_state)
 
         if research_state.get("task").get("verbose"):
             if self.websocket and self.stream_output:
-                research_layout_content_str = json.dumps(research_layout_content, indent=2)
-                await self.stream_output("logs", "research_layout_content", research_layout_content_str, self.websocket)
+                research_layout_content_str = json.dumps(
+                    research_layout_content, indent=2
+                )
+                await self.stream_output(
+                    "logs",
+                    "research_layout_content",
+                    research_layout_content_str,
+                    self.websocket,
+                )
             else:
                 print_agent_output(research_layout_content, agent="WRITER")
 
         headers = self.get_headers(research_state)
         if research_state.get("task").get("follow_guidelines"):
             if self.websocket and self.stream_output:
-                await self.stream_output("logs", "rewriting_layout", "Rewriting layout based on guidelines...", self.websocket)
+                await self.stream_output(
+                    "logs",
+                    "rewriting_layout",
+                    "Rewriting layout based on guidelines...",
+                    self.websocket,
+                )
             else:
-                print_agent_output("Rewriting layout based on guidelines...", agent="WRITER")
-            headers = await self.revise_headers(task=research_state.get("task"), headers=headers)
+                print_agent_output(
+                    "Rewriting layout based on guidelines...", agent="WRITER"
+                )
+            headers = await self.revise_headers(
+                task=research_state.get("task"), headers=headers
+            )
             headers = headers.get("headers")
 
         return {**research_layout_content, "headers": headers}


### PR DESCRIPTION
This addresses issue #764 

Changed the `call_llm`  function 
- to re-use the "select the right model from .env" from GPT-R
- Changed the handling of the response in "json" mode to return a parsed json, else return the response as is.
- Simplified the function to take less params, as most can/should be configured either via task or .env (Config() from GPTR, or config_file)

@ElishaKay, I tried to touch as little code as possible, but also don't fully grasp the langgraph logic you built. Please check If I broke something essential.

I can run and generate reports using multi-agent with AzureOpenAI now. (but my report switched from English to Spanish in the last agent -- my colleagues tell me GPT-4o likes to speak Spanish more than English and often does that.)