### PR TITLE
fix: Add missing langgraph module to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ unstructured
 json_repair
 json5
 loguru
+langgraph
 
 # uncomment for testing
 # pytest


### PR DESCRIPTION
This PR adds the missing langgraph module to requirements.txt. The absence of this dependency caused issues when setting up the project in a new environment.

Changes:
Added langgraph to requirements.txt
This update ensures that all required dependencies are properly installed when running pip install -r requirements.txt.