### PR TITLE
fix: linux/arm64 machine cannot pull arm64 image from ghcr

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -118,6 +118,8 @@ jobs:
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
+          provenance: false
+          sbom: false
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
 
@@ -214,6 +216,8 @@ jobs:
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
+          provenance: false
+          sbom: false
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
 
@@ -310,6 +314,8 @@ jobs:
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
+          provenance: false
+          sbom: false
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"
 
@@ -406,5 +412,7 @@ jobs:
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
+          provenance: false
+          sbom: false
           cache-from: "type=gha"
           cache-to: "type=gha,mode=max"


### PR DESCRIPTION
# Background
When trying to run `docker pull` to pull the existing images from GitHub Container Registry, I got the following error:
```
docker pull ghcr.io/assafelovic/gpt-researcher:latest
latest: Pulling from assafelovic/gpt-researcher
no matching manifest for linux/arm64/v8 in the manifest list entries
```

The issue is that the pushed arm64 image is labeled as `unknown/unknown`, as seen in the screenshot below:
<img width="764" alt="unknown-gh" src="https://github.com/user-attachments/assets/33ae91d3-0941-40e1-b5e1-94a69ecf0241" />

# The Change
I did some digging and found a fix [here](https://github.com/orgs/community/discussions/45969#discussioncomment-13352049).

Disabling build attestations will enable arm64 users to pull the docker images and run GPT Researcher via Docker without going through the process of setting up a Python environment, installing dependencies and building the images.