### PR TITLE
New provider openrouter.ai added

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -299,6 +299,18 @@ FAST_LLM="deepseek:deepseek-chat"
 SMART_LLM="deepseek:deepseek-chat"
 STRATEGIC_LLM="deepseek:deepseek-chat"
 ```
+## Openrouter.ai
+
+```bash
+OPENROUTER_API_KEY=[Your openrouter.ai key]
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+FAST_LLM="openrouter:google/gemini-2.0-flash-lite-001"
+SMART_LLM="openrouter:google/gemini-2.0-flash-001"
+STRATEGIC_LLM="openrouter:google/gemini-2.5-pro-exp-03-25"
+OPENROUTER_LIMIT_RPS=1  # Ratelimit request per secound
+EMBEDDING=google_genai:models/text-embedding-004 # openrouter doesn't support embedding models, use google instead its free
+GOOGLE_API_KEY=[Your *google gemini* key]  
+```
 
 
 ## Other Embedding Models


### PR DESCRIPTION
This pull request introduces support for the Openrouter.ai LLM provider.

### Documentation Updates:
* [`docs/docs/gpt-researcher/llms/llms.md`](diffhunk://#diff-66e67992fcc7f98a640cf20b6db5746d0563c4ece5fd0ecacdb14c01b7a2bc51R302-R313): Added configuration instructions for using Openrouter.ai, including setting environment variables for API keys, base URL, and model identifiers.

### Codebase Enhancements:
* [`gpt_researcher/llm_provider/generic/base.py`](diffhunk://#diff-566085fd98745d6c73683585cd9225b6b86248ef2f95180cd326be652e765a26L27-R28): Added "openrouter" to the list of supported LLM providers.
* [`gpt_researcher/llm_provider/generic/base.py`](diffhunk://#diff-566085fd98745d6c73683585cd9225b6b86248ef2f95180cd326be652e765a26R164-R182): Implemented the `from_provider` method to support initializing the `ChatOpenAI` model from Openrouter.ai, including rate limiting configuration.