### PR TITLE
bug_fix: vectorstore_filter not passed

### DIFF
--- a/gpt_researcher/skills/context_manager.py
+++ b/gpt_researcher/skills/context_manager.py
@@ -39,7 +39,7 @@ class ContextManager:
                 self.researcher.websocket,
                 )
         vectorstore_compressor = VectorstoreCompressor(
-            self.researcher.vector_store, filter, prompt_family=self.researcher.prompt_family,
+            self.researcher.vector_store, filter=filter, prompt_family=self.researcher.prompt_family,
             **self.researcher.kwargs
         )
         return await vectorstore_compressor.async_get_context(query=query, max_results=8)


### PR DESCRIPTION
**Describe the bug**
The vectorstore_filter parameter passed in GPTResearcher class is not passed the VectorstoreCompressor and VectorStoreWrapper class while conduct research.

**To Reproduce**
Steps to reproduce the behavior:
In `gptresearcher/context/compression.py -> VectorStoreCompressor` Make this change to async_get_context
```
async def async_get_context(self, query, max_results=5, cost_callback=None):
    print(f"DEBUG: VectorstoreCompressor.async_get_context using filter: {self.filter}")
    results = await self.vector_store.asimilarity_search(query=query, k=max_results, filter=self.filter)
    print(f"DEBUG: VectorstoreCompressor.async_get_context raw results (first 2 metadata): {[r.metadata for r in results[:2]]}")
    return self.prompt_family.pretty_print_docs(results)
```

In `gptresearcher/vector_store/vector_store.py -> VectorStoreWrapper` Make this change to asimilarity_search

```
async def asimilarity_search(self, query, k, filter):
      print(f"DEBUG: VectorStoreWrapper.asimilarity_search received filter: {filter}")
      results = await self.vector_store.asimilarity_search(query=query, k=k, filter=filter)
      print(f"DEBUG: VectorStoreWrapper.asimilarity_search results (first 2 metadata): {[r.metadata for r in results[:2]]}")
      return results
```

The filter is not passed here
```
DEBUG: VectorstoreCompressor.async_get_context using filter: None
DEBUG: VectorStoreWrapper.asimilarity_search received filter: None
DEBUG: VectorstoreCompressor.async_get_context using filter: None
DEBUG: VectorStoreWrapper.asimilarity_search received filter: None
DEBUG: VectorstoreCompressor.async_get_context using filter: None
DEBUG: VectorStoreWrapper.asimilarity_search received filter: None
DEBUG: VectorstoreCompressor.async_get_context using filter: None
DEBUG: VectorStoreWrapper.asimilarity_search received filter: None
DEBUG: VectorStoreWrapper.asimilarity_search results (first 2 metadata): [{'fileid': 'jun28'}, {'fileid': 'jun26'}]
DEBUG: VectorstoreCompressor.async_get_context raw results (first 2 metadata): [{'fileid': 'jun28'}, {'fileid': 'jun26'}]
DEBUG: VectorStoreWrapper.asimilarity_search results (first 2 metadata): [{'fileid': 'jun28'}, {'fileid': 'jun26'}]
DEBUG: VectorstoreCompressor.async_get_context raw results (first 2 metadata): [{'fileid': 'jun28'}, {'fileid': 'jun26'}]
DEBUG: VectorStoreWrapper.asimilarity_search results (first 2 metadata): [{'fileid': 'jun28'}, {'fileid': 'jun28'}]
DEBUG: VectorstoreCompressor.async_get_context raw results (first 2 metadata): [{'fileid': 'jun28'}, {'fileid': 'jun28'}]
```

**Expected behavior**
```
DEBUG: VectorstoreCompressor.async_get_context using filter: {'fileid': 'jun26'}
DEBUG: VectorStoreWrapper.asimilarity_search received filter: {'fileid': 'jun26'}
DEBUG: VectorstoreCompressor.async_get_context using filter: {'fileid': 'jun26'}
DEBUG: VectorStoreWrapper.asimilarity_search received filter: {'fileid': 'jun26'}
DEBUG: VectorstoreCompressor.async_get_context using filter: {'fileid': 'jun26'}
DEBUG: VectorStoreWrapper.asimilarity_search received filter: {'fileid': 'jun26'}
DEBUG: VectorstoreCompressor.async_get_context using filter: {'fileid': 'jun26'}
DEBUG: VectorStoreWrapper.asimilarity_search received filter: {'fileid': 'jun26'}
DEBUG: VectorStoreWrapper.asimilarity_search results (first 2 metadata): [{'fileid': 'jun26'}, {'fileid': 'jun26'}]
DEBUG: VectorstoreCompressor.async_get_context raw results (first 2 metadata): [{'fileid': 'jun26'}, {'fileid': 'jun26'}]
DEBUG: VectorStoreWrapper.asimilarity_search results (first 2 metadata): [{'fileid': 'jun26'}, {'fileid': 'jun26'}]
DEBUG: VectorstoreCompressor.async_get_context raw results (first 2 metadata): [{'fileid': 'jun26'}, {'fileid': 'jun26'}]
```

**Fix**
This issue can easily be fixed by passing the filter variable correctly by making this change in  `gptresearcher/skills/context_manager.py -> ContextManager -> get_similar_content_by_query_with_vectorstore`

previous:
```
        vectorstore_compressor = VectorstoreCompressor(
            self.researcher.vector_store, filter, prompt_family=self.researcher.prompt_family,
            **self.researcher.kwargs
        )
```

Required changes:
```
        vectorstore_compressor = VectorstoreCompressor(
            self.researcher.vector_store, filter=filter, prompt_family=self.researcher.prompt_family,
            **self.researcher.kwargs
        )
```

 **Pass the `filter` variable as keyword argument and the code runs as expected**