### PR TITLE
Fix AttributeError in PublisherAgent when processing string values

### DIFF
--- a/multi_agents/agents/publisher.py
+++ b/multi_agents/agents/publisher.py
@@ -20,11 +20,19 @@ class PublisherAgent:
         return layout
 
     def generate_layout(self, research_state: dict):
-        sections = '\n\n'.join(f"{value}"
-                                 for subheader in research_state.get("research_data")
-                                 for key, value in subheader.items())
-        references = '\n'.join(f"{reference}" for reference in research_state.get("sources"))
-        headers = research_state.get("headers")
+        sections = []
+        for subheader in research_state.get("research_data", []):
+            if isinstance(subheader, dict):
+                # Handle dictionary case
+                for key, value in subheader.items():
+                    sections.append(f"{value}")
+            else:
+                # Handle string case
+                sections.append(f"{subheader}")
+        
+        sections_text = '\n\n'.join(sections)
+        references = '\n'.join(f"{reference}" for reference in research_state.get("sources", []))
+        headers = research_state.get("headers", {})
         layout = f"""# {headers.get('title')}
 #### {headers.get("date")}: {research_state.get('date')}
 
@@ -34,7 +42,7 @@ class PublisherAgent:
 ## {headers.get("table_of_contents")}
 {research_state.get('table_of_contents')}
 
-{sections}
+{sections_text}
 
 ## {headers.get("conclusion")}
 {research_state.get('conclusion')}


### PR DESCRIPTION

## Issue
When running the multi-agent system, an error occurs in the `PublisherAgent` class when trying to process research data that contains string values instead of dictionaries:

```
AttributeError: 'str' object has no attribute 'items'
```

This happens because the `generate_layout` method assumes all items in `research_data` are dictionaries with an `.items()` method, but sometimes they can be strings.

## Solution
Modified the `generate_layout` method in `PublisherAgent` to handle both dictionary and string values in the research data:

1. Added type checking with `isinstance(subheader, dict)` to handle different data types
2. Changed from a nested list comprehension to a more explicit loop structure
3. Added proper handling for string values in the research data
4. Added default empty values for collections to prevent errors when keys are missing

## Changes
- Updated `multi_agents/agents/publisher.py` to make the `generate_layout` method more robust
