### PR TITLE
preserve user-specified report source instead of config default

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -55,7 +55,7 @@ class GPTResearcher:
         self.report_type = report_type
         self.cfg = Config(config_path)
         self.llm = GenericLLMProvider(self.cfg)
-        self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', 'web')
+        self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', None)
         self.report_format = report_format
         self.max_subtopics = max_subtopics
         self.tone = tone if isinstance(tone, Tone) else Tone.Objective

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -55,8 +55,7 @@ class GPTResearcher:
         self.report_type = report_type
         self.cfg = Config(config_path)
         self.llm = GenericLLMProvider(self.cfg)
-        self.report_source = getattr(
-            self.cfg, 'report_source', None) or report_source
+        self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', 'web')
         self.report_format = report_format
         self.max_subtopics = max_subtopics
         self.tone = tone if isinstance(tone, Tone) else Tone.Objective

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -95,7 +95,9 @@ class ResearchConductor:
 
         # ... rest of the conditions ...
         elif self.researcher.report_source == ReportSource.Local.value:
+            self.logger.info("Using local search")
             document_data = await DocumentLoader(self.researcher.cfg.doc_path).load()
+            self.logger.info(f"Loaded {len(document_data)} documents")
             if self.researcher.vector_store:
                 self.researcher.vector_store.load(document_data)
 


### PR DESCRIPTION
The report_source parameter was being incorrectly overridden by the config  default value due to Python's 'or' operator behavior with truthy values.  Changed the logic to explicitly check for the passed parameter first before  falling back to config values.