### PR TITLE
Respect my verbosity! 

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -59,6 +59,7 @@ class GPTResearcher:
         self.query = query
         self.report_type = report_type
         self.cfg = Config(config_path)
+        self.cfg.set_verbose(verbose)
         self.llm = GenericLLMProvider(self.cfg)
         self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', None)
         self.report_format = report_format

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -229,3 +229,8 @@ class Config:
             return json.loads(env_value)
         else:
             raise ValueError(f"Unsupported type {type_hint} for key {key}")
+
+
+    def set_verbose(self, verbose: bool) -> None:
+        """Set the verbosity level."""
+        self.llm_kwargs["verbose"] = verbose

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -76,12 +76,12 @@ class ChatLogger:
 
 class GenericLLMProvider:
 
-    def __init__(self, llm, chat_log: str | None = None):
+    def __init__(self, llm, chat_log: str | None = None,  verbose: bool = True):
         self.llm = llm
         self.chat_logger = ChatLogger(chat_log) if chat_log else None
-
+        self.verbose = verbose
     @classmethod
-    def from_provider(cls, provider: str, chat_log: str | None = None, **kwargs: Any):
+    def from_provider(cls, provider: str, chat_log: str | None = None, verbose: bool=True, **kwargs: Any):
         if provider == "openai":
             _check_pkg("langchain_openai")
             from langchain_openai import ChatOpenAI
@@ -211,7 +211,7 @@ class GenericLLMProvider:
             raise ValueError(
                 f"Unsupported {provider}.\n\nSupported model providers are: {supported}"
             )
-        return cls(llm, chat_log)
+        return cls(llm, chat_log, verbose=verbose)
 
 
     async def get_chat_response(self, messages, stream, websocket=None):
@@ -251,7 +251,7 @@ class GenericLLMProvider:
     async def _send_output(self, content, websocket=None):
         if websocket is not None:
             await websocket.send_json({"type": "report", "output": content})
-        else:
+        elif self.verbose:
             print(f"{Fore.GREEN}{content}{Style.RESET_ALL}")
 
 


### PR DESCRIPTION
This fixes [the issue](https://github.com/assafelovic/gpt-researcher/issues/1360) I raised earlier. After going through the codebase, it seemed neater to pop the verbose property on `Config` and populate it. This does create a potential bug where somebody could set `LLM_KWARGS.verbose` in their config file and then it could be overridden by the parameter passed to an instance of the GPT researcher object, but I feel like this gives more granular control than always deferring to the config file.