### PR TITLE
feat: Add proper multi-platform Docker build support

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -26,24 +26,16 @@ env:
 
 jobs:
   build-push-root:
-    name: "Build Root Image - ${{ matrix.platform_slash }}"
+    name: "Build Root Image"
     # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
     if: ${{ success() || failure() }}
-    runs-on: "${{ matrix.runner_label }}"
+    runs-on: "ubuntu-latest"
     env:
       # Variables for Docker tokens and authentication
       IMAGE_NAME_GHCR_SUFFIXED: "${{ github.event.repository.name }}"
       IMAGE_NAME_DOCKERHUB_SUFFIXED: "${{ github.event.repository.name }}"
       DOCKERFILE_PATH: "./Dockerfile"
       BUILD_CONTEXT: "."
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform_slash: "linux/amd64"
-            runner_label: "ubuntu-latest"
-          - platform_slash: "linux/arm64"
-            runner_label: "ubuntu-22.04-arm"
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"
@@ -51,6 +43,10 @@ jobs:
         if: ${{ success() || failure() }}
         with:
           fetch-depth: 0
+      - name: "Set up QEMU"
+        uses: "docker/setup-qemu-action@v3"
+        # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
+        if: ${{ success() || failure() }}
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v3"
         # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
@@ -114,7 +110,7 @@ jobs:
         with:
           context: "${{ env.BUILD_CONTEXT }}"
           file: "${{ env.DOCKERFILE_PATH }}"
-          platforms: "${{ matrix.platform_slash }}"
+          platforms: "linux/amd64,linux/arm64"
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
@@ -124,24 +120,16 @@ jobs:
           cache-to: "type=gha,mode=max"
 
   build-push-frontend-nextjs:
-    name: "Build Frontend Next.js Image - ${{ matrix.platform_slash }}"
+    name: "Build Frontend Next.js Image"
     # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
     if: ${{ success() || failure() }}
-    runs-on: "${{ matrix.runner_label }}"
+    runs-on: "ubuntu-latest"
     env:
       # Variables for Docker tokens and authentication
       IMAGE_NAME_GHCR_SUFFIXED: "${{ github.event.repository.name }}-frontend-nextjs"
       IMAGE_NAME_DOCKERHUB_SUFFIXED: "${{ github.event.repository.name }}-frontend-nextjs"
       DOCKERFILE_PATH: "./frontend/nextjs/Dockerfile.dev"
       BUILD_CONTEXT: "./frontend/nextjs"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform_slash: "linux/amd64"
-            runner_label: "ubuntu-latest"
-          - platform_slash: "linux/arm64"
-            runner_label: "ubuntu-22.04-arm"
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"
@@ -149,6 +137,10 @@ jobs:
         if: ${{ success() || failure() }}
         with:
           fetch-depth: 0
+      - name: "Set up QEMU"
+        uses: "docker/setup-qemu-action@v3"
+        # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
+        if: ${{ success() || failure() }}
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v3"
         # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
@@ -212,7 +204,7 @@ jobs:
         with:
           context: "${{ env.BUILD_CONTEXT }}"
           file: "${{ env.DOCKERFILE_PATH }}"
-          platforms: "${{ matrix.platform_slash }}"
+          platforms: "linux/amd64,linux/arm64"
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
@@ -222,24 +214,16 @@ jobs:
           cache-to: "type=gha,mode=max"
 
   build-push-mcp-server:
-    name: "Build MCP Server Image - ${{ matrix.platform_slash }}"
+    name: "Build MCP Server Image"
     # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
     if: ${{ success() || failure() }}
-    runs-on: "${{ matrix.runner_label }}"
+    runs-on: "ubuntu-latest"
     env:
       # Variables for Docker tokens and authentication
       IMAGE_NAME_GHCR_SUFFIXED: "${{ github.event.repository.name }}-mcp-server"
       IMAGE_NAME_DOCKERHUB_SUFFIXED: "${{ github.event.repository.name }}-mcp-server"
       DOCKERFILE_PATH: "./mcp-server/Dockerfile"
       BUILD_CONTEXT: "./mcp-server"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform_slash: "linux/amd64"
-            runner_label: "ubuntu-latest"
-          - platform_slash: "linux/arm64"
-            runner_label: "ubuntu-22.04-arm"
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"
@@ -247,6 +231,10 @@ jobs:
         if: ${{ success() || failure() }}
         with:
           fetch-depth: 0
+      - name: "Set up QEMU"
+        uses: "docker/setup-qemu-action@v3"
+        # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
+        if: ${{ success() || failure() }}
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v3"
         # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
@@ -310,7 +298,7 @@ jobs:
         with:
           context: "${{ env.BUILD_CONTEXT }}"
           file: "${{ env.DOCKERFILE_PATH }}"
-          platforms: "${{ matrix.platform_slash }}"
+          platforms: "linux/amd64,linux/arm64"
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true
@@ -320,24 +308,16 @@ jobs:
           cache-to: "type=gha,mode=max"
 
   build-push-docs-discord-bot:
-    name: "Build Docs Discord Bot Image - ${{ matrix.platform_slash }}"
+    name: "Build Docs Discord Bot Image"
     # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
     if: ${{ success() || failure() }}
-    runs-on: "${{ matrix.runner_label }}"
+    runs-on: "ubuntu-latest"
     env:
       # Variables for Docker tokens and authentication
       IMAGE_NAME_GHCR_SUFFIXED: "${{ github.event.repository.name }}-docs-discord-bot"
       IMAGE_NAME_DOCKERHUB_SUFFIXED: "${{ github.event.repository.name }}-docs-discord-bot"
       DOCKERFILE_PATH: "./docs/discord-bot/Dockerfile"
       BUILD_CONTEXT: "./docs/discord-bot"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform_slash: "linux/amd64"
-            runner_label: "ubuntu-latest"
-          - platform_slash: "linux/arm64"
-            runner_label: "ubuntu-22.04-arm"
     steps:
       - name: "Checkout repository"
         uses: "actions/checkout@v4"
@@ -345,6 +325,10 @@ jobs:
         if: ${{ success() || failure() }}
         with:
           fetch-depth: 0
+      - name: "Set up QEMU"
+        uses: "docker/setup-qemu-action@v3"
+        # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
+        if: ${{ success() || failure() }}
       - name: "Set up Docker Buildx"
         uses: "docker/setup-buildx-action@v3"
         # This line makes it possible to cancel a workflow in the middle of a step. Otherwise the step needs to complete first.
@@ -408,7 +392,7 @@ jobs:
         with:
           context: "${{ env.BUILD_CONTEXT }}"
           file: "${{ env.DOCKERFILE_PATH }}"
-          platforms: "${{ matrix.platform_slash }}"
+          platforms: "linux/amd64,linux/arm64"
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
           push: true


### PR DESCRIPTION
**Issue:**
Current docker build process does not properly support both x86 and ARM images.
Error example (ghcr.io/assafelovic/gpt-researcher-frontend-nextjs:master):
```
Oct 09 11:33:13 unicron systemd[1]: Starting docker-gpt-researcher.service...
Oct 09 11:33:13 unicron pre-start[275682]: Error response from daemon: No such container: gpt-researcher
Oct 09 11:33:13 unicron systemd[1]: Started docker-gpt-researcher.service.
Oct 09 11:33:13 unicron docker-gpt-researcher-start[275705]: WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
Oct 09 11:33:14 unicron docker-gpt-researcher-start[275705]: exec /usr/local/bin/docker-entrypoint.sh: exec format error
Oct 09 11:33:14 unicron systemd[1]: docker-gpt-researcher.service: Main process exited, code=exited, status=255/EXCEPTION
Oct 09 11:33:14 unicron docker-gpt-researcher-post-stop[276194]: Error response from daemon: No such container: gpt-researcher
Oct 09 11:33:14 unicron systemd[1]: docker-gpt-researcher.service: Failed with result 'exit-code'.
```



**Explanation:**
How Cross-Architecture Builds Worked Before
Previously, the project used a build matrix strategy in the GitHub Actions workflow. Here’s what that means:

Separate Jobs: For each Docker image, the workflow would start two separate, parallel jobs: one for the linux/amd64 (x86) architecture and one for linux/arm64.
Native Runners: The amd64 job would run on a standard x86-based runner (ubuntu-latest), and the arm64 job would run on a specialized, ARM-based runner. Each job built the image natively on its corresponding architecture.
The Problem (Tag Overwriting): Both jobs would build and push an image with the exact same tag (e.g., gpt-researcher:latest). When the first job pushed its image, the latest tag would point to it. However, when the second job finished, it would push its image and overwrite that same latest tag. As a result, the tag would only point to the image for the architecture that finished building last. A user on the other architecture would be unable to pull the latest image.
This approach did not create a multi-architecture manifest, which is a crucial piece for modern Docker image distribution.

How QEMU and the New Approach Make It Better
The new solution uses Docker Buildx and QEMU to build both images in a single job from a standard x86 runner.

What is QEMU? QEMU is a machine emulator. In this context, we use it to emulate an ARM environment on the standard x86 GitHub Actions runner. This allows the runner to execute ARM instructions and build a Docker image for the ARM architecture without needing a physical ARM machine.
Consolidated Build: By adding the docker/setup-qemu-action step, we enable the x86 runner to build for both linux/amd64 (natively) and linux/arm64 (via emulation) in a single, consolidated job.
Multi-Architecture Manifest: The key improvement is that the docker/build-push-action now builds for both platforms at once (platforms: linux/amd64,linux/arm64). When it pushes the images to the registry, it also creates and pushes a multi-architecture manifest (sometimes called a "fat manifest").
This manifest acts as an index for a single image tag (like latest). It tells the Docker registry that this tag is associated with images for multiple architectures.

The End Result: When you or another user runs docker pull gpt-researcher:latest, your Docker client tells the registry its architecture. The registry looks at the manifest for the latest tag and automatically sends the image layers that are correct for your machine. This is the modern, compliant way to distribute Docker images and ensures a seamless experience for users on any supported platform.



**Changes:**
Refactors the `.github/workflows/docker-push.yml` workflow to support multi-architecture Docker builds for x86 (amd64) and ARM (arm64) platforms.

The previous implementation used a matrix strategy to build each architecture separately, which resulted in overwriting image tags and did not produce a multi-architecture manifest.

This commit consolidates the build process for each of the four Docker images into a single job that:
- Removes the build matrix.
- Uses `docker/setup-qemu-action` to enable cross-architecture builds.
- Leverages `docker/build-push-action` to build for both `linux/amd64` and `linux/arm64` in a single step.

This creates a multi-architecture manifest, allowing container runtimes to automatically pull the correct image for the user's system architecture, in compliance with modern Docker standards.