### PR TITLE
Added post and get http endpoints to server and updated npm package to allow sending http requests

### DIFF
--- a/backend/report_type/basic_report/basic_report.py
+++ b/backend/report_type/basic_report/basic_report.py
@@ -29,9 +29,8 @@ class BasicReport:
         self.websocket = websocket
         self.headers = headers or {}
 
-    async def run(self):
         # Initialize researcher
-        researcher = GPTResearcher(
+        self.gpt_researcher = GPTResearcher(
             query=self.query,
             query_domains=self.query_domains,
             report_type=self.report_type,
@@ -44,6 +43,7 @@ class BasicReport:
             headers=self.headers
         )
 
-        await researcher.conduct_research()
-        report = await researcher.write_report()
+    async def run(self):
+        await self.gpt_researcher.conduct_research()
+        report = await self.gpt_researcher.write_report()
         return report

--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -1,22 +1,26 @@
 import json
 import os
 from typing import Dict, List
+import time
 
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, File, UploadFile, Header
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, File, UploadFile, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from backend.server.websocket_manager import WebSocketManager
 from backend.server.server_utils import (
-    get_config_dict,
+    get_config_dict, sanitize_filename,
     update_environment_variables, handle_file_upload, handle_file_deletion,
     execute_multi_agents, handle_websocket_communication
 )
 
-
+from backend.server.websocket_manager import run_agent
+from backend.utils import write_md_to_word, write_md_to_pdf
 from gpt_researcher.utils.logging_config import setup_research_logging
+from gpt_researcher.utils.enum import Tone
 
 import logging
 
@@ -40,7 +44,12 @@ logging.basicConfig(
 class ResearchRequest(BaseModel):
     task: str
     report_type: str
-    agent: str
+    report_source: str
+    tone: str
+    headers: dict | None = None
+    repo_name: str
+    branch_name: str
+    generate_in_background: bool = True
 
 
 class ConfigRequest(BaseModel):
@@ -103,10 +112,69 @@ async def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request, "report": None})
 
 
+@app.get("/report/{research_id}")
+async def read_report(request: Request, research_id: str):
+    docx_path = os.path.join('outputs', f"{research_id}.docx")
+    if not os.path.exists(docx_path):
+        return {"message": "Report not found."}
+    return FileResponse(docx_path)
+
+
+async def write_report(research_request: ResearchRequest, research_id: str = None):
+    report_information = await run_agent(
+        task=research_request.task,
+        report_type=research_request.report_type,
+        report_source=research_request.report_source,
+        source_urls=[],
+        document_urls=[],
+        tone=Tone[research_request.tone],
+        websocket=None,
+        stream_output=None,
+        headers=research_request.headers,
+        query_domains=[],
+        config_path="",
+        return_researcher=True
+    )
+
+    docx_path = await write_md_to_word(report_information[0], research_id)
+    pdf_path = await write_md_to_pdf(report_information[0], research_id)
+    if research_request.report_type != "multi_agents":
+        report, researcher = report_information
+        response = {
+            "research_id": research_id,
+            "research_information": {
+                "source_urls": researcher.get_source_urls(),
+                "research_costs": researcher.get_costs(),
+                "visited_urls": list(researcher.visited_urls),
+                "research_images": researcher.get_research_images(),
+                # "research_sources": researcher.get_research_sources(),  # Raw content of sources may be very large
+            },
+            "report": report,
+            "docx_path": docx_path,
+            "pdf_path": pdf_path
+        }
+    else:
+        response = { "research_id": research_id, "report": report, "docx_path": docx_path, "pdf_path": pdf_path }
+
+    return response
+
+@app.post("/report/")
+async def generate_report(research_request: ResearchRequest, background_tasks: BackgroundTasks):
+    research_id = sanitize_filename(f"task_{int(time.time())}_{research_request.task}")
+
+    if research_request.generate_in_background:
+        background_tasks.add_task(write_report, research_request=research_request, research_id=research_id)
+        return {"message": "Your report is being generated in the background. Please check back later.",
+                "research_id": research_id}
+    else:
+        response = await write_report(research_request, research_id)
+        return response
+
+
 @app.get("/files/")
 async def list_files():
     if not os.path.exists(DOC_PATH):
-      os.makedirs(DOC_PATH, exist_ok=True)
+        os.makedirs(DOC_PATH, exist_ok=True)
     files = os.listdir(DOC_PATH)
     print(f"Files in {DOC_PATH}: {files}")
     return {"files": files}

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -91,11 +91,11 @@ class WebSocketManager:
         else:
             await websocket.send_json({"type": "chat", "content": "Knowledge empty, please run the research first to obtain knowledge"})
 
-async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, headers=None, query_domains=[], config_path=""):
+async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False):
     """Run the agent."""    
     # Create logs handler for this research task
     logs_handler = CustomLogsHandler(websocket, task)
-    
+
     # Initialize researcher based on report type
     if report_type == "multi_agents":
         report = await run_research_task(
@@ -106,7 +106,7 @@ async def run_agent(task, report_type, report_source, source_urls, document_urls
             headers=headers
         )
         report = report.get("report", "")
-        
+
     elif report_type == ReportType.DetailedReport.value:
         researcher = DetailedReport(
             query=task,
@@ -137,4 +137,7 @@ async def run_agent(task, report_type, report_source, source_urls, document_urls
         )
         report = await researcher.run()
 
-    return report
+    if report_type != "multi_agents" and return_researcher:
+        return report, researcher.gpt_researcher
+    else:
+        return report


### PR DESCRIPTION
Resolving issue https://github.com/assafelovic/gpt-researcher/issues/1232
The server now accepts post requests for generating reports. The execute_in_background flag can be used to wait for the report to finish generating and return the report, or just return the report_id to then fetch the report later using a get request.

The sendMessage function in npm package now accepts useHTTP and execute_in_background params to decide whether to use websockets or HTTP and whether to wait for the report to finish. The npm package also has a getReport function which accepts the report_id and retrieves the report.