### PR TITLE
Updated Hugging Face embeddings to use all-MiniLM-L6-v2

### DIFF
--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -46,7 +46,10 @@ class Memory:
             case "huggingface":
                 from langchain.embeddings import HuggingFaceEmbeddings
 
-                _embeddings = HuggingFaceEmbeddings()
+                # Specifying the Hugging Face embedding model all-MiniLM-L6-v2
+                _embeddings = HuggingFaceEmbeddings(
+                    model_name="sentence-transformers/all-MiniLM-L6-v2"
+                )
 
             case _:
                 raise Exception("Embedding provider not found.")


### PR DESCRIPTION
This pull request updates the Hugging Face embeddings in the project to use the all-MiniLM-L6-v2 model from the sentence-transformers library. The previous implementation did not specify any specific model (since no specific model is passed, it might load a default model), so this change ensures that we use all-MiniLM-L6-v2, which is more efficient in terms of performance and accuracy.

Why all-MiniLM-L6-v2 ?

- The all-MiniLM-L6-v2 model provides faster performance , making it quicker to handle large corpus.
- This model is known for generating high-quality embeddings, improving the overall accuracy of similarity and other tasks.
- all-MiniLM-L6-v2 is known for improved performance, this model provides a good balance between speed and effectiveness.