### PR TITLE
Fix zero subtopic error

### DIFF
--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -144,7 +144,7 @@ async def construct_subtopics(
 
         chain = prompt | model | parser
 
-        output = chain.invoke({
+        output = await chain.ainvoke({
             "task": task,
             "data": data,
             "subtopics": subtopics,

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -155,4 +155,5 @@ async def construct_subtopics(
 
     except Exception as e:
         print("Exception in parsing subtopics : ", e)
+        logging.getLogger(__name__).error("Exception in parsing subtopics : \n {e}")
         return subtopics


### PR DESCRIPTION
**Problem Description**
When generating subtopic reports for the detailed report, the following error was encountered:
`Exception in parsing subtopics : Connection error`
As a result, neither the table of contents nor the subtopic reports are generated in the final output report.

**Solution**
- Changed the blocking `invoke` call to the asynchronous `ainvoke` to avoid blocking the event loop.
- Added additional logging for improved debugging and traceability.