### PR TITLE
Add Litellm to supported providers in GenericLLMProvider

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -3,7 +3,7 @@
 As described in the [introduction](/docs/gpt-researcher/gptr/config), the default LLM and embedding is OpenAI due to its superior performance and speed. 
 With that said, GPT Researcher supports various open/closed source LLMs and embeddings, and you can easily switch between them by updating the `SMART_LLM`, `FAST_LLM` and `EMBEDDING` env variables. You might also need to include the provider API key and corresponding configuration params.
 
-Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `groq` and `bedrock`.
+Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `groq`, `bedrock` and `litellm`.
 
 Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `nomic` ,`voyageai` and `bedrock`.
 
@@ -239,6 +239,15 @@ SMART_LLM="bedrock:anthropic.claude-3-sonnet-20240229-v1:0"
 STRATEGIC_LLM="bedrock:anthropic.claude-3-sonnet-20240229-v1:0"
 
 EMBEDDING="bedrock:amazon.titan-embed-text-v2:0"
+```
+
+
+## LiteLLM
+
+```bash
+FAST_LLM="litellm:perplexity/pplx-7b-chat"
+SMART_LLM="litellm:perplexity/pplx-70b-chat"
+STRATEGIC_LLM="litellm:perplexity/pplx-70b-chat"
 ```
 
 

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -20,6 +20,7 @@ _SUPPORTED_PROVIDERS = {
     "dashscope",
     "xai",
     "deepseek",
+    "litellm",
 }
 
 
@@ -123,6 +124,11 @@ class GenericLLMProvider:
                      openai_api_key=os.environ["DEEPSEEK_API_KEY"],
                      **kwargs
                 )
+        elif provider == "litellm":
+            _check_pkg("langchain_community")
+            from langchain_community.chat_models.litellm import ChatLiteLLM
+
+            llm = ChatLiteLLM(**kwargs)
         else:
             supported = ", ".join(_SUPPORTED_PROVIDERS)
             raise ValueError(


### PR DESCRIPTION
Add Litellm to supported providers in GenericLLMProvider.


Using Litellm has the following advantages:
Call 100+ LLMs using the OpenAI Input/Output Format

https://docs.litellm.ai/