### PR TITLE
Bug fix: Remove the encoding parameter from kwargs to avoid passing an unsupported argument in the LLM call. 

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -157,6 +157,7 @@ class GPTResearcher:
         
         # Set default encoding to utf-8
         self.encoding = kwargs.get('encoding', 'utf-8')
+        self.kwargs.pop('encoding', None)  # Remove encoding from kwargs to avoid passing it to LLM calls
 
         # Initialize components
         self.research_conductor: ResearchConductor = ResearchConductor(self)
@@ -300,6 +301,8 @@ class GPTResearcher:
 
         if not (self.agent and self.role):
             await self._log_event("action", action="choose_agent")
+            # Filter out encoding parameter as it's not supported by LLM APIs
+            # filtered_kwargs = {k: v for k, v in self.kwargs.items() if k != 'encoding'}
             self.agent, self.role = await choose_agent(
                 query=self.query,
                 cfg=self.cfg,
@@ -307,7 +310,8 @@ class GPTResearcher:
                 cost_callback=self.add_costs,
                 headers=self.headers,
                 prompt_family=self.prompt_family,
-                **self.kwargs
+                **self.kwargs,
+                # **filtered_kwargs
             )
             await self._log_event("action", action="agent_selected", details={
                 "agent": self.agent,


### PR DESCRIPTION
In `cli.py`, the default parameter `encoding` is wrapped in `kwargs` and passed to `gpt_researcher/agent.py`, and is finally passed incorrectly to the `AsyncCompletions.create` method in `site-packages/openai/resources/chat/completions/completions.py`. This method rejects illegal parameters and throws the error `TypeError: AsyncCompletions.create() got an unexpected keyword argument 'encoding'` when calling the OpenAI API. Furthermore, the `encoding` parameter was not effective, so I popped it out during the initialization of `GPTResearcher`.