### PR TITLE
missing langchain-google-genai for Gemini provider

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ python-multipart
 markdown
 langchain
 langchain_community
+langchain-google-genai
 langchain-openai
 langchain-ollama
 langgraph


### PR DESCRIPTION
Using Gemini as provider was broken due to missing dependency.
Added langchain-google-genai to the requirements.txt, as Gemini provider cannot be used without it