### PR TITLE
Fix Gemini bug when system role is provided

### DIFF
--- a/gpt_researcher/actions/report_generation.py
+++ b/gpt_researcher/actions/report_generation.py
@@ -245,7 +245,7 @@ async def generate_report(
             llm_kwargs=cfg.llm_kwargs,
             cost_callback=cost_callback,
         )
-    except Exception as e:
+    except:
         try:
             report = await create_chat_completion(
                 model=cfg.smart_llm_model,
@@ -260,7 +260,7 @@ async def generate_report(
                 llm_kwargs=cfg.llm_kwargs,
                 cost_callback=cost_callback,
             )
-        except:
+        except Exception as e:
             print(f"Error in generate_report: {e}")
 
     return report

--- a/gpt_researcher/actions/report_generation.py
+++ b/gpt_researcher/actions/report_generation.py
@@ -246,6 +246,21 @@ async def generate_report(
             cost_callback=cost_callback,
         )
     except Exception as e:
-        print(f"Error in generate_report: {e}")
+        try:
+            report = await create_chat_completion(
+                model=cfg.smart_llm_model,
+                messages=[
+                    {"role": "user", "content": f"{agent_role_prompt}\n\n{content}"},
+                ],
+                temperature=0.35,
+                llm_provider=cfg.smart_llm_provider,
+                stream=True,
+                websocket=websocket,
+                max_tokens=cfg.smart_token_limit,
+                llm_kwargs=cfg.llm_kwargs,
+                cost_callback=cost_callback,
+            )
+        except:
+            print(f"Error in generate_report: {e}")
 
     return report


### PR DESCRIPTION
Gemini doesn't support role=system.

When `"SMART_LLM": "google_vertexai:gemini-1.5-flash-002"` for example, the current report generation fails with "Error in generate_report".

This fix adds a fallback. It first attempts the original chat completion:
```
            messages=[                                                                              
                {"role": "system", "content": f"{agent_role_prompt}"},                              
                {"role": "user", "content": content},                                               
            ],
```

Upon failure, it retries with this new chat completion:
```
                messages=[                                                                          
                    {"role": "user", "content": f"{agent_role_prompt}\n\n{content}"},               
                ],
```

This results in a successful report generation when `"SMART_LLM": "google_vertexai:gemini-1.5-flash-002"`.