### PR TITLE
Fix: image relevance filtering

### DIFF
--- a/gpt_researcher/actions/web_scraping.py
+++ b/gpt_researcher/actions/web_scraping.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Tuple
+from typing import Any
 from colorama import Fore, Style
 
 from gpt_researcher.utils.workers import WorkerPool
@@ -11,7 +11,7 @@ logger = get_formatted_logger()
 
 async def scrape_urls(
     urls, cfg: Config, worker_pool: WorkerPool
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Scrapes the urls
     Args:
@@ -19,7 +19,7 @@ async def scrape_urls(
         cfg: Config (optional)
 
     Returns:
-        Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]: Tuple containing scraped content and images
+        tuple[list[dict[str, Any]], list[dict[str, Any]]]: tuple containing scraped content and images
 
     """
     scraped_data = []
@@ -42,16 +42,16 @@ async def scrape_urls(
     return scraped_data, images
 
 
-async def filter_urls(urls: List[str], config: Config) -> List[str]:
+async def filter_urls(urls: list[str], config: Config) -> list[str]:
     """
     Filter URLs based on configuration settings.
 
     Args:
-        urls (List[str]): List of URLs to filter.
+        urls (list[str]): List of URLs to filter.
         config (Config): Configuration object.
 
     Returns:
-        List[str]: Filtered list of URLs.
+        list[str]: Filtered list of URLs.
     """
     filtered_urls = []
     for url in urls:
@@ -76,16 +76,16 @@ async def extract_main_content(html_content: str) -> str:
     # For now, we'll just return the raw HTML as a placeholder
     return html_content
 
-async def process_scraped_data(scraped_data: List[Dict[str, Any]], config: Config) -> List[Dict[str, Any]]:
+async def process_scraped_data(scraped_data: list[dict[str, Any]], config: Config) -> list[dict[str, Any]]:
     """
     Process the scraped data to extract and clean the main content.
 
     Args:
-        scraped_data (List[Dict[str, Any]]): List of dictionaries containing scraped data.
+        scraped_data (list[dict[str, Any]]): List of dictionaries containing scraped data.
         config (Config): Configuration object.
 
     Returns:
-        List[Dict[str, Any]]: Processed scraped data.
+        list[dict[str, Any]]: Processed scraped data.
     """
     processed_data = []
     for item in scraped_data:

--- a/gpt_researcher/actions/web_scraping.py
+++ b/gpt_researcher/actions/web_scraping.py
@@ -35,7 +35,7 @@ async def scrape_urls(
         scraped_data = await scraper.run()
         for item in scraped_data:
             if 'image_urls' in item:
-                images.extend([img for img in item['image_urls']])
+                images.extend(item['image_urls'])
     except Exception as e:
         print(f"{Fore.RED}Error in scrape_urls: {e}{Style.RESET_ALL}")
 

--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -41,12 +41,7 @@ def get_relevant_images(soup: BeautifulSoup, url: str) -> list:
         # Sort images by score (highest first)
         sorted_images = sorted(image_urls, key=lambda x: x['score'], reverse=True)
         
-        # Select all images with score 3 and 2, then add score 1 images up to a total of 10
-        high_score_images = [img for img in sorted_images if img['score'] in [3, 2]]
-        low_score_images = [img for img in sorted_images if img['score'] == 1]
-        
-        result = high_score_images + low_score_images[:max(0, 10 - len(high_score_images))]
-        return result[:10]  # Ensure we don't return more than 10 images in total
+        return sorted_images[:10]  # Ensure we don't return more than 10 images in total
     
     except Exception as e:
         logging.error(f"Error in get_relevant_images: {e}")

--- a/gpt_researcher/skills/browser.py
+++ b/gpt_researcher/skills/browser.py
@@ -1,6 +1,3 @@
-import asyncio
-from typing import List, Dict
-
 from gpt_researcher.utils.workers import WorkerPool
 
 from ..actions.utils import stream_output

--- a/gpt_researcher/skills/browser.py
+++ b/gpt_researcher/skills/browser.py
@@ -79,10 +79,8 @@ class BrowserManager:
         seen_hashes = set()
         current_research_images = self.researcher.get_research_images()
 
-        # First, select all score 2 and 3 images
-        high_score_images = [img for img in images if img['score'] >= 2]
-
-        for img in high_score_images + images:  # Process high-score images first, then all images
+        # Process images in descending order of their scores
+        for img in sorted(images, key=lambda im: im["score"], reverse=True):
             img_hash = get_image_hash(img['url'])
             if (
                 img_hash


### PR DESCRIPTION
I found a strange thing in the current image filtering logic, that seems to ignore images with the highest "relevance score" 4, and also performs unnecessary steps.

Maybe I'm missing something here, but I wouldn't expect this behavior so implemented a fix, as well as some type hinting clean up in the affected files.