### PR TITLE
Fix generate_custom_report_prompt language bug

### DIFF
--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -179,7 +179,7 @@ def generate_resource_report_prompt(
 
 
 def generate_custom_report_prompt(
-    query_prompt, context, report_source: str, report_format="apa", tone=None, total_words=1000
+    query_prompt, context, report_source: str, report_format="apa", tone=None, total_words=1000, language: str = "english"
 ):
     return f'"{context}"\n\n{query_prompt}'
 


### PR DESCRIPTION
```
[ERROR] 2024-12-20 07:13:06 - Error in _get_report
Exception details: generate_custom_report_prompt() got an unexpected keyword argument 'language'
Traceback:
Traceback (most recent call last):
  File "ask_gptr.py", line 50, in _get_report
    report = await researcher.write_report()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gpt-researcher/gpt_researcher/agent.py", line 104, in write_report
    return await self.report_generator.write_report(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gpt-researcher/gpt_researcher/skills/writer.py", line 76, in write_report
    report = await generate_report(**report_params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "gpt-researcher/gpt_researcher/actions/report_generation.py", line 232, in generate_report
    content = f"{generate_prompt(query, context, report_source, report_format=cfg.report_format, tone=tone, total_words=cfg.total_words, language=cfg.language)}"
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: generate_custom_report_prompt() got an unexpected keyword argument 'language'
```

Fixing bug introduced in https://github.com/assafelovic/gpt-researcher/pull/1026

Similar to https://github.com/assafelovic/gpt-researcher/pull/1029