### PR TITLE
Fix broken link in llms.md

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -7,7 +7,7 @@ Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `goo
 
 Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `nomic` ,`voyageai` and `bedrock`.
 
-To learn more about support customization options see [here](/gpt-researcher/gptr/config).
+To learn more about support customization options see [here](/docs/gpt-researcher/gptr/config).
 
 **Please note**: GPT Researcher is optimized and heavily tested on GPT models. Some other models might run into context limit errors, and unexpected responses.
 Please provide any feedback in our [Discord community](https://discord.gg/DUmbTebB) channel, so we can better improve the experience and performance.


### PR DESCRIPTION
Replace `gpt-researcher/gptr/config` with `docs/gpt-researcher/gptr/config`