### PR TITLE
Fix uncaught exception in Google retrieval

### DIFF
--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -77,11 +77,14 @@ class GoogleSearch:
             # skip youtube results
             if "youtube.com" in result["link"]:
                 continue
-            search_result = {
-                "title": result["title"],
-                "href": result["link"],
-                "body": result["snippet"],
-            }
+            try:
+                search_result = {
+                    "title": result["title"],
+                    "href": result["link"],
+                    "body": result["snippet"],
+                }
+            except:
+                continue
             search_results.append(search_result)
 
         return search_results[:max_results]


### PR DESCRIPTION
```
File "/home/winston/.local/lib/python3.10/site-packages/gp _researcher/retrievers/google/google.py", line 83, in searc
h
"body": result["snippet"],
KeyError: 'snippet'
Error! : HTTPSConnectionPool(host='zyk.bjhd.gov.cn', port=44
3): Read timed out. (read timeout=4)
```

gpt-researcher crashes if a Google search result doesn't contain a snippet (which happens on errors such as read timeout)

