### PR TITLE
Add missing imports

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -1,4 +1,6 @@
 import importlib
+import subprocess
+import sys
 from typing import Any
 from colorama import Fore, Style, init
 import os


### PR DESCRIPTION
The generic LLM provider tries to dynamically pip install packages that are not currently available, but the routine that does this does not have subprocess or sys imported, so the code throws at runtime.

Fixes issue: #1251 
