### PR TITLE
Summary: Fix missing WebSocketDisconnect import

### DIFF
--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 from backend.chat.chat import ChatAgentWithMemory


### PR DESCRIPTION
Problem: App.py does use WebSocketDisconnect yet it failed to import.
Solution: import WebSocketDisconnect.