### PR TITLE
Sort pubmed_central search results by relevance versus default newest

### DIFF
--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -51,6 +51,7 @@ class PubMedCentralSearch:
             "usehistory": "y",
             "api_key": self.api_key,
             "retmode": "json",
+            "sort": "relevance"
         }
         response = requests.get(base_url, params=params)
 


### PR DESCRIPTION
By default, it looks like pubmed_central results are sorted by latest. This can produce results that are not helpful. 

The added sort=relevance parameter can be tried with a link like this: 

https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pmc&term=what+are+the+physiological+functions+of+calcium+AND+free+fulltext%5Bfilter%5D&retmax=3&usehistory=y&retmode=json&sort=relevance