### PR TITLE
Add query_domains support to search retrievers

### DIFF
--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -52,10 +52,16 @@ class BingSearch():
             'Ocp-Apim-Subscription-Key': self.api_key,
             'Content-Type': 'application/json'
         }
-        # TODO: Add support for query domains
+
+        # Build query with domain filtering if query_domains is provided
+        query = self.query
+        if self.query_domains:
+            domain_filter = " OR ".join([f"site:{domain}" for domain in self.query_domains])
+            query = f"{self.query} ({domain_filter})"
+
         params = {
             "responseFilter": "Webpages",
-            "q": self.query,
+            "q": query,
             "count": max_results,
             "setLang": "en-GB",
             "textDecorations": False,

--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -20,9 +20,14 @@ class Duckduckgo:
         :param max_results:
         :return:
         """
-        # TODO: Add support for query domains
+        # Build query with domain filtering if query_domains is provided
+        query = self.query
+        if self.query_domains:
+            domain_filter = " OR ".join([f"site:{domain}" for domain in self.query_domains])
+            query = f"{self.query} ({domain_filter})"
+
         try:
-            search_response = self.ddg.text(self.query, region='wt-wt', max_results=max_results)
+            search_response = self.ddg.text(query, region='wt-wt', max_results=max_results)
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -45,10 +45,16 @@ class SearxSearch():
             List of dictionaries containing search results
         """
         search_url = urljoin(self.base_url, "search")
-        # TODO: Add support for query domains
+
+        # Build query with domain filtering if query_domains is provided
+        query = self.query
+        if self.query_domains:
+            domain_filter = " OR ".join([f"site:{domain}" for domain in self.query_domains])
+            query = f"{self.query} ({domain_filter})"
+
         params = {
-            # The search query. 
-            'q': self.query, 
+            # The search query.
+            'q': query,
             # Output format of results. Format needs to be activated in searxng config.
             'format': 'json'
         }


### PR DESCRIPTION
Implemented the TODO to add support for query domains in three search retrievers:
- SearxNG (searx.py)
- DuckDuckGo (duckduckgo.py)
- Bing (bing.py)

All retrievers now filter search results to specified domains using the site: operator when query_domains is provided. This brings them in line with the existing Tavily implementation.