### PR TITLE
Fix KeyError: 'deep' in cli.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -51,7 +51,8 @@ report_type_descriptions = {
     ReportType.ResourceReport.value: "",
     ReportType.OutlineReport.value: "",
     ReportType.CustomReport.value: "",
-    ReportType.SubtopicReport.value: ""
+    ReportType.SubtopicReport.value: "",
+    ReportType.DeepResearch.value: "Deep Research"
 }
 
 cli.add_argument(


### PR DESCRIPTION
Addresses KeyError: 'deep' resulting from python cli.py.

Adds option for Deep Research in cli.py using ' DeepResearch = "deep" ' from enum.py (line 11).

Executing python cli.py now works as anticipated, including for report_type "deep".