### PR TITLE
feat: add plan manager and budgeting layer

### DIFF
--- a/docs/deep-research-align-A.md
+++ b/docs/deep-research-align-A.md
@@ -1,0 +1,8 @@
+# deep-research-align:A – Planning & Budget Layer
+| Current | Proposed (Deep Research) |
+| --- | --- |
+| Planner returns string list only; no artifact. | `PlanManager` keeps structured steps + budgets with trace metadata. |
+| Costs tracked post-hoc; no budgets or stops. | Configurable token/cost/web budgets with optional enforcement. |
+| No plan trace or token accounting. | Plan trace persists to JSON/logs; tokens recorded with costs. |
+Summary: `PlanManager` tracks steps and budgets and can emit plan traces without altering CLI/API behaviour.
+Verify: `pip install pytest`; `pytest tests/test_plan_manager.py`

--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -22,6 +22,11 @@ async def get_search_results(query: str, retriever: Any, query_domains: List[str
     Returns:
         A list of search results
     """
+    if researcher and hasattr(researcher, "plan_manager") and researcher.plan_manager:
+        researcher.plan_manager.record_usage("web_calls", 1)
+        if hasattr(researcher, "update_plan_trace"):
+            researcher.update_plan_trace()
+
     # Check if this is an MCP retriever and pass the researcher instance
     if "mcpretriever" in retriever.__name__.lower():
         search_retriever = retriever(

--- a/gpt_researcher/config/variables/base.py
+++ b/gpt_researcher/config/variables/base.py
@@ -41,3 +41,8 @@ class BaseConfig(TypedDict):
     MCP_ALLOWED_ROOT_PATHS: List[str]
     MCP_STRATEGY: str
     REASONING_EFFORT: str
+    PLANNING_TOKEN_BUDGET: Union[int, None]
+    PLANNING_WEB_BUDGET: Union[int, None]
+    PLANNING_COST_BUDGET: Union[float, None]
+    PLANNING_ENFORCE_BUDGET: bool
+    PLAN_TRACE_PATH: Union[str, None]

--- a/gpt_researcher/config/variables/default.py
+++ b/gpt_researcher/config/variables/default.py
@@ -42,4 +42,10 @@ DEFAULT_CONFIG: BaseConfig = {
     "MCP_ALLOWED_ROOT_PATHS": [],  # List of allowed root paths for local file access
     "MCP_STRATEGY": "fast",  # MCP execution strategy: "fast", "deep", "disabled"
     "REASONING_EFFORT": "medium",
+    # Planning & budgeting
+    "PLANNING_TOKEN_BUDGET": None,
+    "PLANNING_WEB_BUDGET": None,
+    "PLANNING_COST_BUDGET": None,
+    "PLANNING_ENFORCE_BUDGET": False,
+    "PLAN_TRACE_PATH": None,
 }

--- a/gpt_researcher/planning/__init__.py
+++ b/gpt_researcher/planning/__init__.py
@@ -1,0 +1,4 @@
+"""Planning utilities for GPT Researcher."""
+
+from .manager import PlanManager, PlanStep, PlanBudget  # noqa: F401
+

--- a/gpt_researcher/planning/manager.py
+++ b/gpt_researcher/planning/manager.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+
+class PlanManager:
+    def __init__(
+        self,
+        query: str,
+        token_limit: Optional[float] = None,
+        web_limit: Optional[int] = None,
+        cost_limit: Optional[float] = None,
+    ) -> None:
+        self.query = query
+        self.created_at = datetime.utcnow().isoformat()
+        self.steps: list[Dict[str, object]] = []
+        self.budgets: Dict[str, Dict[str, Optional[float]]] = {
+            "tokens": {"limit": token_limit, "used": 0.0},
+            "web_calls": {"limit": web_limit, "used": 0.0},
+            "cost": {"limit": cost_limit, "used": 0.0},
+        }
+
+    def add_step(self, query: str, rationale: str) -> Dict[str, object]:
+        step = {"query": query, "rationale": rationale, "status": "pending"}
+        step["created_at"] = datetime.utcnow().isoformat(); step["metadata"] = {}
+        self.steps.append(step)
+        return step
+
+    def update_step(self, query: str, status: str, metadata: Optional[Dict[str, object]] = None) -> None:
+        for step in self.steps:
+            if step["query"] == query:
+                step["status"] = status
+                if metadata:
+                    step["metadata"].update(metadata)
+                break
+
+    def record_usage(self, budget_name: str, amount: float) -> None:
+        if amount < 0:
+            raise ValueError("Budget usage must be non-negative")
+        budget = self.budgets.setdefault(budget_name, {"limit": None, "used": 0.0})
+        budget["used"] = float(budget.get("used", 0.0)) + float(amount)
+
+    def should_halt(self, enforce: bool = False) -> bool:
+        return bool(enforce and any(
+            b["limit"] is not None and b.get("used", 0.0) >= b["limit"]
+            for b in self.budgets.values()
+        ))
+
+    def get_trace(self) -> Dict[str, object]:
+        def summary(budget: Dict[str, Optional[float]]) -> Dict[str, Optional[float]]:
+            limit = budget["limit"]; used = budget.get("used", 0.0)
+            return {
+                "limit": limit,
+                "used": used,
+                "remaining": None if limit is None else max(limit - used, 0.0),
+                "exhausted": limit is not None and used >= limit,
+            }
+        return {
+            "query": self.query,
+            "created_at": self.created_at,
+            "steps": list(self.steps),
+            "budgets": {name: summary(budget) for name, budget in self.budgets.items()},
+        }

--- a/gpt_researcher/skills/browser.py
+++ b/gpt_researcher/skills/browser.py
@@ -30,6 +30,11 @@ class BrowserManager:
                 self.researcher.websocket,
             )
 
+        if hasattr(self.researcher, "plan_manager") and self.researcher.plan_manager:
+            self.researcher.plan_manager.record_usage("web_calls", len(urls))
+            if hasattr(self.researcher, "update_plan_trace"):
+                self.researcher.update_plan_trace()
+
         scraped_content, images = await scrape_urls(
             urls, self.researcher.cfg, self.worker_pool
         )

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -97,7 +97,7 @@ class DeepResearchSkill:
     async def generate_research_plan(self, query: str, num_questions: int = 3) -> List[str]:
         """Generate follow-up questions to clarify research direction"""
         # Get initial search results to inform query generation
-        search_results = await get_search_results(query, self.researcher.retrievers[0])
+        search_results = await get_search_results(query, self.researcher.retrievers[0], researcher=self.researcher)
         logger.info(f"Initial web knowledge obtained: {len(search_results)} results")
 
         # Get current time for context

--- a/gpt_researcher/utils/costs.py
+++ b/gpt_researcher/utils/costs.py
@@ -23,3 +23,10 @@ def estimate_embedding_cost(model, docs):
     total_tokens = sum(len(encoding.encode(str(doc))) for doc in docs)
     return total_tokens * EMBEDDING_COST
 
+
+def estimate_token_usage(input_content: str, output_content: str) -> tuple[int, int, int]:
+    """Return (input_tokens, output_tokens, total_tokens) for the given content."""
+    encoding = tiktoken.get_encoding(ENCODING_MODEL)
+    input_tokens = len(encoding.encode(input_content))
+    output_tokens = len(encoding.encode(output_content))
+    return input_tokens, output_tokens, input_tokens + output_tokens

--- a/tests/test_plan_manager.py
+++ b/tests/test_plan_manager.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+from gpt_researcher.agent import GPTResearcher
+from gpt_researcher.planning import PlanManager
+
+
+def test_plan_manager_usage_and_persistence(tmp_path):
+    manager = PlanManager("sample query", token_limit=120, web_limit=2, cost_limit=1.0)
+    manager.add_step("sample query", "Resolve the main question")
+    for name, value in [("tokens", 40), ("web_calls", 2), ("cost", 0.5)]:
+        manager.record_usage(name, value)
+    trace = manager.get_trace()
+    assert trace["budgets"]["web_calls"]["used"] == 2
+    assert manager.should_halt(enforce=True) is True
+    researcher = GPTResearcher(query="test plan trace", verbose=False)
+    researcher.plan_trace_path = str(tmp_path / "traces")
+    researcher.plan_manager.add_step("test plan trace", "Primary objective")
+    saved = Path(researcher.persist_plan_trace())
+    payload = json.loads(saved.read_text())
+    assert payload["query"] == "test plan trace"
+    assert payload["steps"][0]["query"] == "test plan trace"


### PR DESCRIPTION
# deep-research-align:A – Planning & Budget Layer
| Current | Proposed (Deep Research) |
| --- | --- |
| Planner returns string list only; no artifact. | `PlanManager` keeps structured steps + budgets with trace metadata. |
| Costs tracked post-hoc; no budgets or stops. | Configurable token/cost/web budgets with optional enforcement. |
| No plan trace or token accounting. | Plan trace persists to JSON/logs; tokens recorded with costs. |
Summary: `PlanManager` tracks steps and budgets and can emit plan traces without altering CLI/API behaviour.
Verify: `pip install pytest`; `pytest tests/test_plan_manager.py`