### PR TITLE
Fix xAI bug

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -17,7 +17,7 @@ _SUPPORTED_PROVIDERS = {
     "huggingface",
     "groq",
     "bedrock",
-    "dashscope"
+    "dashscope",
     "xai",
 }
 


### PR DESCRIPTION
```
AssertionError: Unsupported xai.
Supported llm providers are: bedrock, ollama, azure_openai, cohere, anthropic, dashscopexai, fireworks, huggingface, mistralai, openai, google_vertexai, groq, together, google_genai
```

```
$ git diff 40a6c409755b73b9fcf3c6afbf33dc608f52546a~ 40a6c409755b73b9fcf3c6afbf33dc608f52546a      
diff --git a/gpt_researcher/llm_provider/generic/base.py b/gpt_researcher/llm_provider/generic/base.py
index 05536f6f..4c4757c3 100644
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -17,6 +17,7 @@ _SUPPORTED_PROVIDERS = {
     "huggingface",
     "groq",
     "bedrock",
+    "dashscope"
     "xai",
 }
```

One of the recent git merges broke the xAI functionality. Note the missing comma. Nobody's to blame, just git's annoying merge logic ._.

This means the xAI functionality will be broken until the next release unfortunately.