### PR TITLE
fix: avoid double .docx extension in multi_agents write_md_to_word

### DIFF
--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -93,7 +93,7 @@ async def write_md_to_word(text: str, path: str) -> str:
 
         print(f"Report written to {file_path}")
 
-        encoded_file_path = urllib.parse.quote(f"{file_path}.docx")
+        encoded_file_path = urllib.parse.quote(file_path)
         return encoded_file_path
 
     except Exception as e:


### PR DESCRIPTION
## Summary

This PR fixes a small bug in the multi-agents file export helper where the returned DOCX path ended up with a duplicated `.docx` extension.

## Changes

- **File**: [multi_agents/agents/utils/file_formats.py](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/gpt-researcher/multi_agents/agents/utils/file_formats.py:0:0-0:0)
  - In [write_md_to_word](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/gpt-researcher/backend/utils.py:60:0-91:17), we now URL-encode the actual DOCX file path instead of appending another `.docx`:

    ```python
    # Saving the docx document to file_path
    doc.save(file_path)

    print(f"Report written to {file_path}")

    encoded_file_path = urllib.parse.quote(file_path)
    return encoded_file_path
    ```

  - Previously this line was:

    ```python
    encoded_file_path = urllib.parse.quote(f"{file_path}.docx")
    ```

    which produced paths like `.../xxxx.docx.docx`.

## Rationale

- `file_path` is already constructed with a `.docx` suffix earlier in the function.
- Returning an encoded path with `.docx.docx` can be confusing for callers and users, and is clearly unintended.

## Testing

- Verified the path construction logic by inspection:
  - `file_path = f"{path}/{task}.docx"`
  - `doc.save(file_path)`
  - Returned URL now correctly encodes `.../{task}.docx` without duplicating the extension.
- No other behavior changed; the function still writes the DOCX file and returns its encoded path.