### PR TITLE
Ollama fixes

### DIFF
--- a/backend/report_type/detailed_report/detailed_report.py
+++ b/backend/report_type/detailed_report/detailed_report.py
@@ -64,8 +64,16 @@ class DetailedReport:
         self.global_urls = self.main_task_assistant.visited_urls
 
     async def _get_all_subtopics(self) -> List[Dict]:
-        subtopics = await self.main_task_assistant.get_subtopics()
-        return subtopics.dict().get("subtopics", [])
+            # Assuming this method returns a list of dictionaries
+        subtopics_list = await self.main_task_assistant.get_subtopics()
+        
+        # If subtopics_list is a list of dictionaries
+        all_subtopics = []
+        for subtopic in subtopics_list:
+            if isinstance(subtopic, dict):
+                all_subtopics.extend(subtopic.get("subtopics", []))
+        
+        return all_subtopics
 
     async def _generate_subtopic_reports(self, subtopics: List[Dict]) -> tuple:
         subtopic_reports = []

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -48,8 +48,8 @@ class GenericLLMProvider:
         elif provider == "ollama":
             _check_pkg("langchain_community")
             from langchain_community.chat_models import ChatOllama
-
-            llm = ChatOllama(**kwargs)
+            
+            llm = ChatOllama(base_url=os.environ["OLLAMA_BASE_URL"], **kwargs)
         elif provider == "together":
             _check_pkg("langchain_together")
             from langchain_together import ChatTogether


### PR DESCRIPTION
# GPT Researcher - Fix Issues when Running in Docker Container

## Issue Description

The GPT Researcher tool was unable to complete research tasks with Ollama when run inside a Docker container on WSL2. This issue has been resolved by addressing two key problems.

### Issue 1: Incorrect Ollama Base URL

By default, the tool attempted to connect to `localhost` instead of using the provided base URL for Ollama. We have updated the code to use the provided base URL when running in a Docker container.

### Issue 2: Error in Generating Detailed Report

When generating detailed reports, we encountered an error because `get_subtopics` was sending a list instead of a dictionary. This has been corrected by updating the `get_subtopics` function to return a dictionary.

## Changes Made

The following changes have been made to address these issues:

* Updated `base.py` to use the provided Ollama base URL.
* Modified the `get_subtopics` function in `report.py` to return a dictionary instead of a list.

## Steps to Reproduce the Fix

To reproduce the fix, follow these steps:

1. Without fixes, run the gpt-researcher in using docker compose on WSL2


## Code Changes

The code changes made to address these issues include updating the following files:

* `base.py`
* `report.py`

The updated code can be found in the attached code snippet.
