### PR TITLE
fix: Add request_timeout to OpenRouter provider to prevent indefinite hangs

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -220,6 +220,7 @@ class GenericLLMProvider:
             )
 
             llm = ChatOpenAI(openai_api_base='https://openrouter.ai/api/v1',
+                     request_timeout=180,
                      openai_api_key=os.environ["OPENROUTER_API_KEY"],
                      rate_limiter=rate_limiter,
                      **kwargs


### PR DESCRIPTION
## Problem
When using OpenRouter as the LLM provider, deep research mode can hang indefinitely if any LLM call to OpenRouter takes too long or times out. The process shows only ping messages in logs and never completes.

## Root Cause
The OpenRouter provider's `ChatOpenAI` initialization has no `request_timeout` configured. Deep research makes 9+ LLM calls, and if any single call hangs, the entire process waits forever.

## Solution
Add `request_timeout=180` (3 minutes) to the OpenRouter ChatOpenAI configuration. This ensures:
- LLM calls timeout after 3 minutes instead of hanging indefinitely
- Errors are raised properly so they can be handled or retried
- Deep research either completes or fails gracefully with a clear error

## Testing
- Tested with deep research mode (breadth=3, depth=2)
- Previously hanging requests now timeout and raise proper exceptions
- Normal research continues to work as expected
- This was tested with `Qwen3-Next-80B-A3B` as model for OpenRouter