### PR TITLE
Fix Config instantiation for ChatAgentWithMemory: pass config_path as keyword argument

### DIFF
--- a/backend/chat/chat.py
+++ b/backend/chat/chat.py
@@ -22,7 +22,7 @@ class ChatAgentWithMemory:
     ):
         self.report = report
         self.headers = headers
-        self.config = Config(config_path)
+        self.config = Config(config_path=config_path)
         self.vector_store = vector_store
         self.graph = self.create_agent()
 


### PR DESCRIPTION
**Description**:
This PR resolves a TypeError raised during `Config` initialization for `ChatAgentWithMemory`.

**Context**:
The code previously constructed the `Config` object with a positional argument causing TypeError
<img width="1173" height="268" alt="Screenshot 2025-08-13 at 3 23 04 PM" src="https://github.com/user-attachments/assets/cda1076c-b31c-4126-849d-f8e020bfa713" />

**Fix**:
Provide `config_path` as a keyword argument