### PR TITLE
Expose **kwargs throughout core modules to unlock LangChain integrations

### DIFF
--- a/gpt_researcher/actions/agent_creator.py
+++ b/gpt_researcher/actions/agent_creator.py
@@ -11,6 +11,7 @@ async def choose_agent(
     cost_callback: callable = None,
     headers=None,
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ):
     """
     Chooses the agent automatically
@@ -40,6 +41,7 @@ async def choose_agent(
             llm_provider=cfg.smart_llm_provider,
             llm_kwargs=cfg.llm_kwargs,
             cost_callback=cost_callback,
+            **kwargs
         )
 
         agent_dict = json.loads(response)

--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -31,6 +31,7 @@ async def generate_sub_queries(
     cfg: Config,
     cost_callback: callable = None,
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ) -> List[str]:
     """
     Generate sub-queries using the specified LLM model.
@@ -65,6 +66,7 @@ async def generate_sub_queries(
             llm_kwargs=cfg.llm_kwargs,
             reasoning_effort=ReasoningEfforts.Medium.value,
             cost_callback=cost_callback,
+            **kwargs
         )
     except Exception as e:
         logger.warning(f"Error with strategic LLM: {e}. Retrying with max_tokens={cfg.strategic_token_limit}.")
@@ -77,6 +79,7 @@ async def generate_sub_queries(
                 llm_provider=cfg.strategic_llm_provider,
                 llm_kwargs=cfg.llm_kwargs,
                 cost_callback=cost_callback,
+                **kwargs
             )
             logger.warning(f"Retrying with max_tokens={cfg.strategic_token_limit} successful.")
         except Exception as e:
@@ -90,6 +93,7 @@ async def generate_sub_queries(
                 llm_provider=cfg.smart_llm_provider,
                 llm_kwargs=cfg.llm_kwargs,
                 cost_callback=cost_callback,
+                **kwargs
             )
 
     return json_repair.loads(response)
@@ -102,6 +106,7 @@ async def plan_research_outline(
     parent_query: str,
     report_type: str,
     cost_callback: callable = None,
+    **kwargs
 ) -> List[str]:
     """
     Plan the research outline by generating sub-queries.
@@ -125,7 +130,8 @@ async def plan_research_outline(
         report_type,
         search_results,
         cfg,
-        cost_callback
+        cost_callback,
+        **kwargs
     )
 
     return sub_queries

--- a/gpt_researcher/actions/report_generation.py
+++ b/gpt_researcher/actions/report_generation.py
@@ -17,6 +17,7 @@ async def write_report_introduction(
     websocket=None,
     cost_callback: callable = None,
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ) -> str:
     """
     Generate an introduction for the report.
@@ -51,6 +52,7 @@ async def write_report_introduction(
             max_tokens=config.smart_token_limit,
             llm_kwargs=config.llm_kwargs,
             cost_callback=cost_callback,
+            **kwargs
         )
         return introduction
     except Exception as e:
@@ -66,6 +68,7 @@ async def write_conclusion(
     websocket=None,
     cost_callback: callable = None,
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ) -> str:
     """
     Write a conclusion for the report.
@@ -101,6 +104,7 @@ async def write_conclusion(
             max_tokens=config.smart_token_limit,
             llm_kwargs=config.llm_kwargs,
             cost_callback=cost_callback,
+            **kwargs
         )
         return conclusion
     except Exception as e:
@@ -114,7 +118,8 @@ async def summarize_url(
     role: str,
     config: Config,
     websocket=None,
-    cost_callback: callable = None
+    cost_callback: callable = None,
+    **kwargs
 ) -> str:
     """
     Summarize the content of a URL.
@@ -144,6 +149,7 @@ async def summarize_url(
             max_tokens=config.smart_token_limit,
             llm_kwargs=config.llm_kwargs,
             cost_callback=cost_callback,
+            **kwargs
         )
         return summary
     except Exception as e:
@@ -160,6 +166,7 @@ async def generate_draft_section_titles(
     websocket=None,
     cost_callback: callable = None,
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ) -> List[str]:
     """
     Generate draft section titles for the report.
@@ -191,6 +198,7 @@ async def generate_draft_section_titles(
             max_tokens=config.smart_token_limit,
             llm_kwargs=config.llm_kwargs,
             cost_callback=cost_callback,
+            **kwargs
         )
         return section_titles.split("\n")
     except Exception as e:
@@ -214,6 +222,7 @@ async def generate_report(
     custom_prompt: str = "", # This can be any prompt the user chooses with the context
     headers=None,
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ):
     """
     generates the final report
@@ -258,6 +267,7 @@ async def generate_report(
             max_tokens=cfg.smart_token_limit,
             llm_kwargs=cfg.llm_kwargs,
             cost_callback=cost_callback,
+            **kwargs
         )
     except:
         try:
@@ -273,6 +283,7 @@ async def generate_report(
                 max_tokens=cfg.smart_token_limit,
                 llm_kwargs=cfg.llm_kwargs,
                 cost_callback=cost_callback,
+                **kwargs
             )
         except Exception as e:
             print(f"Error in generate_report: {e}")

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -55,7 +55,9 @@ class GPTResearcher:
         max_subtopics: int = 5,
         log_handler=None,
         prompt_family: str | None = None,
+        **kwargs
     ):
+        self.kwargs = kwargs
         self.query = query
         self.report_type = report_type
         self.cfg = Config(config_path)
@@ -142,6 +144,7 @@ class GPTResearcher:
                 cost_callback=self.add_costs,
                 headers=self.headers,
                 prompt_family=self.prompt_family,
+                **self.kwargs
             )
             await self._log_event("action", action="agent_selected", details={
                 "agent": self.agent,

--- a/gpt_researcher/context/compression.py
+++ b/gpt_researcher/context/compression.py
@@ -73,7 +73,7 @@ class ContextCompressor:
         compressed_docs = self.__get_contextual_retriever()
         if cost_callback:
             cost_callback(estimate_embedding_cost(model=OPENAI_EMBEDDING_MODEL, docs=self.documents))
-        relevant_docs = await asyncio.to_thread(compressed_docs.invoke, query)
+        relevant_docs = await asyncio.to_thread(compressed_docs.invoke, query, **self.kwargs)
         return self.prompt_family.pretty_print_docs(relevant_docs, max_results)
 
 
@@ -106,5 +106,5 @@ class WrittenContentCompressor:
         compressed_docs = self.__get_contextual_retriever()
         if cost_callback:
             cost_callback(estimate_embedding_cost(model=OPENAI_EMBEDDING_MODEL, docs=self.documents))
-        relevant_docs = await asyncio.to_thread(compressed_docs.invoke, query)
+        relevant_docs = await asyncio.to_thread(compressed_docs.invoke, query, **self.kwargs)
         return self.__pretty_docs_list(relevant_docs, max_results)

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -214,27 +214,27 @@ class GenericLLMProvider:
         return cls(llm, chat_log, verbose=verbose)
 
 
-    async def get_chat_response(self, messages, stream, websocket=None):
+    async def get_chat_response(self, messages, stream, websocket=None, **kwargs):
         if not stream:
             # Getting output from the model chain using ainvoke for asynchronous invoking
-            output = await self.llm.ainvoke(messages)
+            output = await self.llm.ainvoke(messages, **kwargs)
 
             res = output.content
 
         else:
-            res = await self.stream_response(messages, websocket)
+            res = await self.stream_response(messages, websocket, **kwargs)
 
         if self.chat_logger:
             await self.chat_logger.log_request(messages, res)
 
         return res
 
-    async def stream_response(self, messages, websocket=None):
+    async def stream_response(self, messages, websocket=None, **kwargs):
         paragraph = ""
         response = ""
 
         # Streaming the response using the chain astream method from langchain
-        async for chunk in self.llm.astream(messages):
+        async for chunk in self.llm.astream(messages, **kwargs):
             content = chunk.content
             if content is not None:
                 response += content

--- a/gpt_researcher/skills/context_manager.py
+++ b/gpt_researcher/skills/context_manager.py
@@ -24,6 +24,7 @@ class ContextManager:
             documents=pages,
             embeddings=self.researcher.memory.get_embeddings(),
             prompt_family=self.researcher.prompt_family,
+            **self.researcher.kwargs
         )
         return await context_compressor.async_get_context(
             query=query, max_results=10, cost_callback=self.researcher.add_costs
@@ -39,6 +40,7 @@ class ContextManager:
                 )
         vectorstore_compressor = VectorstoreCompressor(
             self.researcher.vector_store, filter, prompt_family=self.researcher.prompt_family,
+            **self.researcher.kwargs
         )
         return await vectorstore_compressor.async_get_context(query=query, max_results=8)
 
@@ -52,7 +54,7 @@ class ContextManager:
         all_queries = [current_subtopic] + draft_section_titles
 
         async def process_query(query: str) -> Set[str]:
-            return set(await self.__get_similar_written_contents_by_query(query, written_contents))
+            return set(await self.__get_similar_written_contents_by_query(query, written_contents, **self.researcher.kwargs))
 
         results = await asyncio.gather(*[process_query(query) for query in all_queries])
         relevant_contents = set().union(*results)
@@ -77,7 +79,8 @@ class ContextManager:
         written_content_compressor = WrittenContentCompressor(
             documents=written_contents,
             embeddings=self.researcher.memory.get_embeddings(),
-            similarity_threshold=similarity_threshold
+            similarity_threshold=similarity_threshold,
+            **self.researcher.kwargs
         )
         return await written_content_compressor.async_get_context(
             query=query, max_results=max_results, cost_callback=self.researcher.add_costs

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -47,6 +47,7 @@ class ResearchConductor:
             parent_query=self.researcher.parent_query,
             report_type=self.researcher.report_type,
             cost_callback=self.researcher.add_costs,
+            **self.researcher.kwargs
         )
         self.logger.info(f"Research outline planned: {outline}")
         return outline

--- a/gpt_researcher/skills/writer.py
+++ b/gpt_researcher/skills/writer.py
@@ -75,7 +75,7 @@ class ReportGenerator:
         else:
             report_params["cost_callback"] = self.researcher.add_costs
 
-        report = await generate_report(**report_params)
+        report = await generate_report(**report_params, **self.researcher.kwargs)
 
         if self.researcher.verbose:
             await stream_output(
@@ -113,6 +113,7 @@ class ReportGenerator:
             cost_callback=self.researcher.add_costs,
             websocket=self.researcher.websocket,
             prompt_family=self.researcher.prompt_family,
+            **self.researcher.kwargs
         )
 
         if self.researcher.verbose:
@@ -143,6 +144,7 @@ class ReportGenerator:
             websocket=self.researcher.websocket,
             cost_callback=self.researcher.add_costs,
             prompt_family=self.researcher.prompt_family,
+            **self.researcher.kwargs
         )
 
         if self.researcher.verbose:
@@ -171,6 +173,7 @@ class ReportGenerator:
             config=self.researcher.cfg,
             subtopics=self.researcher.subtopics,
             prompt_family=self.researcher.prompt_family,
+            **self.researcher.kwargs
         )
 
         if self.researcher.verbose:
@@ -202,6 +205,7 @@ class ReportGenerator:
             config=self.researcher.cfg,
             cost_callback=self.researcher.add_costs,
             prompt_family=self.researcher.prompt_family,
+            **self.researcher.kwargs
         )
 
         if self.researcher.verbose:

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -79,10 +79,6 @@ async def create_chat_completion(
 
     provider = get_llm(llm_provider, **provider_kwargs)
     response = ""
-
-    # Merge kwargs with provider_kwargs
-    kwargs = {**kwargs, **provider_kwargs}
-
     # create response
     for _ in range(10):  # maximum of 10 attempts
         response = await provider.get_chat_response(
@@ -147,8 +143,6 @@ async def construct_subtopics(
         model = provider.llm
 
         chain = prompt | model | parser
-
-        kwargs = {**kwargs, **provider_kwargs}
 
         output = chain.invoke({
             "task": task,

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -30,7 +30,8 @@ async def create_chat_completion(
         websocket: Any | None = None,
         llm_kwargs: dict[str, Any] | None = None,
         cost_callback: callable = None,
-        reasoning_effort: str | None = ReasoningEfforts.Medium.value
+        reasoning_effort: str | None = ReasoningEfforts.Medium.value,
+        **kwargs
 ) -> str:
     """Create a chat completion using the OpenAI API
     Args:
@@ -44,6 +45,7 @@ async def create_chat_completion(
         llm_kwargs (dict[str, Any], optional): Additional LLM keyword arguments. Defaults to None.
         cost_callback: Callback function for updating cost.
         reasoning_effort (str, optional): Reasoning effort for OpenAI's reasoning models. Defaults to 'low'.
+        **kwargs: Additional keyword arguments.
     Returns:
         str: The response from the chat completion.
     """
@@ -55,32 +57,36 @@ async def create_chat_completion(
             f"Max tokens cannot be more than 16,000, but got {max_tokens}")
 
     # Get the provider from supported providers
-    kwargs = {
-        'model': model,
-        **(llm_kwargs or {})
-    }
+    provider_kwargs = {'model': model}
+    
+    if llm_kwargs:
+        provider_kwargs.update(llm_kwargs)
 
     if model in SUPPORT_REASONING_EFFORT_MODELS:
-        kwargs['reasoning_effort'] = reasoning_effort
+        provider_kwargs['reasoning_effort'] = reasoning_effort
 
     if model not in NO_SUPPORT_TEMPERATURE_MODELS:
-        kwargs['temperature'] = temperature
-        kwargs['max_tokens'] = max_tokens
+        provider_kwargs['temperature'] = temperature
+        provider_kwargs['max_tokens'] = max_tokens
     else:
-        kwargs['temperature'] = None
-        kwargs['max_tokens'] = None
+        provider_kwargs['temperature'] = None
+        provider_kwargs['max_tokens'] = None
 
     if llm_provider == "openai":
         base_url = os.environ.get("OPENAI_BASE_URL", None)
         if base_url:
-            kwargs['openai_api_base'] = base_url
+            provider_kwargs['openai_api_base'] = base_url
 
-    provider = get_llm(llm_provider, **kwargs)
+    provider = get_llm(llm_provider, **provider_kwargs)
     response = ""
+
+    # Merge kwargs with provider_kwargs
+    kwargs = {**kwargs, **provider_kwargs}
+
     # create response
     for _ in range(10):  # maximum of 10 attempts
         response = await provider.get_chat_response(
-            messages, stream, websocket
+            messages, stream, websocket, **kwargs
         )
 
         if cost_callback:
@@ -99,6 +105,7 @@ async def construct_subtopics(
     config,
     subtopics: list = [],
     prompt_family: type[PromptFamily] | PromptFamily = PromptFamily,
+    **kwargs
 ) -> list:
     """
     Construct subtopics based on the given task and data.
@@ -109,6 +116,7 @@ async def construct_subtopics(
         config: Configuration settings.
         subtopics (list, optional): Existing subtopics. Defaults to [].
         prompt_family (PromptFamily): Family of prompts
+        **kwargs: Additional keyword arguments.
 
     Returns:
         list: A list of constructed subtopics.
@@ -123,29 +131,31 @@ async def construct_subtopics(
                 "format_instructions": parser.get_format_instructions()},
         )
 
-        kwargs = {
-            'model': config.smart_llm_model,
-            **(config.llm_kwargs or {})
-        }
+        provider_kwargs = {'model': config.smart_llm_model}
+
+        if config.llm_kwargs:
+            provider_kwargs.update(config.llm_kwargs)
 
         if config.smart_llm_model in SUPPORT_REASONING_EFFORT_MODELS:
-            kwargs['reasoning_effort'] = ReasoningEfforts.High.value
+            provider_kwargs['reasoning_effort'] = ReasoningEfforts.High.value
         else:
-            kwargs['temperature'] = config.temperature
-            kwargs['max_tokens'] = config.smart_token_limit
+            provider_kwargs['temperature'] = config.temperature
+            provider_kwargs['max_tokens'] = config.smart_token_limit
 
-        provider = get_llm(config.smart_llm_provider, **kwargs)
+        provider = get_llm(config.smart_llm_provider, **provider_kwargs)
 
         model = provider.llm
 
         chain = prompt | model | parser
+
+        kwargs = {**kwargs, **provider_kwargs}
 
         output = chain.invoke({
             "task": task,
             "data": data,
             "subtopics": subtopics,
             "max_subtopics": config.max_subtopics
-        })
+        }, **kwargs)
 
         return output
 


### PR DESCRIPTION
This PR exposes `**kwargs` throughout the codebase, allowing seamless integration with LangChain’s extended ecosystem including support for callback handlers such as **Langfuse**, tracing tools, and custom monitoring utilities.

With this change, you can now pass in LangChain-native arguments directly through the config, enabling much richer observability and control over the research process.

**Related Issues:**  
- Closes #1129 
- Closes #1298 


## Why This Matters

- **Unlocks integrations**: Easily connect tools like Langfuse using their official `CallbackHandler`
- **Future-proof**: Supports upcoming LangChain features without further changes
- **Better tracing & debugging**: Full visibility into model steps and decisions


## Example Usage

```python
from dotenv import load_dotenv
from langfuse.callback import CallbackHandler
from gpt_researcher.agent import GPTResearcher

load_dotenv()

langfuse_handler = CallbackHandler()


config = {
    "callbacks": [langfuse_handler],
    "run_name": "researcher",
    "metadata": {
        "langfuse_session_id": "123",
        "langfuse_user_id": "456",
    },
}

researcher = GPTResearcher(
    query="Intel's chances of a comeback in the AI market",
    report_type="research_report",
    config=config
)

await researcher.conduct_research()  # Conduct the research
report = await researcher.write_report()  # Write the research report
```

Once connected, you’ll see full trace logs in your [Langfuse dashboard](https://langfuse.com), including token usage, steps, and intermediate results.


### Screenshot

**Langfuse**

![image](https://github.com/user-attachments/assets/a3b07a40-1b11-4e4e-852d-43ed75cb31b2)

**Opik**

<img width="1475" alt="Screenshot 2025-05-02 at 2 21 17 AM" src="https://github.com/user-attachments/assets/e927c713-18a9-40a4-93ef-a64dbdfc9ee5" />


## Validation Screenshot

To see if callbacks were working properly I tracked the output using langfuse callbacks(left) and the native langsmith (right) integration. Was seeing same things on both suggesting the tracing worked

![comparison](https://github.com/user-attachments/assets/0914d437-3447-4ad1-8cda-a48128fb7ed8)

