### PR TITLE
fix: restrict Python version range in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.11"
+python = ">=3.11, <3.13"
 beautifulsoup4 = ">=4.12.2"
 colorama = ">=0.4.6"
 duckduckgo_search = ">=4.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.11, <3.13"
+python = ">=3.11, <4"
 beautifulsoup4 = ">=4.12.2"
 colorama = ">=0.4.6"
 duckduckgo_search = ">=4.1.1"
@@ -36,7 +36,7 @@ mistune = "^3.0.2"
 htmldocx = "^0.0.6"
 python-docx = "^1.1.0"
 lxml = { version = ">=4.9.2", extras = ["html_clean"] }
-unstructured = ">=0.13,<0.16"
+unstructured = ">=0.13"
 tiktoken = ">=0.7.0"
 json-repair = "^0.29.8"
 json5 = "^0.9.25"


### PR DESCRIPTION
This PR updates the Python version specification in pyproject.toml from ">=3.11" to ">=3.11, <3.13" to resolve dependency conflicts with the unstructured package. The unstructured package requires Python versions <3.13, but our previous version constraint allowed Python 3.13 and above, which caused conflicts during dependency resolution.

```
poetry install
Updating dependencies
Resolving dependencies... (1.3s)

The current project's supported Python range (>=3.11) is not compatible with some of the required packages Python requirement:
  - unstructured requires Python <3.13,>=3.9.0, so it will not be satisfied for Python >=3.13
  - unstructured requires Python <3.13,>=3.9.0, so it will not be satisfied for Python >=3.13
...
....
.....
Because no versions of unstructured match >0.13,<0.13.2 || >0.13.2,<0.13.3 || >0.13.3,<0.13.4 || >0.13.4,<0.13.5 || >0.13.5,<0.13.6 || >0.13.6,<0.13.7 || >0.13.7,<0.14.0 || >0.14.0,<0.14.2 || >0.14.2,<0.14.3 || >0.14.3,<0.14.4 || >0.14.4,<0.14.5 || >0.14.5,<0.14.6 || >0.14.6,<0.14.7 || >0.14.7,<0.14.8 || >0.14.8,<0.14.9 || >0.14.9,<0.14.10 || >0.14.10,<0.15.0 || >0.15.0,<0.15.1 || >0.15.1,<0.15.3 || >0.15.3,<0.15.5 || >0.15.5,<0.15.6 || >0.15.6,<0.15.7 || >0.15.7,<0.15.8 || >0.15.8,<0.15.9 || >0.15.9,<0.15.10 || >0.15.10,<0.15.12 || >0.15.12,<0.15.13 || >0.15.13,<0.15.14 || >0.15.14,<0.16
 and unstructured (0.13.0) requires Python <3.12,>=3.9.0, unstructured is forbidden.
And because unstructured (0.13.2) requires Python <3.12,>=3.9.0, unstructured is forbidden.
And because unstructured (0.13.3) requires Python <3.12,>=3.9.0
 and unstructured (0.13.4) requires Python <3.12,>=3.9.0, unstructured is forbidden.
```