### PR TITLE
fix: add language param to generate_outline_report_prompt

### DIFF
--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -185,7 +185,7 @@ def generate_custom_report_prompt(
 
 
 def generate_outline_report_prompt(
-    question, context, report_source: str, report_format="apa", tone=None,  total_words=1000
+    question, context, report_source: str, report_format="apa", tone=None,  total_words=1000, language: str = "english"
 ):
     """Generates the outline report prompt for the given question and research summary.
     Args: question (str): The question to generate the outline report prompt for


### PR DESCRIPTION
when run cli script
```
python cli.py "story protocol" --report_type outline_report
```
it throws error:
```
File "/home/gpt-researcher/gpt_researcher/actions/report_generation.py", line 237, in generate_report
    content = f"{generate_prompt(query, context, report_source, report_format=cfg.report_format, tone=tone, total_words=cfg.total_words, language=cfg.language)}"
TypeError: generate_outline_report_prompt() got an unexpected keyword argument 'language'
```
I found that because generate_outline_report_prompt does not have language param