### PR TITLE
feat(llm): stop sending temperature to non‑supporting models

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -47,6 +47,9 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "o3-2025-04-16",
     "o4-mini",
     "o4-mini-2025-04-16",
+    # GPT-5 family: OpenAI enforces default temperature only
+    "gpt-5",
+    "gpt-5-mini",
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [


### PR DESCRIPTION
- Title: feat(llm): gate temperature/max_tokens for non‑supporting models
- Body:
  - Summary: Prevent 400s from GPT‑5 and reasoning models by sending `temperatur
e` and `max_tokens` only when supported. Also marks `gpt-5` and `gpt-5-mini` as 
no‑temperature models.
  - Changes:
    - `backend/chat/chat.py`: Include `temperature`/`max_tokens` only if the sel
ected model supports temperature.
    - `gpt_researcher/llm_provider/generic/base.py`: Add `gpt-5` and `gpt-5-mini
` to `NO_SUPPORT_TEMPERATURE_MODELS`.
  - Why: Avoids provider errors like “Unsupported value: 'temperature' … only th
e default (1) value is supported” that break chat/report flows.
  - Repro:
    - Before: Start a chat or report with `gpt-5` (or o-model) and non‑default t
emperature → 400 from provider; blank output.
    - After: Same flow completes without 400s; content renders normally.
  - Testing:
    - Chat with `gpt-5`, `o3`, `o1`, `o4-mini` at non‑default temperature → no 4
00.
    - Chat with standard models that support temperature → temperature still app
lied.
  - Risk: Low — guarded param inclusion based on model allowlist; default behavi
or unchanged for supporting models.

Confirmed working with Summary/Deep