### PR TITLE
fix(#1100): apply language config to Introduction and Conclusion sections

### DIFF
--- a/gpt_researcher/actions/report_generation.py
+++ b/gpt_researcher/actions/report_generation.py
@@ -42,7 +42,10 @@ async def write_report_introduction(
             messages=[
                 {"role": "system", "content": f"{agent_role_prompt}"},
                 {"role": "user", "content": generate_report_introduction(
-                    query, context)},
+                    question=query,
+                    research_summary=context,
+                    language=config.language
+                )},
             ],
             temperature=0.25,
             llm_provider=config.smart_llm_provider,
@@ -85,7 +88,9 @@ async def write_conclusion(
             model=config.smart_llm_model,
             messages=[
                 {"role": "system", "content": f"{agent_role_prompt}"},
-                {"role": "user", "content": generate_report_conclusion(query, context)},
+                {"role": "user", "content": generate_report_conclusion(query=query,
+                                                                       report_content=context,
+                                                                       language=config.language)},
             ],
             temperature=0.25,
             llm_provider=config.smart_llm_provider,

--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -393,7 +393,7 @@ Provide the draft headers in a list format using markdown syntax, for example:
 """
 
 
-def generate_report_introduction(question: str, research_summary: str = "") -> str:
+def generate_report_introduction(question: str, research_summary: str = "", language: str = "english") -> str:
     return f"""{research_summary}\n 
 Using the above latest information, Prepare a detailed report introduction on the topic -- {question}.
 - The introduction should be succinct, well-structured, informative with markdown syntax.
@@ -401,15 +401,18 @@ Using the above latest information, Prepare a detailed report introduction on th
 - The introduction should be preceded by an H1 heading with a suitable topic for the entire report.
 - You must include hyperlinks with markdown syntax ([url website](url)) related to the sentences wherever necessary.
 Assume that the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if required.
+- The output must be in {language} language.
 """
 
 
-def generate_report_conclusion(query: str, report_content: str) -> str:
+def generate_report_conclusion(query: str, report_content: str, language: str = "english") -> str:
     """
     Generate a concise conclusion summarizing the main findings and implications of a research report.
 
     Args:
+        query (str): The research task or question.
         report_content (str): The content of the research report.
+        language (str): The language in which the conclusion should be written.
 
     Returns:
         str: A concise conclusion summarizing the report's main findings and implications.
@@ -429,7 +432,9 @@ def generate_report_conclusion(query: str, report_content: str) -> str:
     
     If there is no "## Conclusion" section title written at the end of the report, please add it to the top of your conclusion. 
     You must include hyperlinks with markdown syntax ([url website](url)) related to the sentences wherever necessary.
-    
+
+    IMPORTANT: The entire conclusion MUST be written in {language} language.
+
     Write the conclusion:
     """
 


### PR DESCRIPTION
First, thank you for considering my contribution to the GPT Researcher project. This PR addresses the issue [#1100](https://github.com/assafelovic/gpt-researcher/issues/1100#issue-2828944245) where the Introduction and Conclusion sections of research reports do not respect the LANGUAGE configuration setting.

## Issue Description
When `LANGUAGE` is set to a non-English value in the configuration (e.g., "japanese"), the Introduction and Conclusion sections remain in English while the rest of the report is generated in the configured language. This creates inconsistency in the report output.

## Changes Made
- Modified report generation to pass language configuration to Introduction and Conclusion generation prompts
- Ensures consistent language usage throughout the entire report
- Maintains existing config system behavior while extending its reach to previously missed sections

## Testing
I have tested these changes by:
1. Setting `LANGUAGE: "japanese"` in the configuration
2. Generating a "Detailed" report which includes Introduction/Conclusion sections
3. Verifying that all sections, including Introduction and Conclusion, are now generated in Japanese
4. Confirming that other functionalities remain unaffected
![Screenshot 2025-02-04 at 11 26 04](https://github.com/user-attachments/assets/dff8cb11-ac3e-41e8-a817-0b9a9256a5f6)
![Screenshot 2025-02-04 at 11 25 58](https://github.com/user-attachments/assets/cf24f02d-1bdd-4559-bbac-0ef813ce4910)
![Screenshot 2025-02-04 at 11 25 50](https://github.com/user-attachments/assets/570acfe4-e660-4add-9a98-e33428497334)

## Steps to Reproduce (Original Issue)
1. Set `LANGUAGE: "japanese"` in the config
2. Run the researcher
3. Select "Detailed - In depth and longer(~5min)" when prompted
4. Observe that Introduction and Conclusion remain in English despite Japanese config

## Current Config Example
```
python
DEFAULT_CONFIG: BaseConfig = {
   "LANGUAGE": "japanese",
   # ... other settings
}
```