### PR TITLE
Add DeepSeek to SUPPORTED_PROVIDERS

### DIFF
--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -41,6 +41,7 @@ class ConfigRequest(BaseModel):
     SERPER_API_KEY: str = ''
     SEARX_URL: str = ''
     XAI_API_KEY: str
+    DEEPSEEK_API_KEY: str
 
 
 # App initialization

--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -251,6 +251,15 @@ STRATEGIC_LLM="xai:grok-beta"
 ```
 
 
+## DeepSeek
+```bash
+DEEPSEEK_API_KEY=[Your key]
+FAST_LLM="deepseek:deepseek-chat"
+SMART_LLM="deepseek:deepseek-chat"
+STRATEGIC_LLM="deepseek:deepseek-chat"
+```
+
+
 ## Other Embedding Models
 
 ### Nomic

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -19,6 +19,7 @@ _SUPPORTED_PROVIDERS = {
     "bedrock",
     "dashscope",
     "xai",
+    "deepseek",
 }
 
 
@@ -114,6 +115,14 @@ class GenericLLMProvider:
             from langchain_xai import ChatXAI
 
             llm = ChatXAI(**kwargs)
+        elif provider == "deepseek":
+            _check_pkg("langchain_openai")
+            from langchain_openai import ChatOpenAI
+
+            llm = ChatOpenAI(openai_api_base='https://api.deepseek.com',
+                     openai_api_key=os.environ["DEEPSEEK_API_KEY"],
+                     **kwargs
+                )
         else:
             supported = ", ".join(_SUPPORTED_PROVIDERS)
             raise ValueError(


### PR DESCRIPTION
This change adds `deepseek:deepseek-chat`, which is the latest DeepSeek-V3 model (released December 26, 2024).

DeepSeek doesn't have its own LangChain, so official DeepSeek documentation suggests using OpenAI's LangChain (https://api-docs.deepseek.com/faq), which this change implements.

Confirmed working with `FAST_LLM="deepseek:deepseek-chat"`, `SMART_LLM="deepseek:deepseek-chat"`, and `STRATEGIC_LLM="deepseek:deepseek-chat"` when `DEEPSEEK_API_KEY` system variable is set.

