### PR TITLE
Adds support for o3-mini

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -60,6 +60,7 @@ async def generate_sub_queries(
             llm_provider=cfg.strategic_llm_provider,
             max_tokens=None,
             llm_kwargs=cfg.llm_kwargs,
+            reasoning_effort="high",
             cost_callback=cost_callback,
         )
     except Exception as e:

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -28,7 +28,8 @@ async def create_chat_completion(
         stream: Optional[bool] = False,
         websocket: Any | None = None,
         llm_kwargs: Dict[str, Any] | None = None,
-        cost_callback: callable = None
+        cost_callback: callable = None,
+        reasoning_effort: Optional[str] = "low"
 ) -> str:
     """Create a chat completion using the OpenAI API
     Args:
@@ -51,9 +52,19 @@ async def create_chat_completion(
             f"Max tokens cannot be more than 16,000, but got {max_tokens}")
 
     # Get the provider from supported providers
-    provider = get_llm(llm_provider, model=model, temperature=temperature,
-                       max_tokens=max_tokens, **(llm_kwargs or {}))
+    kwargs = {
+        'model': model,
+        'max_tokens': max_tokens,
+        **(llm_kwargs or {})
+    }
 
+    if 'o3' in model:
+        kwargs['reasoning_effort'] = reasoning_effort
+    else:
+        kwargs['temperature'] = temperature
+
+    print(f"\n🤖 Calling {llm_provider} with model {model}...\n")
+    provider = get_llm(llm_provider, **kwargs)
     response = ""
     # create response
     for _ in range(10):  # maximum of 10 attempts
@@ -95,16 +106,22 @@ async def construct_subtopics(task: str, data: str, config, subtopics: list = []
         )
 
         print(f"\n🤖 Calling {config.smart_llm_model}...\n")
+        kwargs = {
+            'model': config.smart_llm_model,
+            'max_tokens': config.smart_token_limit,
+            **(config.llm_kwargs or {})
+        }
 
         temperature = config.temperature
         # temperature = 0 # Note: temperature throughout the code base is currently set to Zero
-        provider = get_llm(
-            config.smart_llm_provider,
-            model=config.smart_llm_model,
-            temperature=temperature,
-            max_tokens=config.smart_token_limit,
-            **config.llm_kwargs,
-        )
+        if 'o3' in config.smart_llm_model:
+            kwargs['reasoning_effort'] = "high"
+        else:
+            kwargs['temperature'] = temperature
+
+        print(f"\n🤖 Calling {config.smart_llm_provider} with model {config.smart_llm_model}...\n")
+        provider = get_llm(config.smart_llm_provider, **kwargs)
+
         model = provider.llm
 
         chain = prompt | model | parser


### PR DESCRIPTION
As discussed in issue #1098, this pull request adds support for the o3-mini model without impacting users of other models.

o3-mini is much faster (higher latency but much higher throughput) and cheaper than 4o and previous o1 models. Adding support for it allows for faster more complete research at similar prices.

