### PR TITLE
Updated the validation logic for max_tokensto allow a maximum of ​​32,000​​ (previously capped at 16,000).

### DIFF
--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -54,7 +54,7 @@ async def create_chat_completion(
         raise ValueError("Model cannot be None")
     if max_tokens is not None and max_tokens > 32001:
         raise ValueError(
-            f"Max tokens cannot be more than 16,000, but got {max_tokens}")
+            f"Max tokens cannot be more than 32,000, but got {max_tokens}")
 
     # Get the provider from supported providers
     provider_kwargs = {'model': model}


### PR DESCRIPTION
Updated the validation logic for max_tokensto allow a maximum of ​​32,000​​ (previously capped at 16,000).