### PR TITLE
Doc: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ export DOC_PATH="./my-docs"
 ```
 
 Step 2: 
- - If you're running the frontend app on localhost:8000, simply select "My Documents" from the the "Report Source" Dropdown Options.
+ - If you're running the frontend app on localhost:8000, simply select "My Documents" from the "Report Source" Dropdown Options.
  - If you're running GPT Researcher with the [PIP package](https://docs.tavily.com/docs/gpt-researcher/pip-package), pass the `report_source` argument as "local" when you instantiate the `GPTResearcher` class [code sample here](https://docs.gptr.dev/docs/gpt-researcher/context/tailored-research).
 
 


### PR DESCRIPTION
Corrected "the the" to "the" in [README.md].
Removing the extra "the".

This pull request addresses a minor typo found in the repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.