### PR TITLE
Fix max_results for Google Search

### DIFF
--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -84,4 +84,4 @@ class GoogleSearch:
             }
             search_results.append(search_result)
 
-        return search_results
+        return search_results[:max_results]


### PR DESCRIPTION
There's a bug in Google Search where the max_results value in configs aren't respected. Found the bug and fixed it.