### PR TITLE
Added support for base_url param in create_chat_completions for OpenAI Provider

### DIFF
--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -6,6 +6,7 @@ import logging
 from typing import Optional, Any, Dict
 
 from colorama import Fore, Style
+import os
 from langchain.output_parsers import PydanticOutputParser
 from langchain.prompts import PromptTemplate
 
@@ -62,6 +63,11 @@ async def create_chat_completion(
     else:
         kwargs['temperature'] = temperature
         kwargs['max_tokens'] = max_tokens
+
+    if llm_provider == "openai":
+        base_url = os.enviorn.get("OPENAI_BASE_URL", None)
+        if base_url:
+            kwargs['openai_api_base'] = base_url
 
     provider = get_llm(llm_provider, **kwargs)
     response = ""


### PR DESCRIPTION
Resolved issue #1185 by checking for the base url in the environment variables and adding it to the arguments sent to llm provider.