### PR TITLE
Users can upload larger files

### DIFF
--- a/docs/docs/gpt-researcher/getting-started/linux-deployment.md
+++ b/docs/docs/gpt-researcher/getting-started/linux-deployment.md
@@ -81,6 +81,8 @@ http {
    server {
        listen 80;
        server_name name.example;
+       
+       client_max_body_size 64M;
 
        location / {
            proxy_pass http://localhost:3000;
@@ -107,6 +109,8 @@ And if you're using SSL:
 ```nginx
 server {
     server_name name.example;
+    
+    client_max_body_size 64M;
     
     location / {
         proxy_pass http://localhost:3000;


### PR DESCRIPTION
Users cannot upload larger documents. The default size is less than 1MB. To solve this, server nginx should be updated with `client_max_body_size 64M;`. I added it to the documentation.