### PR TITLE
Refactor: typing cleanup

### DIFF
--- a/gpt_researcher/actions/agent_creator.py
+++ b/gpt_researcher/actions/agent_creator.py
@@ -11,7 +11,7 @@ async def choose_agent(
     Chooses the agent automatically
     Args:
         parent_query: In some cases the research is conducted on a subtopic from the main query.
-        The parent query allows the agent to know the main context for better reasoning.
+            The parent query allows the agent to know the main context for better reasoning.
         query: original query
         cfg: Config
         cost_callback: callback for calculating llm costs

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -1,11 +1,10 @@
-from typing import List, Type
 from ..config.config import Config
 
-def get_retriever(retriever):
+def get_retriever(retriever: str):
     """
     Gets the retriever
     Args:
-        retriever: retriever name
+        retriever (str): retriever name
 
     Returns:
         retriever: Retriever class
@@ -70,8 +69,7 @@ def get_retriever(retriever):
 
     return retriever
 
-
-def get_retrievers(headers, cfg):
+def get_retrievers(headers: dict[str, str], cfg: Config):
     """
     Determine which retriever(s) to use based on headers, config, or default.
 
@@ -103,7 +101,7 @@ def get_retrievers(headers, cfg):
     return [get_retriever(r) or get_default_retriever() for r in retrievers]
 
 
-def get_default_retriever(retriever):
+def get_default_retriever():
     from gpt_researcher.retrievers import TavilySearch
 
     return TavilySearch

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -14,60 +14,59 @@ def get_retriever(retriever: str):
         case "google":
             from gpt_researcher.retrievers import GoogleSearch
 
-            retriever = GoogleSearch
+            return GoogleSearch
         case "searx":
             from gpt_researcher.retrievers import SearxSearch
 
-            retriever = SearxSearch
+            return SearxSearch
         case "searchapi":
             from gpt_researcher.retrievers import SearchApiSearch
 
-            retriever = SearchApiSearch
+            return SearchApiSearch
         case "serpapi":
             from gpt_researcher.retrievers import SerpApiSearch
 
-            retriever = SerpApiSearch
+            return SerpApiSearch
         case "serper":
             from gpt_researcher.retrievers import SerperSearch
 
-            retriever = SerperSearch
+            return SerperSearch
         case "duckduckgo":
             from gpt_researcher.retrievers import Duckduckgo
 
-            retriever = Duckduckgo
+            return Duckduckgo
         case "bing":
             from gpt_researcher.retrievers import BingSearch
 
-            retriever = BingSearch
+            return BingSearch
         case "arxiv":
             from gpt_researcher.retrievers import ArxivSearch
 
-            retriever = ArxivSearch
+            return ArxivSearch
         case "tavily":
             from gpt_researcher.retrievers import TavilySearch
 
-            retriever = TavilySearch
+            return TavilySearch
         case "exa":
             from gpt_researcher.retrievers import ExaSearch
 
-            retriever = ExaSearch
+            return ExaSearch
         case "semantic_scholar":
             from gpt_researcher.retrievers import SemanticScholarSearch
 
-            retriever = SemanticScholarSearch
+            return SemanticScholarSearch
         case "pubmed_central":
             from gpt_researcher.retrievers import PubMedCentralSearch
 
-            retriever = PubMedCentralSearch
+            return PubMedCentralSearch
         case "custom":
             from gpt_researcher.retrievers import CustomRetriever
 
-            retriever = CustomRetriever
+            return CustomRetriever
 
         case _:
-            retriever = None
+            return None
 
-    return retriever
 
 def get_retrievers(headers: dict[str, str], cfg: Config):
     """

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Set
+from typing import Any
 import json
 
 from .config import Config
@@ -33,10 +33,10 @@ class GPTResearcher:
         report_format: str = "markdown",
         report_source: str = ReportSource.Web.value,
         tone: Tone = Tone.Objective,
-        source_urls=None,
-        document_urls=None,
-        complement_source_urls=False,
-        query_domains: List[str] = [],
+        source_urls: list[str] | None = None,
+        document_urls: list[str] | None = None,
+        complement_source_urls: bool = False,
+        query_domains: list[str] | None = None,
         documents=None,
         vector_store=None,
         vector_store_filter=None,
@@ -45,11 +45,11 @@ class GPTResearcher:
         agent=None,
         role=None,
         parent_query: str = "",
-        subtopics: list = [],
-        visited_urls: set = set(),
+        subtopics: list | None = None,
+        visited_urls: set | None = None,
         verbose: bool = True,
-        context=[],
-        headers: dict = None,
+        context=None,
+        headers: dict | None = None,
         max_subtopics: int = 5,
         log_handler=None,
     ):
@@ -63,8 +63,8 @@ class GPTResearcher:
         self.tone = tone if isinstance(tone, Tone) else Tone.Objective
         self.source_urls = source_urls
         self.document_urls = document_urls
-        self.complement_source_urls: bool = complement_source_urls
-        self.query_domains = query_domains
+        self.complement_source_urls = complement_source_urls
+        self.query_domains = query_domains or []
         self.research_sources = []  # The list of scraped sources including title, content and images
         self.research_images = []  # The list of selected research images
         self.documents = documents
@@ -74,10 +74,10 @@ class GPTResearcher:
         self.agent = agent
         self.role = role
         self.parent_query = parent_query
-        self.subtopics = subtopics
-        self.visited_urls = visited_urls
+        self.subtopics = subtopics or []
+        self.visited_urls = visited_urls or set()
         self.verbose = verbose
-        self.context = context
+        self.context = context or []
         self.headers = headers or {}
         self.research_costs = 0.0
         self.retrievers = get_retrievers(self.headers, self.cfg)
@@ -221,10 +221,10 @@ class GPTResearcher:
     async def get_similar_written_contents_by_draft_section_titles(
         self,
         current_subtopic: str,
-        draft_section_titles: List[str],
-        written_contents: List[Dict],
+        draft_section_titles: list[str],
+        written_contents: list[dict],
         max_results: int = 10
-    ) -> List[str]:
+    ) -> list[str]:
         return await self.context_manager.get_similar_written_contents_by_draft_section_titles(
             current_subtopic,
             draft_section_titles,
@@ -233,25 +233,25 @@ class GPTResearcher:
         )
 
     # Utility methods
-    def get_research_images(self, top_k=10) -> List[Dict[str, Any]]:
+    def get_research_images(self, top_k=10) -> list[dict[str, Any]]:
         return self.research_images[:top_k]
 
-    def add_research_images(self, images: List[Dict[str, Any]]) -> None:
+    def add_research_images(self, images: list[dict[str, Any]]) -> None:
         self.research_images.extend(images)
 
-    def get_research_sources(self) -> List[Dict[str, Any]]:
+    def get_research_sources(self) -> list[dict[str, Any]]:
         return self.research_sources
 
-    def add_research_sources(self, sources: List[Dict[str, Any]]) -> None:
+    def add_research_sources(self, sources: list[dict[str, Any]]) -> None:
         self.research_sources.extend(sources)
 
     def add_references(self, report_markdown: str, visited_urls: set) -> str:
         return add_references(report_markdown, visited_urls)
 
-    def extract_headers(self, markdown_text: str) -> List[Dict]:
+    def extract_headers(self, markdown_text: str) -> list[dict]:
         return extract_headers(markdown_text)
 
-    def extract_sections(self, markdown_text: str) -> List[Dict]:
+    def extract_sections(self, markdown_text: str) -> list[dict]:
         return extract_sections(markdown_text)
 
     def table_of_contents(self, markdown_text: str) -> str:

--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -295,7 +295,7 @@ response:
 task: "what are the most interesting sites in Tel Aviv?"
 response:
 {
-    "server:  "🌍 Travel Agent",
+    "server":  "🌍 Travel Agent",
     "agent_role_prompt": "You are a world-travelled AI tour guide assistant. Your main purpose is to draft engaging, insightful, unbiased, and well-structured travel reports on given locations, including history, attractions, and cultural insights."
 }
 """

--- a/gpt_researcher/skills/browser.py
+++ b/gpt_researcher/skills/browser.py
@@ -1,8 +1,6 @@
-from typing import List, Dict
-
 from ..actions.utils import stream_output
 from ..actions.web_scraping import scrape_urls
-from ..scraper.utils import get_image_hash  # Add this import
+from ..scraper.utils import get_image_hash
 
 
 class BrowserManager:
@@ -11,15 +9,15 @@ class BrowserManager:
     def __init__(self, researcher):
         self.researcher = researcher
 
-    async def browse_urls(self, urls: List[str]) -> List[Dict]:
+    async def browse_urls(self, urls: list[str]) -> list[dict]:
         """
         Scrape content from a list of URLs.
 
         Args:
-            urls (List[str]): List of URLs to scrape.
+            urls (list[str]): list of URLs to scrape.
 
         Returns:
-            List[Dict]: List of scraped content results.
+            list[dict]: list of scraped content results.
         """
         if self.researcher.verbose:
             await stream_output(
@@ -31,7 +29,7 @@ class BrowserManager:
 
         scraped_content, images = scrape_urls(urls, self.researcher.cfg)
         self.researcher.add_research_sources(scraped_content)
-        new_images = self.select_top_images(images, k=4)  # Select top 2 images
+        new_images = self.select_top_images(images, k=4)  # Select top 4 images
         self.researcher.add_research_images(new_images)
 
         if self.researcher.verbose:
@@ -58,16 +56,16 @@ class BrowserManager:
 
         return scraped_content
 
-    def select_top_images(self, images: List[Dict], k: int = 2) -> List[str]:
+    def select_top_images(self, images: list[dict], k: int = 2) -> list[str]:
         """
         Select most relevant images and remove duplicates based on image content.
 
         Args:
-            images (List[Dict]): List of image dictionaries with 'url' and 'score' keys.
+            images (list[dict]): list of image dictionaries with 'url' and 'score' keys.
             k (int): Number of top images to select if no high-score images are found.
 
         Returns:
-            List[str]: List of selected image URLs.
+            list[str]: list of selected image URLs.
         """
         unique_images = []
         seen_hashes = set()
@@ -78,7 +76,11 @@ class BrowserManager:
 
         for img in high_score_images + images:  # Process high-score images first, then all images
             img_hash = get_image_hash(img['url'])
-            if img_hash and img_hash not in seen_hashes and img['url'] not in current_research_images:
+            if (
+                img_hash
+                and img_hash not in seen_hashes
+                and img['url'] not in current_research_images
+            ):
                 seen_hashes.add(img_hash)
                 unique_images.append(img['url'])
 

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -1,11 +1,9 @@
 # libraries
 from __future__ import annotations
 
-import json
 import logging
-from typing import Optional, Any, Dict
+from typing import Any
 
-from colorama import Fore, Style
 from langchain.output_parsers import PydanticOutputParser
 from langchain.prompts import PromptTemplate
 
@@ -20,29 +18,31 @@ def get_llm(llm_provider, **kwargs):
 
 
 async def create_chat_completion(
-        messages: list,  # type: ignore
-        model: Optional[str] = None,
-        temperature: Optional[float] = 0.4,
-        max_tokens: Optional[int] = 4000,
-        llm_provider: Optional[str] = None,
-        stream: Optional[bool] = False,
+        messages: list[dict[str, str]],
+        model: str | None = None,
+        temperature: float | None = 0.4,
+        max_tokens: int | None = 4000,
+        llm_provider: str | None = None,
+        stream: bool = False,
         websocket: Any | None = None,
-        llm_kwargs: Dict[str, Any] | None = None,
+        llm_kwargs: dict[str, Any] | None = None,
         cost_callback: callable = None,
-        reasoning_effort: Optional[str] = "low"
+        reasoning_effort: str | None = "low"
 ) -> str:
     """Create a chat completion using the OpenAI API
     Args:
-        messages (list[dict[str, str]]): The messages to send to the chat completion
+        messages (list[dict[str, str]]): The messages to send to the chat completion.
         model (str, optional): The model to use. Defaults to None.
         temperature (float, optional): The temperature to use. Defaults to 0.4.
         max_tokens (int, optional): The max tokens to use. Defaults to 4000.
-        stream (bool, optional): Whether to stream the response. Defaults to False.
         llm_provider (str, optional): The LLM Provider to use.
+        stream (bool): Whether to stream the response. Defaults to False.
         webocket (WebSocket): The websocket used in the currect request,
-        cost_callback: Callback function for updating cost
+        llm_kwargs (dict[str, Any], optional): Additional LLM keyword arguments. Defaults to None.
+        cost_callback: Callback function for updating cost.
+        reasoning_effort (str, optional): Reasoning effort for OpenAI's reasoning models. Defaults to 'low'.
     Returns:
-        str: The response from the chat completion
+        str: The response from the chat completion.
     """
     # validate input
     if model is None:


### PR DESCRIPTION
Introduces some non-functional improvements aimed mainly at modernizing the codebase and improving readability, only affecting the part I have come across so far:

- Type annotations: Updated type annotations to use the built-in `list` and `dict` types instead of `List` and `Dict` from the typing module, and replaced `Optional` with the union type (`| None`) since Python 3.11+ is required.

- Code Cleanup: Removed unused imports and mutable default arguments from function signatures.

- Documentation Improvements: Refined duck typing hints and updated docstrings.

- Formatting Fixes: Applied minor formatting improvements.