### PR TITLE
Fix/bing retriever consistency

### DIFF
--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -31,7 +31,7 @@ class BingSearch():
             raise Exception("Bing API key not found. Please set the BING_API_KEY environment variable.")
         return api_key
 
-    def search(self, max_results=7):
+    def search(self, max_results=7) -> list[dict[str]]:
         """
         Searches the query
         Returns:

--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -10,6 +10,8 @@ class BingSearch():
     """
     Bing Search Retriever
     """
+    logger = logging.getLogger(__name__)
+
     def __init__(self, query):
         """
         Initializes the BingSearch object
@@ -62,14 +64,16 @@ class BingSearch():
 
         # Preprocess the results
         if resp is None:
-            return
+            return []
         try:
             search_results = json.loads(resp.text)
             results = search_results["webPages"]["value"]
-        except Exception:
-            return
+        except Exception as e:
+            logger.error(f"Error parsing Bing search results: {e}. Resulting in empty response.")
+            return []
         if search_results is None:
-            return
+            logger.warning(f"No search results found for query: {self.query}")
+            return []
         search_results = []
 
         # Normalize the results to match the format of the other search APIs


### PR DESCRIPTION
This fixes an inconsistency in the return type of the Bing retriever.

It could return a list or `None`. However, the [calling code](https://github.com/assafelovic/gpt-researcher/blob/1a36430acfc74d1804d313d20c958140a05f953d/gpt_researcher/skills/researcher.py#L284) assumed the result was always a list. As a result, the entire researcher would fail if the Bing retriever reached any code path that returned `None`.

This PR makes the Bing retriever always return a list, consistent with other retrievers.