### PR TITLE
Fixing the missing "os" import for base.py

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -1,7 +1,7 @@
 import importlib
 from typing import Any
 from colorama import Fore, Style, init
-
+import os
 
 class GenericLLMProvider:
 


### PR DESCRIPTION
Title: Fix missing "import os" in base.py (Ollama Integration)

Steps To Reproduce: When trying to use Ollama integration features, an ImportError occurs due to missing "os" import in base.py.

Fix Details: Added import os at the beginning of the file. This ensures that all necessary modules are imported before they're used within other parts of the codebase.