### PR TITLE
Fix: ArxivScraper causing error when scraping the link.

### DIFF
--- a/gpt_researcher/scraper/arxiv/arxiv.py
+++ b/gpt_researcher/scraper/arxiv/arxiv.py
@@ -18,5 +18,6 @@ class ArxivScraper:
         """
         query = self.link.split("/")[-1]
         retriever = ArxivRetriever(load_max_docs=2, doc_content_chars_max=None)
-        docs = retriever.invoke(query=query)
-        return docs[0].page_content
+        docs = retriever.invoke(query)
+        # returns content, image_urls, title
+        return docs[0].page_content, [], docs[0].metadata["Title"]


### PR DESCRIPTION
<img width="946" alt="Screenshot 2025-02-21 at 12 47 39 PM" src="https://github.com/user-attachments/assets/02a51832-2d14-4a6b-b254-19cbc2251030" />

On setting RETRIEVER=arxiv, an error comes and content is not retrieved.
Reference for fix: https://python.langchain.com/docs/integrations/retrievers/arxiv/#usage