### PR TITLE
Add function get_similar_content_by_query_with_vectorstore. 

### DIFF
--- a/gpt_researcher/skills/context_manager.py
+++ b/gpt_researcher/skills/context_manager.py
@@ -26,7 +26,19 @@ class ContextManager:
         return await context_compressor.async_get_context(
             query=query, max_results=10, cost_callback=self.researcher.add_costs
         )
-
+        
+    async def get_similar_content_by_query_with_vectorstore(self, query, filter): 
+        if self.researcher.verbose:
+            await stream_output(
+                "logs",
+                "fetching_query_format",
+                f" Getting relevant content based on query: {query}...",
+                self.researcher.websocket,
+                )
+        vectorstore_compressor = VectorstoreCompressor(self.researcher.vector_store, filter)
+        return await vectorstore_compressor.async_get_context(query=query, max_results=8)
+    
+    
     async def get_similar_written_contents_by_draft_section_titles(
         self,
         current_subtopic: str,


### PR DESCRIPTION
Fixes a bug when calling GPTResearcher with report_source='langchain_vectorstore'. 

code to test: 

```
import asyncio 
from gpt_researcher import GPTResearcher
import os 
from langchain.text_splitter import RecursiveCharacterTextSplitter
from langchain_openai import OpenAIEmbeddings 
from langchain_community.vectorstores import FAISS 
from langchain_core.documents import Document 
from gpt_researcher.document import DocumentLoader, LangChainDocumentLoader 

os.environ['OPENAI_API_KEY']="add your key"
os.environ['TAVILY_API_KEY']="add your key"

async def main():
    document_data = await DocumentLoader("./my-docs").load()
    langchain_docs = [Document(page_content=item["raw_content"], metadata={"source":item["url"]}) 
                      for item in document_data]
    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1400, chunk_overlap=200)
    splitted_docs = text_splitter.split_documents(langchain_docs)
    vector_store = FAISS.from_documents(splitted_docs, OpenAIEmbeddings())
    
    researcher = GPTResearcher(
        query="Write me a summary about formalin or formaldehyde", 
        report_source="langchain_vectorstore",
        vector_store=vector_store
    )
    
    context = await researcher.conduct_research()

if __name__ == "__main__":
    asyncio.run(main())
```

Without the addition of the function get_similar_content_by_query_with_vectorstore, it would throw an error. 

P.S.: Before some weeks, the problem was that while this function existed it used double underscore, hence when it was called, it was not called correctly. But now, I see that this function disappeared completely.
