### PR TITLE
Add support for o4-mini model in temperature & reasoning-effort config

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -36,12 +36,14 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "o1-2024-12-17",
     "o3-mini",
     "o3-mini-2025-01-31",
+    "o4-mini",
     "o1-preview"
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [
     "o3-mini",
     "o3-mini-2025-01-31"
+    "o4-mini"
 ]
 
 class ReasoningEfforts(Enum):


### PR DESCRIPTION
### Summary
Added `"o4-mini"` to `NO_SUPPORT_TEMPERATURE_MODELS` and `SUPPORT_REASONING_EFFORT_MODELS`.

### Why?
Without this change, the temperature is incorrectly set for the `o4-mini` model, leading to unexpected LLM behavior.