### PR TITLE
utils.py: resolve SyntaxWarning

### DIFF
--- a/multi_agents/agents/utils/utils.py
+++ b/multi_agents/agents/utils/utils.py
@@ -8,7 +8,7 @@ def sanitize_filename(filename: str) -> str:
     This function ensures that the filename is compatible with all 
     operating systems by removing or replacing characters that are 
     not allowed in Windows file paths. Specifically, it replaces 
-    the following characters: < > : " / \ | ? *
+    the following characters: < > : " / \\ | ? *
 
     Parameters:
     filename (str): The original filename to be sanitized.


### PR DESCRIPTION
Resolves the `SyntaxWarning` when starting up
```apl
INFO:     Will watch for changes in these directories: ['/Users/samy/Dropbox/Mac/Documents/Code/gpt/gpt-researcher']
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [85658] using StatReload
/Users/samy/Dropbox/Mac/Documents/Code/gpt/gpt-researcher/multi_agents/agents/utils/utils.py:4: SyntaxWarning: invalid escape sequence '\ '
  """
```