### PR TITLE
chore: align multi_agents write_to_file with backend UTF-8 handling

### DIFF
--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -11,12 +11,15 @@ async def write_to_file(filename: str, text: str) -> None:
         filename (str): The filename to write to.
         text (str): The text to write.
     """
+    # Ensure text is a string
+    if not isinstance(text, str):
+        text = str(text)
+
     # Convert text to UTF-8, replacing any problematic characters
     text_utf8 = text.encode('utf-8', errors='replace').decode('utf-8')
 
     async with aiofiles.open(filename, "w", encoding='utf-8') as file:
         await file.write(text_utf8)
-
 
 async def write_text_to_md(text: str, path: str) -> str:
     """Writes text to a Markdown file and returns the file path.


### PR DESCRIPTION
## Summary

This PR makes the multi-agents file export utility more robust by aligning its [write_to_file](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Prisca/gpt-researcher/backend/utils.py:4:0-19:35) implementation with the existing backend [write_to_file](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Prisca/gpt-researcher/backend/utils.py:4:0-19:35) helper. It ensures that any non-string text is coerced to a string before UTF-8 encoding.

## Changes

- **File**: [multi_agents/agents/utils/file_formats.py](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/gpt-researcher/multi_agents/agents/utils/file_formats.py:0:0-0:0)
  - Updated [write_to_file](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Prisca/gpt-researcher/backend/utils.py:4:0-19:35):

    ```python
    async def write_to_file(filename: str, text: str) -> None:
        """Asynchronously write text to a file in UTF-8 encoding.

        Args:
            filename (str): The filename to write to.
            text (str): The text to write.
        """
        # Ensure text is a string
        if not isinstance(text, str):
            text = str(text)

        # Convert text to UTF-8, replacing any problematic characters
        text_utf8 = text.encode('utf-8', errors='replace').decode('utf-8')

        async with aiofiles.open(filename, "w", encoding='utf-8') as file:
            await file.write(text_utf8)
    ```

- This mirrors the behavior already used in [backend/utils.py](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/Bolaji/gpt-researcher/backend/utils.py:0:0-0:0), so both single-agent and multi-agents flows handle non-string text consistently.

## Rationale

- In some paths, `text` may not be a plain `str` (e.g., other types or objects with a `__str__` representation).
- Backend [write_to_file](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/Prisca/gpt-researcher/backend/utils.py:4:0-19:35) already handles this case; this change brings the multi-agents version in line, reducing the chance of unexpected encoding errors.

## Testing

- Verified by inspection that:
  - Non-string `text` will now be converted via `str(text)` before encoding.
  - UTF-8 encoding with `errors='replace'` is preserved.
- No changes were made to the public API or other functions; this is a small internal robustness improvement.