### PR TITLE
Add published date and author to Arxiv context; adjust PDF scraper return; adjust detail report prompt for consistent formating style

### DIFF
--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -393,7 +393,7 @@ IMPORTANT:Content and Sections Uniqueness:
 
     ### Section Header
     
-    This is a sample text. ([url website](url))
+    This is a sample text ([in-text citation](url)).
 
 - Use H2 for the main subtopic header (##) and H3 for subsections (###).
 - Use smaller Markdown headers (e.g., H2 or H3) for content structure, avoiding the largest header (H1) as it will be used for the larger report's heading.
@@ -411,7 +411,7 @@ Assume the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if
 - You MUST write the report in the following language: {language}.
 - The focus MUST be on the main topic! You MUST Leave out any information un-related to it!
 - Must NOT have any introduction, conclusion, summary or reference section.
-- You MUST include hyperlinks with markdown syntax ([url website](url)) related to the sentences wherever necessary.
+- You MUST use in-text citation references in {report_format.upper()} format and make it with markdown hyperlink placed at the end of the sentence or paragraph that references them like this: ([in-text citation](url)).
 - You MUST mention the difference between the existing content and the new content in the report if you are adding the similar or same subsections wherever necessary.
 - The report should have a minimum length of {total_words} words.
 - Use an {tone.value} tone throughout the report.
@@ -454,19 +454,19 @@ Provide the draft headers in a list format using markdown syntax, for example:
 """
 
 
-def generate_report_introduction(question: str, research_summary: str = "", language: str = "english") -> str:
+def generate_report_introduction(question: str, research_summary: str = "", language: str = "english", report_format: str = "apa") -> str:
     return f"""{research_summary}\n 
 Using the above latest information, Prepare a detailed report introduction on the topic -- {question}.
 - The introduction should be succinct, well-structured, informative with markdown syntax.
 - As this introduction will be part of a larger report, do NOT include any other sections, which are generally present in a report.
 - The introduction should be preceded by an H1 heading with a suitable topic for the entire report.
-- You must include hyperlinks with markdown syntax ([url website](url)) related to the sentences wherever necessary.
+- You must use in-text citation references in {report_format.upper()} format and make it with markdown hyperlink placed at the end of the sentence or paragraph that references them like this: ([in-text citation](url)).
 Assume that the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if required.
 - The output must be in {language} language.
 """
 
 
-def generate_report_conclusion(query: str, report_content: str, language: str = "english") -> str:
+def generate_report_conclusion(query: str, report_content: str, language: str = "english", report_format: str = "apa") -> str:
     """
     Generate a concise conclusion summarizing the main findings and implications of a research report.
 
@@ -492,7 +492,7 @@ def generate_report_conclusion(query: str, report_content: str, language: str = 
     4. Be approximately 2-3 paragraphs long
     
     If there is no "## Conclusion" section title written at the end of the report, please add it to the top of your conclusion. 
-    You must include hyperlinks with markdown syntax ([url website](url)) related to the sentences wherever necessary.
+    You must use in-text citation references in {report_format.upper()} format and make it with markdown hyperlink placed at the end of the sentence or paragraph that references them like this: ([in-text citation](url)).
 
     IMPORTANT: The entire conclusion MUST be written in {language} language.
 

--- a/gpt_researcher/scraper/arxiv/arxiv.py
+++ b/gpt_researcher/scraper/arxiv/arxiv.py
@@ -19,5 +19,10 @@ class ArxivScraper:
         query = self.link.split("/")[-1]
         retriever = ArxivRetriever(load_max_docs=2, doc_content_chars_max=None)
         docs = retriever.invoke(query)
-        # returns content, image_urls, title
-        return docs[0].page_content, [], docs[0].metadata["Title"]
+
+        # Include the published date and author to provide additional context, 
+        # aligning with APA-style formatting in the report.
+        context = f"Published: {docs[0].metadata['Published']}; Author: {docs[0].metadata['Authors']}; Content: {docs[0].page_content}"
+        image = []
+
+        return context, image, docs[0].metadata["Title"]

--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -57,7 +57,10 @@ class PyMuPDFScraper:
                 loader = PyMuPDFLoader(self.link)
                 doc = loader.load()
 
-            return str(doc)
+            # Extract the content, image (if any), and title from the document.
+            image = []
+            # Retrieve the content of the first page to minimize embedding costs.
+            return doc[0].page_content, image, doc[0].metadata["title"]
 
         except requests.exceptions.Timeout:
             print(f"Download timed out. Please check the link : {self.link}")


### PR DESCRIPTION
- Include the published date and author to align with APA-style formatting for the results from the Arxiv scraper.
- Returning the content, image (if any), and title from the PDF scraper to prevent ValueError, retrieving only the first page to minimize embedding costs.
- Adjust prompt, especially detail report prompt for report format to maintain consistency on the final report