### PR TITLE
Fix Last Paragraph is not Sent to Websocket

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -111,13 +111,19 @@ class GenericLLMProvider:
                 response += content
                 paragraph += content
                 if "\n" in paragraph:
-                    if websocket is not None:
-                        await websocket.send_json({"type": "report", "output": paragraph})
-                    else:
-                        print(f"{Fore.GREEN}{paragraph}{Style.RESET_ALL}")
+                    await self._send_output(paragraph, websocket)
                     paragraph = ""
 
+        if paragraph:
+            await self._send_output(paragraph, websocket)
+
         return response
+
+    async def _send_output(self, content, websocket=None):
+        if websocket is not None:
+            await websocket.send_json({"type": "report", "output": content})
+        else:
+            print(f"{Fore.GREEN}{content}{Style.RESET_ALL}")
 
 
 


### PR DESCRIPTION
How to reproduct: Ask a random question and the result shown in the webUI does not contain the last few lines when compare to the PDF.

Description: when the model output chunks of messages, the chunks are combined to paragraphs and send to websocket. However, the last paragraph is never sent (if the last paragraph does not contain \n). My change check if paragraph is not empty to send the last paragraph out. 