### PR TITLE
Fix SyntaxError in prompts.py due to conflicting quotes in f-string

### DIFF
--- a/gpt_researcher/master/prompts.py
+++ b/gpt_researcher/master/prompts.py
@@ -30,7 +30,7 @@ def generate_search_queries_prompt(
 
     return (
         f'Write {max_iterations} google search queries to search online that form an objective opinion from the following task: "{task}"\n'
-        f'Assume the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if required.\n'
+        f"Assume the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if required.\n"
         f'You must respond with a list of strings in the following format: ["query 1", "query 2", "query 3"].\n'
         f"The response should contain ONLY the list."
     )


### PR DESCRIPTION
## Description
This PR fixes a SyntaxError in `/usr/src/app/gpt_researcher/master/prompts.py` that was causing the application to fail on startup. The error was due to conflicting quotes in an f-string used to format the current date.

## Changes Made
- Modified line 33 in `/usr/src/app/gpt_researcher/master/prompts.py` to resolve quote conflicts in the f-string.