### PR TITLE
Fix AWS Bedrock invocation; create output folder in cli.py if it doesn't exist

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12,6 +12,7 @@ import asyncio
 import argparse
 from argparse import RawTextHelpFormatter
 from uuid import uuid4
+import os
 
 from dotenv import load_dotenv
 
@@ -92,6 +93,7 @@ async def main(args):
 
     # Write the report to a file
     artifact_filepath = f"outputs/{uuid4()}.md"
+    os.makedirs("outputs", exist_ok=True)
     with open(artifact_filepath, "w") as f:
         f.write(report)
 

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -100,7 +100,7 @@ class GenericLLMProvider:
 
             if "model" in kwargs or "model_name" in kwargs:
                 model_id = kwargs.pop("model", None) or kwargs.pop("model_name", None)
-                kwargs = {"model_id": model_id, **kwargs}
+                kwargs = {"model_id": model_id, "model_kwargs": kwargs}
             llm = ChatBedrock(**kwargs)
         else:
             supported = ", ".join(_SUPPORTED_PROVIDERS)


### PR DESCRIPTION
Without this change AWS Bedrock fails with the following error:

Error in reading JSON, attempting to repair JSON
Error using json_repair: the JSON object must be str, bytes or bytearray, not NoneType
Traceback (most recent call last):
  File "/Users/xo/gpt-researcher/gpt_researcher/actions/agent_creator.py", line 27, in choose_agent
    response = await create_chat_completion(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/gpt_researcher/utils/llm.py", line 54, in create_chat_completion
    provider = get_llm(llm_provider, model=model, temperature=temperature,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/gpt_researcher/utils/llm.py", line 19, in get_llm
    return GenericLLMProvider.from_provider(llm_provider, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/gpt_researcher/llm_provider/generic/base.py", line 104, in from_provider
    llm = ChatBedrock(**kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/langchain_core/load/serializable.py", line 113, in __init__
    super().__init__(*args, **kwargs)
  File "/opt/homebrew/lib/python3.12/site-packages/pydantic/v1/main.py", line 341, in __init__
    raise validation_error
pydantic.v1.error_wrappers.ValidationError: 2 validation errors for ChatBedrock
max_tokens
  extra fields not permitted (type=value_error.extra)
temperature
  extra fields not permitted (type=value_error.extra)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/xo/gpt-researcher/cli.py", line 103, in <module>
    asyncio.run(main(args))
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/cli.py", line 89, in main
    await researcher.conduct_research()
  File "/Users/xo/gpt-researcher/gpt_researcher/agent.py", line 92, in conduct_research
    self.agent, self.role = await choose_agent(
                            ^^^^^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/gpt_researcher/actions/agent_creator.py", line 44, in choose_agent
    return await handle_json_error(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/gpt_researcher/actions/agent_creator.py", line 55, in handle_json_error
    json_string = extract_json_with_regex(response)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xo/gpt-researcher/gpt_researcher/actions/agent_creator.py", line 71, in extract_json_with_regex
    json_match = re.search(r"{.*?}", response, re.DOTALL)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/__init__.py", line 177, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'