### PR TITLE
Docling integration

### DIFF
--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -93,6 +93,8 @@ app.add_middleware(
 
 # Constants
 DOC_PATH = os.getenv("DOC_PATH", "./my-docs")
+CONVERT_WITH_DOCLING = os.getenv("CONVERT_WITH_DOCLING", "").lower() == "true"
+DOCLING_VLM = os.getenv("DOCLING_VLM", "")
 
 # Startup event
 
@@ -102,7 +104,7 @@ def startup_event():
     os.makedirs("outputs", exist_ok=True)
     app.mount("/outputs", StaticFiles(directory="outputs"), name="outputs")
     # os.makedirs(DOC_PATH, exist_ok=True)  # Commented out to avoid creating the folder if not needed
-    
+
 
 # Routes
 
@@ -187,7 +189,7 @@ async def run_multi_agents():
 
 @app.post("/upload/")
 async def upload_file(file: UploadFile = File(...)):
-    return await handle_file_upload(file, DOC_PATH)
+    return await handle_file_upload(file, DOC_PATH, CONVERT_WITH_DOCLING, DOCLING_VLM)
 
 
 @app.delete("/files/{filename}")

--- a/docs/docs/gpt-researcher/gptr/config.md
+++ b/docs/docs/gpt-researcher/gptr/config.md
@@ -44,6 +44,8 @@ Below is a list of current supported options:
 - **`EMBEDDING_KWARGS`**: Json formatted dict of additional keyword args to be passed to the embedding provider class when instantiating it.
 - **`USER_AGENT`**: Custom User-Agent string for web crawling and web requests.
 - **`MEMORY_BACKEND`**: Backend used for memory operations, such as local storage of temporary data. Defaults to `local`.
+- **`CONVERT_WITH_DOCLING`**: Use [docling](https://docling-project.github.io/docling/) for document conversion (NOTE: This requires installing the `docling` extra e.g. `pip install gpt-researcher[docling]`).
+- **`DOCLING_VLM`**: If `CONVERT_WITH_DOCLING` is set, this will enable docling's pipeline for using a Visual Language Model (VLM) to parse images.
 
 To change the default configurations, you can simply add env variables to your `.env` file as named above or export manually in your local project directory.
 

--- a/docs/docs/gpt-researcher/gptr/pip-package.md
+++ b/docs/docs/gpt-researcher/gptr/pip-package.md
@@ -15,6 +15,12 @@ Follow these easy steps to get started:
 pip install gpt-researcher
 ```
 
+To install optional dependencies, use the following syntax:
+
+```bash
+pip install gpt-researcher[docling]
+```
+
 2. **Environment Variables:** Create a .env file with your OpenAI API key or simply export it
 
 ```bash

--- a/gpt_researcher/config/variables/base.py
+++ b/gpt_researcher/config/variables/base.py
@@ -28,10 +28,12 @@ class BaseConfig(TypedDict):
     MAX_SCRAPER_WORKERS: int
     MAX_SUBTOPICS: int
     REPORT_SOURCE: Union[str, None]
-    DOC_PATH: str
     PROMPT_FAMILY: str
     LLM_KWARGS: dict
     EMBEDDING_KWARGS: dict
     DEEP_RESEARCH_CONCURRENCY: int
     DEEP_RESEARCH_DEPTH: int
     DEEP_RESEARCH_BREADTH: int
+    DOC_PATH: str
+    CONVERT_WITH_DOCLING: bool
+    DOCLING_VLM: Union[str, None]

--- a/gpt_researcher/config/variables/default.py
+++ b/gpt_researcher/config/variables/default.py
@@ -26,7 +26,6 @@ DEFAULT_CONFIG: BaseConfig = {
     "MAX_SUBTOPICS": 3,
     "LANGUAGE": "english",
     "REPORT_SOURCE": "web",
-    "DOC_PATH": "./my-docs",
     "PROMPT_FAMILY": "default",
     "LLM_KWARGS": {},
     "EMBEDDING_KWARGS": {},
@@ -34,4 +33,8 @@ DEFAULT_CONFIG: BaseConfig = {
     "DEEP_RESEARCH_BREADTH": 3,
     "DEEP_RESEARCH_DEPTH": 2,
     "DEEP_RESEARCH_CONCURRENCY": 4,
+    # Doc conversion settings
+    "DOC_PATH": "./my-docs",
+    "CONVERT_WITH_DOCLING": False,
+    "DOCLING_VLM": None,
 }

--- a/gpt_researcher/document/document.py
+++ b/gpt_researcher/document/document.py
@@ -16,6 +16,7 @@ from langchain_core.documents import Document
 
 try:
     from docling.document_converter import DocumentConverter, PdfFormatOption
+    from docling.datamodel.base_models import InputFormat
     from docling.datamodel.pipeline_options import (
         VlmModelType,
         VlmPipelineOptions,
@@ -54,15 +55,19 @@ class DoclingLoader:
         elif vlm is not None:
             raise ValueError(f"Unknown docling vlm option: {vlm}")
 
-        pdf_format_option = None
+        format_options = None
         if vlm_options is not None:
-            pipeline_options = VlmPipelineOptions()
+            pipeline_options = VlmPipelineOptions(enable_remote_services=True)
             pipeline_options.vlm_options = vlm_options
             pdf_format_option = PdfFormatOption(
                 pipeline_cls=VlmPipeline, pipeline_options=pipeline_options
             )
+            format_options = {
+                InputFormat.PDF: pdf_format_option,
+                InputFormat.IMAGE: pdf_format_option,
+            }
 
-        self.converter = DocumentConverter(format_options=pdf_format_option)
+        self.converter = DocumentConverter(format_options=format_options)
 
     def load(self) -> list[Document]:
         assert HAVE_DOCLING

--- a/gpt_researcher/document/document.py
+++ b/gpt_researcher/document/document.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
-from typing import List, Union
+import sys
+from typing import List, Optional, Union
 from langchain_community.document_loaders import (
     PyMuPDFLoader,
     TextLoader,
@@ -11,12 +12,79 @@ from langchain_community.document_loaders import (
     UnstructuredWordDocumentLoader
 )
 from langchain_community.document_loaders import BSHTMLLoader
+from langchain_core.documents import Document
+
+try:
+    from docling.document_converter import DocumentConverter, PdfFormatOption
+    from docling.datamodel.pipeline_options import (
+        VlmModelType,
+        VlmPipelineOptions,
+        granite_vision_vlm_conversion_options,
+        granite_vision_vlm_ollama_conversion_options,
+        smoldocling_vlm_conversion_options,
+        smoldocling_vlm_mlx_conversion_options,
+    )
+    from docling.pipeline.vlm_pipeline import VlmPipeline
+    HAVE_DOCLING = True
+except ImportError:
+    HAVE_DOCLING = False
+
+
+class DoclingLoader:
+    """Loader for an individual document that matches langchain API"""
+
+    def __init__(self, file_path: str, vlm: Optional[str] = None):
+        if not HAVE_DOCLING:
+            raise ImportError("Please install docling to use this function.")
+        self.file_path = file_path
+        vlm_options = None
+        if vlm == VlmModelType.GRANITE_VISION:
+            vlm_options = granite_vision_vlm_conversion_options
+        elif vlm == VlmModelType.GRANITE_VISION_OLLAMA:
+            vlm_options = granite_vision_vlm_ollama_conversion_options
+        elif vlm == VlmModelType.SMOLDOCLING:
+            vlm_options = smoldocling_vlm_conversion_options
+            if sys.platform == "darwin":
+                try:
+                    import mlx_vlm
+
+                    vlm_options = smoldocling_vlm_mlx_conversion_options
+                except ImportError:
+                    print("mlx-vlm not installed, falling back to torch")
+        elif vlm is not None:
+            raise ValueError(f"Unknown docling vlm option: {vlm}")
+
+        pdf_format_option = None
+        if vlm_options is not None:
+            pipeline_options = VlmPipelineOptions()
+            pipeline_options.vlm_options = vlm_options
+            pdf_format_option = PdfFormatOption(
+                pipeline_cls=VlmPipeline, pipeline_options=pipeline_options
+            )
+
+        self.converter = DocumentConverter(format_options=pdf_format_option)
+
+    def load(self) -> list[Document]:
+        assert HAVE_DOCLING
+        res = self.converter.convert(self.file_path)
+        doc = Document(
+            page_content=res.document.export_to_markdown(),
+            metadata={"source": self.file_path}
+        )
+        return [doc]
 
 
 class DocumentLoader:
 
-    def __init__(self, path: Union[str, List[str]]):
+    def __init__(
+        self,
+        path: Union[str, List[str]],
+        use_docling: bool = False,
+        docling_vlm: Optional[str] = None,
+    ):
         self.path = path
+        self.use_docling = use_docling
+        self.docling_vlm = docling_vlm
 
     async def load(self) -> list:
         tasks = []
@@ -27,7 +95,7 @@ class DocumentLoader:
                     file_name, file_extension_with_dot = os.path.splitext(filename)
                     file_extension = file_extension_with_dot.strip(".").lower()
                     tasks.append(self._load_document(file_path, file_extension))
-                    
+
         elif isinstance(self.path, (str, bytes, os.PathLike)):
             for root, dirs, files in os.walk(self.path):
                 for file in files:
@@ -35,16 +103,9 @@ class DocumentLoader:
                     file_name, file_extension_with_dot = os.path.splitext(file)
                     file_extension = file_extension_with_dot.strip(".").lower()
                     tasks.append(self._load_document(file_path, file_extension))
-                    
+
         else:
             raise ValueError("Invalid type for path. Expected str, bytes, os.PathLike, or list thereof.")
-
-        # for root, dirs, files in os.walk(self.path):
-        #     for file in files:
-        #         file_path = os.path.join(root, file)
-        #         file_name, file_extension_with_dot = os.path.splitext(file_path)
-        #         file_extension = file_extension_with_dot.strip(".")
-        #         tasks.append(self._load_document(file_path, file_extension))
 
         docs = []
         for pages in await asyncio.gather(*tasks):
@@ -54,7 +115,7 @@ class DocumentLoader:
                         "raw_content": page.page_content,
                         "url": os.path.basename(page.metadata['source'])
                     })
-                    
+
         if not docs:
             raise ValueError("🤷 Failed to load any documents!")
 
@@ -63,19 +124,39 @@ class DocumentLoader:
     async def _load_document(self, file_path: str, file_extension: str) -> list:
         ret_data = []
         try:
-            loader_dict = {
-                "pdf": PyMuPDFLoader(file_path),
-                "txt": TextLoader(file_path),
-                "doc": UnstructuredWordDocumentLoader(file_path),
-                "docx": UnstructuredWordDocumentLoader(file_path),
-                "pptx": UnstructuredPowerPointLoader(file_path),
-                "csv": UnstructuredCSVLoader(file_path, mode="elements"),
-                "xls": UnstructuredExcelLoader(file_path, mode="elements"),
-                "xlsx": UnstructuredExcelLoader(file_path, mode="elements"),
-                "md": UnstructuredMarkdownLoader(file_path),
-                "html": BSHTMLLoader(file_path),
-                "htm": BSHTMLLoader(file_path)
-            }
+            if self.use_docling and HAVE_DOCLING:
+                docling_loader = DoclingLoader(file_path, self.docling_vlm)
+                loader_dict = {
+                    "pdf": docling_loader,
+                    "txt": TextLoader(file_path),
+                    "doc": docling_loader,
+                    "docx": docling_loader,
+                    "pptx": docling_loader,
+                    "csv": docling_loader,
+                    "xls": docling_loader,
+                    "xlsx": docling_loader,
+                    "md": UnstructuredMarkdownLoader(file_path),
+                    "html": BSHTMLLoader(file_path),
+                    "htm": BSHTMLLoader(file_path),
+                    "png": docling_loader,
+                    "jpg": docling_loader,
+                    "jpeg": docling_loader,
+                }
+
+            else:
+                loader_dict = {
+                    "pdf": PyMuPDFLoader(file_path),
+                    "txt": TextLoader(file_path),
+                    "doc": UnstructuredWordDocumentLoader(file_path),
+                    "docx": UnstructuredWordDocumentLoader(file_path),
+                    "pptx": UnstructuredPowerPointLoader(file_path),
+                    "csv": UnstructuredCSVLoader(file_path, mode="elements"),
+                    "xls": UnstructuredExcelLoader(file_path, mode="elements"),
+                    "xlsx": UnstructuredExcelLoader(file_path, mode="elements"),
+                    "md": UnstructuredMarkdownLoader(file_path),
+                    "html": BSHTMLLoader(file_path),
+                    "htm": BSHTMLLoader(file_path)
+                }
 
             loader = loader_dict.get(file_extension, None)
             if loader:

--- a/gpt_researcher/document/document.py
+++ b/gpt_researcher/document/document.py
@@ -52,7 +52,7 @@ class DoclingLoader:
                     vlm_options = smoldocling_vlm_mlx_conversion_options
                 except ImportError:
                     print("mlx-vlm not installed, falling back to torch")
-        elif vlm is not None:
+        elif vlm:
             raise ValueError(f"Unknown docling vlm option: {vlm}")
 
         format_options = None

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -21,7 +21,7 @@ class ResearchConductor:
         self.logger.info(f"Planning research for query: {query}")
         if query_domains:
             self.logger.info(f"Query domains: {query_domains}")
-        
+
         await stream_output(
             "logs",
             "planning_research",
@@ -55,9 +55,9 @@ class ResearchConductor:
         """Runs the GPT Researcher to conduct research"""
         if self.json_handler:
             self.json_handler.update_content("query", self.researcher.query)
-        
+
         self.logger.info(f"Starting research for query: {self.researcher.query}")
-        
+
         # Reset visited_urls and source_urls at the start of each research task
         self.researcher.visited_urls.clear()
         research_data = []
@@ -77,6 +77,10 @@ class ResearchConductor:
             )
 
         # Research for relevant sources based on source types below
+        doc_loader_kwargs = {
+            "use_docling": self.researcher.cfg.convert_with_docling,
+            "docling_vlm": self.researcher.cfg.docling_vlm,
+        }
         if self.researcher.source_urls:
             self.logger.info("Using provided source URLs")
             research_data = await self._get_context_by_urls(self.researcher.source_urls)
@@ -98,7 +102,7 @@ class ResearchConductor:
 
         elif self.researcher.report_source == ReportSource.Local.value:
             self.logger.info("Using local search")
-            document_data = await DocumentLoader(self.researcher.cfg.doc_path).load()
+            document_data = await DocumentLoader(self.researcher.cfg.doc_path, **doc_loader_kwargs).load()
             self.logger.info(f"Loaded {len(document_data)} documents")
             if self.researcher.vector_store:
                 self.researcher.vector_store.load(document_data)
@@ -110,7 +114,7 @@ class ResearchConductor:
             if self.researcher.document_urls:
                 document_data = await OnlineDocumentLoader(self.researcher.document_urls).load()
             else:
-                document_data = await DocumentLoader(self.researcher.cfg.doc_path).load()
+                document_data = await DocumentLoader(self.researcher.cfg.doc_path, **doc_loader_kwargs).load()
             if self.researcher.vector_store:
                 self.researcher.vector_store.load(document_data)
             docs_context = await self._get_context_by_web_search(self.researcher.query, document_data, self.researcher.query_domains)
@@ -124,9 +128,9 @@ class ResearchConductor:
                 connection_string=os.getenv("AZURE_CONNECTION_STRING")
             )
             azure_files = await azure_loader.load()
-            document_data = await DocumentLoader(azure_files).load()  # Reuse existing loader
+            document_data = await DocumentLoader(azure_files, **doc_loader_kwargs).load()  # Reuse existing loader
             research_data = await self._get_context_by_web_search(self.researcher.query, document_data)
-            
+
         elif self.researcher.report_source == ReportSource.LangChainDocuments.value:
             langchain_documents_data = await LangChainDocumentLoader(
                 self.researcher.documents
@@ -163,7 +167,7 @@ class ResearchConductor:
     async def _get_context_by_urls(self, urls):
         """Scrapes and compresses the context from the given urls"""
         self.logger.info(f"Getting context from URLs: {urls}")
-        
+
         new_search_urls = await self._get_new_urls(urls)
         self.logger.info(f"New URLs to process: {new_search_urls}")
 
@@ -221,7 +225,7 @@ class ResearchConductor:
             context: List of context
         """
         self.logger.info(f"Starting web search for query: {query}")
-        
+
         if scraped_data is None:
             scraped_data = []
         if query_domains is None:
@@ -230,7 +234,7 @@ class ResearchConductor:
         # Generate Sub-Queries including original query
         sub_queries = await self.plan_research(query, query_domains)
         self.logger.info(f"Generated sub-queries: {sub_queries}")
-        
+
         # If this is not part of a sub researcher, add original query to research for better results
         if self.researcher.report_type != "subtopic_report":
             sub_queries.append(query)
@@ -272,7 +276,7 @@ class ResearchConductor:
                 "query": sub_query,
                 "scraped_data_size": len(scraped_data)
             })
-        
+
         if self.researcher.verbose:
             await stream_output(
                 "logs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ firecrawl-py = "^1.12.0"
 pytest = "^8.3.5"
 pytest-asyncio = "^0.25.3"
 
+
+[tool.poetry.group.docling.dependencies]
+docling = "^2.30.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,14 @@ json5 = "^0.9.25"
 loguru = "^0.7.2"
 websockets = "^13.1"
 firecrawl-py = "^1.12.0"
+docling = { version = "^2.30.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
 pytest-asyncio = "^0.25.3"
 
-
-[tool.poetry.group.docling.dependencies]
-docling = "^2.30.0"
+[tool.poetry.extras]
+docling = ["docling"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Description

This PR extends the local document parsing capabilities to allow the user to choose [docling](https://github.com/docling-project/docling) and optionally also use a VLM like [smoldocling](https://huggingface.co/ds4sd/SmolDocling-256M-preview) or [granite3.2-vision](https://ollama.com/library/granite3.2-vision) for visual parsing. In addition to allowing users to choose `docling` for its output quality, this also allows users to input `png` and `jpeg` images as context.

## Testing

I've tested this in conjunction with my #1278 branch for a fully local LLM / VLM researcher. My two methods of testing are via a custom script and via the `nextjs` CLI.

### Custom Script

```py
import asyncio
import json
import os
import sys
from gpt_researcher import GPTResearcher

os.environ["FAST_LLM"] = "ollama:granite3.2:2b"
os.environ["SMART_LLM"] = "ollama:granite3.2:8b"
os.environ["STRATEGIC_LLM"] = "ollama:granite3.2:8b"
os.environ["EMBEDDING"] = "ollama:granite-embedding:278m"
os.environ["OPENAI_API_KEY"] = "ollama"
os.environ["OLLAMA_BASE_URL"] = "http://localhost:11434"
os.environ["RETRIEVER"] = "duckduckgo"
os.environ["PROMPT_FAMILY"] = "granite"
os.environ["LLM_KWARGS"] = json.dumps({"num_ctx": 1024 * 128})

os.environ["REPORT_SOURCE"] = "hybrid"
os.environ["DOC_PATH"] = "./report_docs"
os.environ["CONVERT_WITH_DOCLING"]  = "True"
os.environ["DOCLING_VLM"] = "granite_vision_ollama"

if not (query := " ".join(sys.argv[1:])):
    query = input("?> ")

researcher = GPTResearcher(
    query=query,
    report_type="research_report",
    report_source="hybrid",
)

loop = asyncio.get_event_loop()
loop.run_until_complete(researcher.conduct_research())
loop.run_until_complete(researcher.write_report())
```

### `nextjs` Frontend

I use the following env vars before running `python main.py` in the root of the repo

```sh
export FAST_LLM="ollama:granite3.2:2b"
export SMART_LLM="ollama:granite3.2:8b"
export STRATEGIC_LLM="ollama:granite3.2:8b"
export EMBEDDING="ollama:granite-embedding:278m"
export OPENAI_API_KEY="ollama"
export OLLAMA_BASE_URL="http://localhost:11434"
export RETRIEVER="duckduckgo"
export PROMPT_FAMILY="granite"
export LLM_KWARGS='{"num_ctx": 131072}'
export REPORT_SOURCE="hybrid"
export DOC_PATH="./report_docs"
export CONVERT_WITH_DOCLING="true"
export DOCLING_VLM="granite_vision_ollama"
```

From there, I've tested swapping to `hybrid` via the `Preferences` panel and then dropping in a `.png` screenshot to ensure it gets converted correctly.

## Dependencies

~~This PR depends on getting the next release of `docling` out with [ollama support for granite3.2-vision](https://github.com/docling-project/docling/pull/1337). I'm coordinating with @PeterStaar-IBM on that release, so it should go out soon!~~

Ollama support for Granite Vision 3.2 in Docling was added in [2.30.0](https://github.com/docling-project/docling/releases/tag/v2.30.0)