### PR TITLE
Introduce strategic_token_limit to fix Anthropic bug

### DIFF
--- a/docs/docs/gpt-researcher/gptr/config.md
+++ b/docs/docs/gpt-researcher/gptr/config.md
@@ -27,6 +27,7 @@ Below is a list of current supported options:
 - **`CURATE_SOURCES`**: Whether to curate sources for research. This step adds an LLM run which may increase costs and total run time but improves quality of source selection. Defaults to `True`.
 - **`FAST_TOKEN_LIMIT`**: Maximum token limit for fast LLM responses. Defaults to `2000`.
 - **`SMART_TOKEN_LIMIT`**: Maximum token limit for smart LLM responses. Defaults to `4000`.
+- **`STRATEGIC_TOKEN_LIMIT`**: Maximum token limit for strategic LLM responses. Defaults to `4000`.
 - **`BROWSE_CHUNK_MAX_LENGTH`**: Maximum length of text chunks to browse in web sources. Defaults to `8192`.
 - **`SUMMARY_TOKEN_LIMIT`**: Maximum token limit for generating summaries. Defaults to `700`.
 - **`TEMPERATURE`**: Sampling temperature for LLM responses, typically between 0 and 1. A higher value results in more randomness and creativity, while a lower value results in more focused and deterministic responses. Defaults to `0.55`.

--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -62,6 +62,18 @@ async def generate_sub_queries(
             llm_kwargs=cfg.llm_kwargs,
             cost_callback=cost_callback,
         )
+    except ValidationError as e:
+        logger.warning(f"ValidationError with strategic LLM: {e}. Retrying with max_tokens={cfg.strategic_token_limit}")
+        response = await create_chat_completion(
+            model=cfg.strategic_llm_model,
+            messages=[{"role": "user", "content": gen_queries_prompt}],
+            temperature=1,
+            llm_provider=cfg.strategic_llm_provider,
+            max_tokens=cfg.strategic_token_limit,
+            llm_kwargs=cfg.llm_kwargs,
+            cost_callback=cost_callback,
+        )
+        logger.warning(f"Retrying with max_tokens={cfg.strategic_token_limit} successful.")
     except Exception as e:
         logger.warning(f"Error with strategic LLM: {e}. Falling back to smart LLM.")
         response = await create_chat_completion(

--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -62,29 +62,32 @@ async def generate_sub_queries(
             llm_kwargs=cfg.llm_kwargs,
             cost_callback=cost_callback,
         )
-    except ValidationError as e:
-        logger.warning(f"ValidationError with strategic LLM: {e}. Retrying with max_tokens={cfg.strategic_token_limit}")
-        response = await create_chat_completion(
-            model=cfg.strategic_llm_model,
-            messages=[{"role": "user", "content": gen_queries_prompt}],
-            temperature=1,
-            llm_provider=cfg.strategic_llm_provider,
-            max_tokens=cfg.strategic_token_limit,
-            llm_kwargs=cfg.llm_kwargs,
-            cost_callback=cost_callback,
-        )
-        logger.warning(f"Retrying with max_tokens={cfg.strategic_token_limit} successful.")
     except Exception as e:
-        logger.warning(f"Error with strategic LLM: {e}. Falling back to smart LLM.")
-        response = await create_chat_completion(
-            model=cfg.smart_llm_model,
-            messages=[{"role": "user", "content": gen_queries_prompt}],
-            temperature=cfg.temperature,
-            max_tokens=cfg.smart_token_limit,
-            llm_provider=cfg.smart_llm_provider,
-            llm_kwargs=cfg.llm_kwargs,
-            cost_callback=cost_callback,
-        )
+        logger.warning(f"Error with strategic LLM: {e}. Retrying with max_tokens={cfg.strategic_token_limit}.")
+        logger.warning(f"See https://github.com/assafelovic/gpt-researcher/issues/1022")
+        try:
+            response = await create_chat_completion(
+                model=cfg.strategic_llm_model,
+                messages=[{"role": "user", "content": gen_queries_prompt}],
+                temperature=1,
+                llm_provider=cfg.strategic_llm_provider,
+                max_tokens=cfg.strategic_token_limit,
+                llm_kwargs=cfg.llm_kwargs,
+                cost_callback=cost_callback,
+            )
+            logger.warning(f"Retrying with max_tokens={cfg.strategic_token_limit} successful.")
+        except Exception as e:
+            logger.warning(f"Retrying with max_tokens={cfg.strategic_token_limit} failed.")
+            logger.warning(f"Error with strategic LLM: {e}. Falling back to smart LLM.")
+            response = await create_chat_completion(
+                model=cfg.smart_llm_model,
+                messages=[{"role": "user", "content": gen_queries_prompt}],
+                temperature=cfg.temperature,
+                max_tokens=cfg.smart_token_limit,
+                llm_provider=cfg.smart_llm_provider,
+                llm_kwargs=cfg.llm_kwargs,
+                cost_callback=cost_callback,
+            )
 
     return json_repair.loads(response)
 

--- a/gpt_researcher/config/variables/base.py
+++ b/gpt_researcher/config/variables/base.py
@@ -11,6 +11,7 @@ class BaseConfig(TypedDict):
     STRATEGIC_LLM: str
     FAST_TOKEN_LIMIT: int
     SMART_TOKEN_LIMIT: int
+    STRATEGIC_TOKEN_LIMIT: int
     BROWSE_CHUNK_MAX_LENGTH: int
     SUMMARY_TOKEN_LIMIT: int
     TEMPERATURE: float

--- a/gpt_researcher/config/variables/default.py
+++ b/gpt_researcher/config/variables/default.py
@@ -9,6 +9,7 @@ DEFAULT_CONFIG: BaseConfig = {
     "STRATEGIC_LLM": "openai:gpt-4o", # Can be used with gpt-o1
     "FAST_TOKEN_LIMIT": 2000,
     "SMART_TOKEN_LIMIT": 4000,
+    "STRATEGIC_TOKEN_LIMIT": 4000,
     "BROWSE_CHUNK_MAX_LENGTH": 8192,
     "CURATE_SOURCES": False,
     "SUMMARY_TOKEN_LIMIT": 700,


### PR DESCRIPTION
Fix for https://github.com/assafelovic/gpt-researcher/issues/1022

New config variable `smart_token_limit` defaults to 4000 to fix ValidationError thrown by ChatAnthropic when `max_tokens=none`, replacing it with `max_tokens=4000`.