### PR TITLE
Fix package name from logurun to loguru in requirements.txt. Fixes #809

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ websockets
 unstructured
 json_repair
 json5
-logurun
+loguru
 
 # uncomment for testing
 # pytest


### PR DESCRIPTION
There is no such PyPi package as logurun. Changes to loguru, consistent with multi_agents/requirements.txt