### PR TITLE
Default to the retriever set in config rather than just tavily

### DIFF
--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -33,7 +33,7 @@ class Config:
             setattr(self, key.lower(), value)
 
         # Handle RETRIEVER with default value
-        retriever_env = os.environ.get("RETRIEVER", "tavily")
+        retriever_env = os.environ.get("RETRIEVER", config.get("RETRIEVER", "tavily"))
         try:
             self.retrievers = self.parse_retrievers(retriever_env)
         except ValueError as e:


### PR DESCRIPTION
```
-        retriever_env = os.environ.get("RETRIEVER", "tavily")
+        retriever_env = os.environ.get("RETRIEVER", config.get("RETRIEVER", "tavily"))
```

Right now if the retriever isn't set in the headers, it defaults to the environment variable RETRIEVER. If that's not set, it defaults to Tavily.

The problem with this is even if the retriever is set in the config, it's completely ignored.

I had no RETRIEVER environment variable set, but I had retriever set in my configs to Bing, Google, etc.,  and was wondering why I was blowing past all my Tavily API limits...

The current workaround is to manually set the retriever in the headers rather than the config.