### PR TITLE
Fix #1418: OSError: [Errno 36] File name too long with long Chinese prompt

### DIFF
--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -110,12 +110,20 @@ def sanitize_filename(filename: str) -> str:
     # 255 - len(os.getcwd()) - len("\\gpt-researcher\\outputs\\") - len("task_") - len(timestamp) - len("_.json") - safety_margin
     max_task_length = 255 - len(os.getcwd()) - 24 - 5 - 10 - 6 - 5  # ~189 chars for task
     
-    # Truncate task if needed
-    truncated_task = task[:max_task_length] if len(task) > max_task_length else task
-    
+    # Truncate task if needed (by bytes)
+    truncated_task = ""
+    byte_count = 0
+    for char in task:
+        char_bytes = len(char.encode('utf-8'))
+        if byte_count + char_bytes <= max_task_length:
+            truncated_task += char
+            byte_count += char_bytes
+        else:
+            break
+
     # Reassemble and clean the filename
     sanitized = f"{prefix}_{timestamp}_{truncated_task}"
-    return re.sub(r"[^\w\s-]", "", sanitized).strip()
+    return re.sub(r"[^\w-]", "", sanitized).strip()
 
 
 async def handle_start_command(websocket, data: str, manager):


### PR DESCRIPTION
Description:

Fixes #1418

This issue arises because the file name length is calculated in bytes, while the sanitize_filename function calculates it by character count.
For English, where each character typically corresponds to a single byte, this wasn't an issue. However, Chinese characters are multi-byte, leading to incorrect length calculations.
This patch is a refinement of the solution provided by Claude-3.7-Sonnet. Additionally, I've removed newline, carriage return, and whitespace characters from the filename, as I believe they can easily cause other problems.

