### PR TITLE
fix(frontend): use existing gptr-logo.png for background to stop 404

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -39,7 +39,8 @@ body::before {
     left: 0;
     width: 100%;
     height: 100%;
-    background-image: url('./static/powerful_wizard.png');
+    /* Use an existing asset to avoid 404s */
+    background-image: url('./static/gptr-logo.png');
     background-position: center;
     background-size: contain;
     background-repeat: no-repeat;


### PR DESCRIPTION
-Point the landing background to an existing asset to remove a missing-file 404 in the browser console.
  - Changes:
    - `frontend/styles.css`: Use `./static/gptr-logo.png` instead of the missing
 `powerful_wizard.png`.
  - Why: Cleans up a persistent 404 on initial load and avoids an unnecessary network request.
  - Testing:
    - Load landing page and confirm no 404 in Network/Console.
    - Verify background still renders.
  - Risk: Low — CSS path change to an existing file.