### PR TITLE
fix python3.11 f-string cannot have backslash

### DIFF
--- a/backend/report_type/deep_research/example.py
+++ b/backend/report_type/deep_research/example.py
@@ -281,10 +281,11 @@ class DeepResearch:
         answers = ["Automatically proceeding with research"] * len(follow_up_questions)
 
         # Combine query and Q&A
+        follow_up_qa = ' '.join([f'Q: {q}\nA: {a}' for q, a in zip(follow_up_questions, answers)])
         combined_query = f"""
         Initial Query: {self.query}
         Follow-up Questions and Answers:
-        {' '.join([f'Q: {q}\nA: {a}' for q, a in zip(follow_up_questions, answers)])}
+        {follow_up_qa}
         """
 
         # Run deep research


### PR DESCRIPTION
In Python 3.11 and earlier, f-strings are not allowed to contain backslashes.

so in backend/report_type/deep_research/example.py, it raise error when python  = 3.11  

```python
        # Combine query and Q&A
        combined_query = f"""
        Initial Query: {self.query}
        Follow-up Questions and Answers:
        {' '.join([f'Q: {q}\nA: {a}' for q, a in zip(follow_up_questions, answers)])}   #here
        """

```