### PR TITLE
Support IBM Watsonx.ai LLM provider

### DIFF
--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -1,7 +1,9 @@
 from langchain_community.vectorstores import FAISS
 import os
 
-OPENAI_EMBEDDING_MODEL = os.environ.get("OPENAI_EMBEDDING_MODEL","text-embedding-3-small")
+OPENAI_EMBEDDING_MODEL = os.environ.get(
+    "OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"
+)
 
 
 class Memory:
@@ -35,7 +37,7 @@ class Memory:
                 _embeddings = OpenAIEmbeddings(
                     openai_api_key=headers.get("openai_api_key")
                     or os.environ.get("OPENAI_API_KEY"),
-                    model=OPENAI_EMBEDDING_MODEL
+                    model=OPENAI_EMBEDDING_MODEL,
                 )
             case "azure_openai":
                 from langchain_openai import AzureOpenAIEmbeddings
@@ -49,6 +51,16 @@ class Memory:
                 # Specifying the Hugging Face embedding model all-MiniLM-L6-v2
                 _embeddings = HuggingFaceEmbeddings(
                     model_name="sentence-transformers/all-MiniLM-L6-v2"
+                )
+
+            case "watsonxai":
+                from langchain_ibm import WatsonxEmbeddings
+
+                _embeddings = WatsonxEmbeddings(
+                    url=os.environ["WATSONX_URL"],
+                    apikey=os.environ["WATSONX_APIKEY"],
+                    project_id=os.environ["WATSONX_PROJECT_ID"],
+                    model_id=os.environ["WATSONX_EMBEDDING_MODEL"],
                 )
 
             case _:

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ unstructured
 json_repair
 json5
 loguru
+langchain-ibm==0.1.12
 
 # uncomment for testing
 # pytest


### PR DESCRIPTION
Adds a support to IBM's Watsonx.ai as LLM provider and embeddings provider

<img width="894" alt="image" src="https://github.com/user-attachments/assets/3c1f2c2c-b9cc-474c-8037-e5cbb0a12527">

#### .env
```
LLM_PROVIDER="watsonxai"
EMBEDDING_PROVIDER="watsonxai"

WATSONX_APIKEY="xxx"
WATSONX_URL="https://us-south.ml.cloud.ibm.com"
WATSONX_PROJECT_ID="xxx"
WATSONX_EMBEDDING_MODEL="intfloat/multilingual-e5-large"

FAST_LLM_MODEL="ibm/granite-13b-instruct-v2"
DEFAULT_LLM_MODEL="ibm/granite-13b-instruct-v2"
SMART_LLM_MODEL="meta-llama/llama-3-405b-instruct"
```
