### PR TITLE
add parameter to fix resource execution

### DIFF
--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -141,7 +141,7 @@ The response MUST not contain any markdown format or additional text (like ```js
 
 
 def generate_resource_report_prompt(
-    question, context, report_source: str, report_format="apa", tone=None, total_words=1000
+    question, context, report_source: str, report_format="apa", tone=None, total_words=1000, language=None
 ):
     """Generates the resource report prompt for the given question and research summary.
 


### PR DESCRIPTION
# Pull Request: Fix TypeError in `generate_resource_report_prompt`

## Summary

This PR resolves the `TypeError` caused by passing an unexpected keyword argument `language` to the `generate_resource_report_prompt` function. The fix includes:

1. **Adding `language` as a parameter to the `generate_resource_report_prompt` function.**
2. **Ensuring compatibility in all calls to this function.**

## Changes Made

### Updated `generate_resource_report_prompt` Function
Added `language` as a parameter to align with its usage in `generate_report`.

**Old Function Signature:**
```python
def generate_resource_report_prompt(
    question, context, report_source: str, report_format="apa", tone=None, total_words=1000
):
```

## Reproduction Steps
To reproduce the error:

1. Run the `gpt-researcher` application.
2. Select **"Resource Report"** when asked, *"What type of report would you like me to generate?"*
3. The application throws the following `TypeError`:

   ```plaintext
   TypeError: generate_resource_report_prompt() got an unexpected keyword argument 'language'

