### PR TITLE
bugfix. third argument of ResearchAgent has to be tone

### DIFF
--- a/multi_agents/agents/editor.py
+++ b/multi_agents/agents/editor.py
@@ -13,9 +13,10 @@ from . import ResearchAgent, ReviewerAgent, ReviserAgent
 class EditorAgent:
     """Agent responsible for editing and managing code."""
 
-    def __init__(self, websocket=None, stream_output=None, headers=None):
+    def __init__(self, websocket=None, stream_output=None, tone=None, headers=None):
         self.websocket = websocket
         self.stream_output = stream_output
+        self.tone = tone
         self.headers = headers or {}
 
     async def plan_research(self, research_state: Dict[str, any]) -> Dict[str, any]:
@@ -117,7 +118,7 @@ class EditorAgent:
     def _initialize_agents(self) -> Dict[str, any]:
         """Initialize the research, reviewer, and reviser skills."""
         return {
-            "research": ResearchAgent(self.websocket, self.stream_output, self.headers),
+            "research": ResearchAgent(self.websocket, self.stream_output, self.tone, self.headers),
             "reviewer": ReviewerAgent(self.websocket, self.stream_output, self.headers),
             "reviser": ReviserAgent(self.websocket, self.stream_output, self.headers),
         }

--- a/multi_agents/agents/orchestrator.py
+++ b/multi_agents/agents/orchestrator.py
@@ -43,7 +43,7 @@ class ChiefEditorAgent:
     def _initialize_agents(self):
         return {
             "writer": WriterAgent(self.websocket, self.stream_output, self.headers),
-            "editor": EditorAgent(self.websocket, self.stream_output, self.headers),
+            "editor": EditorAgent(self.websocket, self.stream_output, self.tone, self.headers),
             "research": ResearchAgent(self.websocket, self.stream_output, self.tone, self.headers),
             "publisher": PublisherAgent(self.output_dir, self.websocket, self.stream_output, self.headers),
             "human": HumanAgent(self.websocket, self.stream_output, self.headers)


### PR DESCRIPTION
The third argument of [ResearchAgent](https://github.com/assafelovic/gpt-researcher/blob/f84e6130b2af47b01fec3cee9ec2dcdb00169a0e/multi_agents/agents/researcher.py#L7) has to be `tone`, but the instantiation of it within EditorAgent [does not include that](https://github.com/assafelovic/gpt-researcher/blob/f84e6130b2af47b01fec3cee9ec2dcdb00169a0e/multi_agents/agents/editor.py#L120). So, I add an instance variable of tone to EditorAgent and the tone variable as the third argument of ResearchAgent for initialization.