### PR TITLE
Add FireCrawl scaper

### DIFF
--- a/docs/docs/gpt-researcher/gptr/scraping.md
+++ b/docs/docs/gpt-researcher/gptr/scraping.md
@@ -16,10 +16,15 @@ You can choose your preferred scraping method by setting the `SCRAPER` environme
    export SCRAPER="browser"
    ```
 
-3. For **production** use cases, you can set the Scraper to `tavily_extract`. [Tavily](https://tavily.com) allows you to scrape sites at scale without the hassle of setting up proxies, managing cookies, or dealing with CAPTCHAs. Please note that you need to have a Tavily account and [API key](https://app.tavily.com) to use this option. To learn more about Tavily Extract [see here](https://docs.tavily.com/docs/python-sdk/tavily-extract/getting-started).
+3. For **production** use cases, you can set the Scraper to `tavily_extract` or `firecrawl`. [Tavily](https://tavily.com) allows you to scrape sites at scale without the hassle of setting up proxies, managing cookies, or dealing with CAPTCHAs. Please note that you need to have a Tavily account and [API key](https://app.tavily.com) to use this option. To learn more about Tavily Extract [see here](https://docs.tavily.com/docs/python-sdk/tavily-extract/getting-started).
     Make sure to first install the pip package `tavily-python`. Then:
    ```
    export SCRAPER="tavily_extract"
+   ```
+   [FireCrawl](https://firecrawl.dev) is also allows you to scrape sites at scale. FireCrawl also provides open source code to self hosted server which provided better scrape quality compared to BeautifulSoup by passing markdown version of the scraped sites to LLMs. You will needs to have FireCrawl account (official service) to get API key or you needs self host URL and API key (if you set for your self host server) to use this option.
+   Make sure to install the pip package `firecrawl-py`. Then:
+   ```bash
+   export SCRAPER="firecrawl"
    ```
 
 Note: If not set, GPT Researcher will default to BeautifulSoup for scraping.
@@ -95,6 +100,56 @@ Usage Considerations:
 - API calls are metered based on your Tavily plan
 - Best for production environments where reliability is crucial
 - Ideal for businesses and applications that need consistent scraping results
+
+### FireCrawl (Recommended for Production)
+When `SCRAPER="firecrawl"`, GPT Researcher uses FireCrawl Scrape API for web scraping in markdown format. This method:
+
+- Uses FireCrawl's robust infrastructure to handle web scraping at scale
+- Or uses self-hosted FireCrawl server.
+- Automatically handles CAPTCHAs, JavaScript rendering, and anti-bot measures
+- Provides clean, structured content extraction in markdown format.
+
+Benefits:
+- Production-ready and highly reliable
+- No need to manage proxies or handle rate limiting
+- Excellent success rate on most websites
+- Handles both static and dynamic content
+- Built-in content cleaning and formatting
+- Fast response times through FireCrawl's distributed infrastructure
+- Ease of setup with FireCrawl self-hosted
+
+Setup (official service by FireCrawl):
+1. Create a FireCrawl account at [firecrawl.dev/app](https://www.firecrawl.dev/app)
+2. Get your API key from the dashboard
+3. Install the FireCrawl Python SDK:
+   ```bash
+   pip install firecrawl-py
+   ```
+4. Set your FireCrawl API key:
+   ```bash
+   export FIRECRAWL_API_KEY=<your-firecrawl-api>
+   ```
+Setup (with self-hosted server):
+1. Host your FireCrawl. Read their [self-hosted guidelines](https://docs.firecrawl.dev/contributing/self-host) or [run locally guidelines](https://docs.firecrawl.dev/contributing/guide)
+2. Get your server URL and API key (if you set it).
+3. Install the FireCrawl Python SDK:
+   ```bash
+   pip install firecrawl-py
+   ```
+4. Set your FireCrawl API key:
+   ```bash
+   export FIRECRAWL_API_KEY=<your-firecrawl-api>
+   ```
+
+Note: `FIRECRAWL_API_KEY` can be empty if you not setup authentication for your self host server (`FIRECRAWL_API_KEY=""`).
+There will be some difference between their cloud service and open source service. To understand differences between FireCrawl option read [here](https://docs.firecrawl.dev/contributing/open-source-or-cloud).
+
+Usage Considerations:
+- Requires a FireCrawl API key and account or self-hosted server
+- API calls are metered based on your FireCrawl plan (it can be basically free with self-hosted FireCrawl method)
+- Best for production environments where reliability is crucial (for their cloud service)
+- Ideal for businesses and applications that need consistent scraping results
+- Need robust scraping option for personal use
 
 ## Additional Setup for Selenium
 

--- a/gpt_researcher/scraper/__init__.py
+++ b/gpt_researcher/scraper/__init__.py
@@ -5,6 +5,7 @@ from .arxiv.arxiv import ArxivScraper
 from .pymupdf.pymupdf import PyMuPDFScraper
 from .browser.browser import BrowserScraper
 from .tavily_extract.tavily_extract import TavilyExtract
+from .firecrawl.firecrawl import FireCrawl
 from .scraper import Scraper
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     "PyMuPDFScraper",
     "BrowserScraper",
     "TavilyExtract",
-    "Scraper"
+    "Scraper",
+    "FireCrawl"
 ]

--- a/gpt_researcher/scraper/firecrawl/firecrawl.py
+++ b/gpt_researcher/scraper/firecrawl/firecrawl.py
@@ -1,0 +1,79 @@
+from bs4 import BeautifulSoup
+import os
+from ..utils import get_relevant_images
+
+class FireCrawl:
+
+    def __init__(self, link, session=None):
+        self.link = link
+        self.session = session
+        from firecrawl import FirecrawlApp
+        self.firecrawl = FirecrawlApp(api_key=self.get_api_key(), api_url=self.get_server_url())
+
+    def get_api_key(self) -> str:
+        """
+        Gets the FireCrawl API key
+        Returns:
+        Api key (str)
+        """
+        try:
+            api_key = os.environ["FIRECRAWL_API_KEY"]
+        except KeyError:
+            raise Exception(
+                "FireCrawl API key not found. Please set the FIRECRAWL_API_KEY environment variable.")
+        return api_key
+
+    def get_server_url(self) -> str:
+        """
+        Gets the FireCrawl server URL.
+        Default to official FireCrawl server ('https://api.firecrawl.dev').
+        Returns:
+        server url (str)
+        """
+        try:
+            server_url = os.environ["FIRECRAWL_SERVER_URL"]
+        except KeyError:
+            server_url = 'https://api.firecrawl.dev'
+        return server_url
+
+    def scrape(self) -> tuple:
+        """
+        This function extracts content and title from a specified link using the FireCrawl Python SDK,
+        images from the link are extracted using the functions from `gpt_researcher/scraper/utils.py`.
+
+        Returns:
+          The `scrape` method returns a tuple containing the extracted content, a list of image URLs, and
+        the title of the webpage specified by the `self.link` attribute. It uses the FireCrawl Python SDK to
+        extract and clean content from the webpage. If any exception occurs during the process, an error
+        message is printed and an empty result is returned.
+        """
+
+        try:
+            response = self.firecrawl.scrape_url(url=self.link, params={"formats": ["markdown"]})
+
+            # Check if the page has been scraped success
+            if "error" in response:
+                print("Scrape failed! : " + str(response["error"]))
+                return "", [], ""
+            elif response["metadata"]["statusCode"] != 200:
+                print("Scrape failed! : " + str(response))
+                return "", [], ""
+
+            # Extract the content (markdown) and title from FireCrawl response
+            content = response["markdown"]
+            title = response["metadata"]["title"]
+
+            # Parse the HTML content of the response to create a BeautifulSoup object for the utility functions
+            response_bs = self.session.get(self.link, timeout=4)
+            soup = BeautifulSoup(
+                response_bs.content, "lxml", from_encoding=response_bs.encoding
+            )
+
+            # Get relevant images using the utility function
+            image_urls = get_relevant_images(soup, self.link)
+
+            return content, image_urls, title
+
+        except Exception as e:
+            print("Error! : " + str(e))
+            return "", [], ""

--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -14,7 +14,8 @@ from . import (
     PyMuPDFScraper,
     WebBaseLoaderScraper,
     BrowserScraper,
-    TavilyExtract
+    TavilyExtract,
+    FireCrawl
 )
 
 
@@ -34,6 +35,8 @@ class Scraper:
         self.session.headers.update({"User-Agent": user_agent})
         self.scraper = scraper
         if self.scraper == "tavily_extract":
+            self._check_pkg(self.scraper)
+        if self.scraper == "firecrawl":
             self._check_pkg(self.scraper)
         self.logger = logging.getLogger(__name__)
 
@@ -56,6 +59,8 @@ class Scraper:
         pkg_map = {
             "tavily_extract": {"package_installation_name": "tavily-python",
                                "import_name": "tavily"},
+            "firecrawl": {"package_installation_name": "firecrawl-py",
+                         "import_name": "firecrawl"}
         }
         pkg = pkg_map[scrapper_name]
         if not importlib.util.find_spec(pkg["import_name"]):
@@ -78,36 +83,36 @@ class Scraper:
         try:
             Scraper = self.get_scraper(link)
             scraper = Scraper(link, session)
-            
+
             # Get scraper name
             scraper_name = scraper.__class__.__name__
             self.logger.info(f"\n=== Using {scraper_name} ===")
-            
+
             # Get content
             content, image_urls, title = scraper.scrape()
 
             if len(content) < 100:
                 self.logger.warning(f"Content too short or empty for {link}")
                 return {"url": link, "raw_content": None, "image_urls": [], "title": title}
-            
+
             # Log results
             self.logger.info(f"\nTitle: {title}")
             self.logger.info(f"Content length: {len(content) if content else 0} characters")
             self.logger.info(f"Number of images: {len(image_urls)}")
             self.logger.info(f"URL: {link}")
             self.logger.info("=" * 50)
-            
+
             if not content or len(content) < 100:
                 self.logger.warning(f"Content too short or empty for {link}")
                 return {"url": link, "raw_content": None, "image_urls": [], "title": title}
-            
+
             return {
                 "url": link,
                 "raw_content": content,
                 "image_urls": image_urls,
                 "title": title
             }
-            
+
         except Exception as e:
             self.logger.error(f"Error processing {link}: {str(e)}")
             return {"url": link, "raw_content": None, "image_urls": [], "title": ""}
@@ -135,7 +140,8 @@ class Scraper:
             "bs": BeautifulSoupScraper,
             "web_base_loader": WebBaseLoaderScraper,
             "browser": BrowserScraper,
-            "tavily_extract": TavilyExtract
+            "tavily_extract": TavilyExtract,
+            "firecrawl": FireCrawl
         }
 
         scraper_key = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ json-repair = "^0.29.8"
 json5 = "^0.9.25"
 loguru = "^0.7.2"
 websockets = "^13.1"
+firecrawl-py = "^1.12.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Add support for FireCrawl scaper for page content and page title.
It should be support self host or official service from FireCrawl by set enviroment variables `FIRECRAWL_SERVER_URL` and `FIRECRAWL_API_KEY`.
And set `SCRAPER=firecrawl` to use FireCrawl scaper.

Already tested with selft hosted FireCrawl.