### PR TITLE
multi_agent: update CSS path to be relative to current file

### DIFF
--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -2,7 +2,7 @@ import aiofiles
 import urllib
 import uuid
 import mistune
-
+import os
 
 async def write_to_file(filename: str, text: str) -> None:
     """Asynchronously write text to a file in UTF-8 encoding.
@@ -47,12 +47,15 @@ async def write_md_to_pdf(text: str, path: str) -> str:
     file_path = f"{path}/{task}.pdf"
 
     try:
+        # Get the directory of the current file
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        css_path = os.path.join(current_dir, "pdf_styles.css")
+        
         # Moved imports to inner function to avoid known import errors with gobject-2.0
         from md2pdf.core import md2pdf
         md2pdf(file_path,
                md_content=text,
-               # md_file_path=f"{file_path}.md",
-               css_file_path="./multi_agents/skills/utils/pdf_styles.css",  # Updated path
+               css_file_path=css_path,
                base_url=None)
         print(f"Report written to {file_path}")
     except Exception as e:


### PR DESCRIPTION
Use os.path to make the CSS file path relative to the current Python file's
location instead of using a hardcoded path. This makes the code more robust
and portable.

Fixes #1008 