### PR TITLE
Add `Dockerfile.fullstack` - single container for nextjs/backend

### DIFF
--- a/Dockerfile.fullstack
+++ b/Dockerfile.fullstack
@@ -71,7 +71,7 @@ WORKDIR /usr/src/app
 
 # Install Node.js and supervisord with retry logic
 RUN apt-get update && \
-  apt-get install -y curl supervisor && \
+  apt-get install -y curl supervisor nginx && \
   curl -fsSL --retry 3 --retry-delay 10 https://deb.nodesource.com/setup_20.x | bash - && \
   apt-get install -y nodejs && \
   rm -rf /var/lib/apt/lists/*
@@ -88,6 +88,10 @@ ARG NEXT_PORT=3000
 ENV NEXT_PORT=${NEXT_PORT}
 EXPOSE ${NEXT_PORT}
 
+# Internal Next.js port (not exposed)
+ARG NEXT_INTERNAL_PORT=3001
+ENV NEXT_INTERNAL_PORT=${NEXT_INTERNAL_PORT}
+
 # Copy application files
 COPY ./ ./
 
@@ -98,6 +102,72 @@ COPY --from=frontend-builder /app/frontend/nextjs/public ./frontend/nextjs/publi
 COPY --from=frontend-builder /app/frontend/nextjs/package.json ./frontend/nextjs/package.json
 # Ensure next.config.mjs and other necessary files are present
 COPY --from=frontend-builder /app/frontend/nextjs/next.config.mjs ./frontend/nextjs/next.config.mjs
+
+# Create nginx configuration
+RUN echo 'events {' > /etc/nginx/nginx.conf && \
+  echo '    worker_connections 1024;' >> /etc/nginx/nginx.conf && \
+  echo '}' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo 'http {' >> /etc/nginx/nginx.conf && \
+  echo '    include /etc/nginx/mime.types;' >> /etc/nginx/nginx.conf && \
+  echo '    default_type application/octet-stream;' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '    # Logging' >> /etc/nginx/nginx.conf && \
+  echo '    access_log /var/log/nginx/access.log;' >> /etc/nginx/nginx.conf && \
+  echo '    error_log /var/log/nginx/error.log;' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '    # Gzip compression' >> /etc/nginx/nginx.conf && \
+  echo '    gzip on;' >> /etc/nginx/nginx.conf && \
+  echo '    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '    # WebSocket support' >> /etc/nginx/nginx.conf && \
+  echo '    map $http_upgrade $connection_upgrade {' >> /etc/nginx/nginx.conf && \
+  echo '        default upgrade;' >> /etc/nginx/nginx.conf && \
+  echo '        '"'"''"'"' close;' >> /etc/nginx/nginx.conf && \
+  echo '    }' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '    server {' >> /etc/nginx/nginx.conf && \
+  echo '        listen 3000;' >> /etc/nginx/nginx.conf && \
+  echo '        server_name _;' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '        # Proxy backend routes to FastAPI server' >> /etc/nginx/nginx.conf && \
+  echo '        location /outputs {' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_pass http://127.0.0.1:8000;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header Host $host;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Real-IP $remote_addr;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-Proto $scheme;' >> /etc/nginx/nginx.conf && \
+  echo '        }' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '        location /reports {' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_pass http://127.0.0.1:8000;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header Host $host;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Real-IP $remote_addr;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-Proto $scheme;' >> /etc/nginx/nginx.conf && \
+  echo '        }' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '        location /ws {' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_pass http://127.0.0.1:8000;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_http_version 1.1;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header Upgrade $http_upgrade;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header Connection $connection_upgrade;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header Host $host;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Real-IP $remote_addr;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-Proto $scheme;' >> /etc/nginx/nginx.conf && \
+  echo '        }' >> /etc/nginx/nginx.conf && \
+  echo '' >> /etc/nginx/nginx.conf && \
+  echo '        # Proxy all other requests to Next.js' >> /etc/nginx/nginx.conf && \
+  echo '        location / {' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_pass http://127.0.0.1:3001;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header Host $host;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Real-IP $remote_addr;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;' >> /etc/nginx/nginx.conf && \
+  echo '            proxy_set_header X-Forwarded-Proto $scheme;' >> /etc/nginx/nginx.conf && \
+  echo '        }' >> /etc/nginx/nginx.conf && \
+  echo '    }' >> /etc/nginx/nginx.conf && \
+  echo '}' >> /etc/nginx/nginx.conf
 
 # Create supervisord configuration
 # stdout/stderr_maxbytes prevents log file rotation and ensures continuous output
@@ -118,8 +188,17 @@ RUN echo '[supervisord]' > /etc/supervisor/conf.d/supervisord.conf && \
   echo 'stderr_logfile_maxbytes=0' >> /etc/supervisor/conf.d/supervisord.conf && \
   echo '' >> /etc/supervisor/conf.d/supervisord.conf && \
   echo '[program:frontend]' >> /etc/supervisor/conf.d/supervisord.conf && \
-  echo 'command=npm run start -- -p %(ENV_NEXT_PORT)s' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'command=npm run start -- -p %(ENV_NEXT_INTERNAL_PORT)s' >> /etc/supervisor/conf.d/supervisord.conf && \
   echo 'directory=/usr/src/app/frontend/nextjs' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'autostart=true' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'autorestart=true' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'stdout_logfile=/dev/stdout' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'stdout_logfile_maxbytes=0' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'stderr_logfile=/dev/stderr' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'stderr_logfile_maxbytes=0' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo '' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo '[program:nginx]' >> /etc/supervisor/conf.d/supervisord.conf && \
+  echo 'command=nginx -g "daemon off;"' >> /etc/supervisor/conf.d/supervisord.conf && \
   echo 'autostart=true' >> /etc/supervisor/conf.d/supervisord.conf && \
   echo 'autorestart=true' >> /etc/supervisor/conf.d/supervisord.conf && \
   echo 'stdout_logfile=/dev/stdout' >> /etc/supervisor/conf.d/supervisord.conf && \


### PR DESCRIPTION
- Combines the `frontend/nextjs` app (exposing port 3000) and the python uvicorn backend (exposing port 8000).
- Allows the environment variables `HOST`, `PORT`, and `NEXTJS_PORT` to configure internals.
- Small strategic changes to improve reliability of the build, e.g. setting up retries and increasing timeouts.
- Comments to clarify each phase/step of the build process.

## Build and run

```bash
docker buildx build -f Dockerfile.fullstack . --tag assafelovic/gpt-researcher-fullstack-test
docker run -p 3000:3000 -p 8000:8000 --env-file .env assafelovic/gpt-researcher-fullstack-test
```

EDIT: Thank you for merging #1411 -- I'll see if I can submit another PR adding this to its workflow (and removing the MCP build) this weekend

AI-written explanations on the changes:

---


## PR: Add `Dockerfile.fullstack` for Unified Frontend and Backend Deployment

### Overview

This PR introduces a new `Dockerfile.fullstack` that builds and serves both the Next.js frontend and the FastAPI (uvicorn) backend in a single Docker container. This approach streamlines deployment and simplifies development or production environments where maintaining separate containers is unnecessary or impractical.

### Key Components and Workflow

**1. Multi-Stage Build**
- **Frontend Build:** Uses a Node.js image to build the Next.js frontend.
- **Browser/Backend Tools:** Installs Chromium, Firefox, Chromedriver, Geckodriver, and required build tools for browser-based features or testing.
- **Backend Build:** Installs all backend Python dependencies.
- **Final Stage:** Combines frontend and backend artifacts, and adds Node.js, supervisord, and nginx.

**2. Supervisord: Unified Process Management**
- Supervisord acts as a process manager, launching and monitoring three key services within the container:
  - **Uvicorn (FastAPI backend):** Serves the API on a configurable port (default 8000). This is **exposed** inside the container (`PORT`)
  - **Next.js Frontend:** Runs the production server on an internal port (default 3001). This is **not exposed** inside the container.  (ARG/ENV `NEXT_INTERNAL_PORT`).
  - **Nginx:** Acts as a reverse proxy, listening on the public-facing port (default 3000). (ARG/ENV `NEXT_PORT`).

Both the `uvicorn` backend and the `nextjs` app are accessible on NEXT_PORT (3000). This was done so reverse proxies outside the container would work properly. Example:

```yaml

  gptr:
    build:
      context: https://github.com/assafelovic/gpt-researcher.git#main
      dockerfile: Dockerfile.fullstack
    image: assafelovic/gpt-researcher-aio:latest
    stdin_open: true
    container_name: gptr
    hostname: gptr
    expose:
      - 3000  # nginx unifying route
      - 3001  # nextjs internal port
      - 8000  # uvicorn external port
    ports:
      - 8000:8000  # unsure if this is needed.
    volumes:
      - ${CONFIG_PATH:-./configs}/gptr/logs:/usr/src/app/logs
      - ${CONFIG_PATH:-./configs}/gptr/outputs:/usr/src/app/outputs
      - ${CONFIG_PATH:-./configs}/gptr/reports:/usr/src/app/reports
    environment:
      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
      - BRAVE_API_KEY=${BRAVE_API_KEY}
      - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
      - EXA_API_KEY=${EXA_API_KEY}
      - FIRECRAWL_API_KEY=${FIRECRAWL_API_KEY}
      - FIRE_CRAWL_API_KEY=${FIRE_CRAWL_API_KEY}
      - GEMINI_API_KEY=${GEMINI_API_KEY}
      - GLAMA_API_KEY=${GLAMA_API_KEY}
      - GROQ_API_KEY=${GROQ_API_KEY}
      - HF_TOKEN=${HF_TOKEN}
      - HUGGINGFACE_ACCESS_TOKEN=${HUGGINGFACE_ACCESS_TOKEN}
      - HUGGINGFACE_API_TOKEN=${HUGGINGFACE_API_TOKEN}
      - LANGCHAIN_API_KEY=${LANGCHAIN_API_KEY}
      - MISTRAL_API_KEY=${MISTRAL_API_KEY}
      - MISTRALAI_API_KEY=${MISTRALAI_API_KEY}
      - OPENAI_API_KEY=${OPENAI_API_KEY}
      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
      - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY}
      - PERPLEXITYAI_API_KEY=${PERPLEXITYAI_API_KEY}
      - REPLICATE_API_KEY=${REPLICATE_API_KEY}
      - REVID_API_KEY=${REVID_API_KEY}
      - SAMBANOVA_API_KEY=${SAMBANOVA_API_KEY}
      - SEARCH1API_KEY=${SEARCH1API_KEY}
      - SERPAPI_API_KEY=${SERPAPI_API_KEY}
      - TAVILY_API_KEY=${TAVILY_API_KEY}
      - TOGETHERAI_API_KEY=${TOGETHERAI_API_KEY}
      - UNIFY_API_KEY=${UNIFY_API_KEY}
      - UPSTAGE_API_KEY=${UPSTAGE_API_KEY}
      - UPSTAGEAI_API_KEY=${UPSTAGEAI_API_KEY}
      - YOU_API_KEY=${YOU_API_KEY}
      - CHOKIDAR_USEPOLLING=true
      - LOGGING_LEVEL=DEBUG
      - NEXT_PUBLIC_GA_MEASUREMENT_ID=${NEXT_PUBLIC_GA_MEASUREMENT_ID}
    labels:
      traefik.enable: "true"
      traefik.http.routers.gptr.service: gptr
      traefik.http.routers.gptr.rule: Host(`gptr.${DOMAIN}`)
      traefik.http.services.gptr.loadbalancer.server.port: 3000
      traefik.http.routers.gptr-legacy.service: gptr-legacy
      traefik.http.routers.gptr-legacy.rule: Host(`gptr-legacy.${DOMAIN}`)
      traefik.http.services.gptr-legacy.loadbalancer.server.port: 8000
```

Without the `nginx` solution, Traefik would need the following lines to actually work properly:
```
labels:
      # ...other labels above here omitted for brevity...
      traefik.http.routers.gptr-backend.service: gptr-legacy
      traefik.http.routers.gptr-backend.rule: Host(`gptr.${DOMAIN}`) && (PathPrefix(`/ws`) || PathPrefix(`/outputs`) || PathPrefix(`/reports`))
```

  This setup ensures all three processes are started together and automatically restarted if any of them crash, which is crucial in a Docker environment where by default only one foreground process is allowed.

**3. Nginx: Reverse Proxy and Routing**
- Nginx serves several roles:
  - **Reverse Proxy:** Forwards API routes (`/outputs`, `/reports`, `/ws`) to the FastAPI backend.
  - **Static & Frontend Routing:** Proxies all other requests to the Next.js frontend server.
  - **WebSocket Support:** Handles WebSocket upgrades for real-time features.
  - **Compression & Logging:** Enables gzip and request logging for observability and performance. (gzip on, gzip_types, access_log, error_log). Simply mount a volume to /var/log/nginx to persist them through container restarts.

  This is needed because neither Next.js nor FastAPI can efficiently serve both frontend and API routes from a shared public port, nor handle WebSockets and static assets as robustly as nginx.

### Usage

- **Build:**  
  ```sh
  docker build -f Dockerfile.fullstack -t gptr:fullstack .
  ```
- **Run:**  
  ```sh
  docker run -p 3000:3000 -p 8000:8000 gptr:fullstack
  ```
  - The application will be available on port 3000.
  - API endpoints and WebSocket connections are seamlessly proxied to the backend.

### Why This Approach?

- **Simplicity:** One container, one deployment, easier local testing and smaller orchestration footprint.
- **Robustness:** `supervisord` ensures all core processes are running, or restarts them if they fail.
- **Production-Ready:** `nginx` provides a production-grade reverse proxy, static asset delivery, and WebSocket support/routing