### PR TITLE
Fix return statements in PyMuPDFScraper

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -31,7 +31,7 @@ class PyMuPDFScraper:
         except Exception:
             return False
 
-    def scrape(self) -> str:
+    def scrape(self) -> tuple[str, list[str], str]:
         """
         The `scrape` function uses PyMuPDFLoader to load a document from the provided link (either URL or local file)
         and returns the document as a string.
@@ -64,5 +64,7 @@ class PyMuPDFScraper:
 
         except requests.exceptions.Timeout:
             print(f"Download timed out. Please check the link : {self.link}")
+            return "", [], ""
         except Exception as e:
             print(f"Error loading PDF : {self.link} {e}")
+            return "", [], ""


### PR DESCRIPTION
Hi, just a quick fix for two bugs in `PyMuPDFScraper`:

1. In case of problems, there were no `return` statements in the except blocks, that caused the function to implicitly return `None`, and that errors out [in here](https://github.com/assafelovic/gpt-researcher/blob/master/gpt_researcher/scraper/scraper.py#L103C1-L113C22), because `None` can not be unpacked to three variables. I added returning of empty strings/lists, as is done in other scraper classes as well.

2. It was typed to return `str`, but actually it returns `tuple[str, list[str], str]`