### PR TITLE
Add custom prompts and language parameter

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -59,6 +59,7 @@ class GPTResearcher:
         mcp_configs: list[dict] | None = None,
         mcp_max_iterations: int | None = None,
         mcp_strategy: str | None = None,
+        custom_prompts: CustomPrompts | None = None,
         **kwargs
     ):
         """
@@ -113,12 +114,16 @@ class GPTResearcher:
                 - "fast" (default): Run MCP once with original query for best performance
                 - "deep": Run MCP for all sub-queries for maximum thoroughness  
                 - "disabled": Skip MCP entirely, use only web retrievers
+            custom_prompts (CustomPrompts, optional): Custom prompt overrides. If provided,
+                overrides the custom_prompts setting from config.
         """
         self.kwargs = kwargs
         self.query = query
         self.report_type = report_type
         self.cfg = Config(config_path)
         self.cfg.set_verbose(verbose)
+        if custom_prompts is not None:
+            self.cfg.custom_prompts = custom_prompts
         self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', None)
         self.report_format = report_format
         self.max_subtopics = max_subtopics

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from .config import Config
+from .config.custom_prompts import CustomPrompts
 from .memory import Memory
 from .utils.enum import ReportSource, ReportType, Tone
 from .llm_provider import GenericLLMProvider
@@ -59,6 +60,7 @@ class GPTResearcher:
         mcp_configs: list[dict] | None = None,
         mcp_max_iterations: int | None = None,
         mcp_strategy: str | None = None,
+        language: str | None = None,
         custom_prompts: CustomPrompts | None = None,
         **kwargs
     ):
@@ -112,8 +114,10 @@ class GPTResearcher:
                 ```
             mcp_strategy (str, optional): MCP execution strategy. Options:
                 - "fast" (default): Run MCP once with original query for best performance
-                - "deep": Run MCP for all sub-queries for maximum thoroughness  
+                - "deep": Run MCP for all sub-queries for maximum thoroughness
                 - "disabled": Skip MCP entirely, use only web retrievers
+            language (str, optional): Language for the report. If provided, overrides
+                the language setting from config.
             custom_prompts (CustomPrompts, optional): Custom prompt overrides. If provided,
                 overrides the custom_prompts setting from config.
         """
@@ -122,6 +126,8 @@ class GPTResearcher:
         self.report_type = report_type
         self.cfg = Config(config_path)
         self.cfg.set_verbose(verbose)
+        if language is not None:
+            self.cfg.language = language
         if custom_prompts is not None:
             self.cfg.custom_prompts = custom_prompts
         self.report_source = report_source if report_source else getattr(self.cfg, 'report_source', None)

--- a/gpt_researcher/config/custom_prompts.py
+++ b/gpt_researcher/config/custom_prompts.py
@@ -1,0 +1,193 @@
+from typing import Any, Dict, List, Protocol, runtime_checkable
+from dataclasses import dataclass
+
+
+# Protocol classes for custom prompt callables with named parameters
+@runtime_checkable
+class AutoAgentInstructionsCallable(Protocol):
+    def __call__(self) -> str: ...
+
+
+@runtime_checkable
+class GenerateSearchQueriesPromptCallable(Protocol):
+    def __call__(
+        self,
+        question: str,
+        parent_query: str,
+        report_type: str,
+        max_iterations: int,
+        context: List[Dict[str, Any]],
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateReportPromptCallable(Protocol):
+    def __call__(
+        self,
+        question: str,
+        context: Any,
+        report_source: str,
+        report_format: str,
+        tone: Any,
+        total_words: int,
+        language: str,
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateResourceReportPromptCallable(Protocol):
+    def __call__(
+        self,
+        question: str,
+        context: str,
+        report_source: str,
+        report_format: str,
+        tone: Any,
+        total_words: int,
+        language: str,
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateCustomReportPromptCallable(Protocol):
+    def __call__(
+        self,
+        query_prompt: str,
+        context: str,
+        report_source: str,
+        report_format: str,
+        tone: Any,
+        total_words: int,
+        language: str,
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateOutlineReportPromptCallable(Protocol):
+    def __call__(
+        self,
+        question: str,
+        context: str,
+        report_source: str,
+        report_format: str,
+        tone: Any,
+        total_words: int,
+        language: str,
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateDeepResearchPromptCallable(Protocol):
+    def __call__(
+        self,
+        question: str,
+        context: str,
+        report_source: str,
+        report_format: str,
+        tone: Any,
+        total_words: int,
+        language: str,
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateSubtopicReportPromptCallable(Protocol):
+    def __call__(
+        self,
+        current_subtopic: str,
+        existing_headers: List,
+        relevant_written_contents: List,
+        main_topic: str,
+        context: str,
+        report_format: str,
+        max_subsections: int,
+        total_words: int,
+        tone: Any,
+        language: str,
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateReportIntroductionCallable(Protocol):
+    def __call__(
+        self, question: str, research_summary: str, language: str, report_format: str
+    ) -> str: ...
+
+
+@runtime_checkable
+class GenerateReportConclusionCallable(Protocol):
+    def __call__(
+        self, query: str, report_content: str, language: str, report_format: str
+    ) -> str: ...
+
+
+@runtime_checkable
+class CurateSourcesCallable(Protocol):
+    def __call__(self, query: str, sources: Any, max_results: int) -> str: ...
+
+
+@runtime_checkable
+class GenerateSummaryPromptCallable(Protocol):
+    def __call__(self, query: str, data: Any) -> str: ...
+
+
+@runtime_checkable
+class GenerateSubtopicsPromptCallable(Protocol):
+    def __call__(self) -> str: ...
+
+
+@runtime_checkable
+class GenerateDraftTitlesPromptCallable(Protocol):
+    def __call__(
+        self, current_subtopic: str, main_topic: str, context: str, max_subsections: int
+    ) -> str: ...
+
+
+@dataclass
+class CustomPrompts:
+    """Override any prompt with a callable or template string.
+
+    Each attribute can be either:
+    - A string template with {placeholder} formatting
+    - A callable function with the same signature as the original prompt method
+    - None to use the default implementation
+
+    Example:
+        # String template
+        custom = CustomPrompts(
+            generate_report_prompt="Write a {language} report about {question}..."
+        )
+
+        # Callable function
+        def my_report_prompt(question, context, report_source, report_format, tone, total_words, language):
+            return f"Custom prompt for {question}..."
+
+        custom = CustomPrompts(generate_report_prompt=my_report_prompt)
+    """
+
+    auto_agent_instructions: str | AutoAgentInstructionsCallable | None = None
+    generate_search_queries_prompt: str | GenerateSearchQueriesPromptCallable | None = (
+        None
+    )
+    generate_report_prompt: str | GenerateReportPromptCallable | None = None
+    generate_resource_report_prompt: (
+        str | GenerateResourceReportPromptCallable | None
+    ) = None
+    generate_custom_report_prompt: str | GenerateCustomReportPromptCallable | None = (
+        None
+    )
+    generate_outline_report_prompt: str | GenerateOutlineReportPromptCallable | None = (
+        None
+    )
+    generate_deep_research_prompt: str | GenerateDeepResearchPromptCallable | None = (
+        None
+    )
+    generate_subtopic_report_prompt: (
+        str | GenerateSubtopicReportPromptCallable | None
+    ) = None
+    generate_report_introduction: str | GenerateReportIntroductionCallable | None = None
+    generate_report_conclusion: str | GenerateReportConclusionCallable | None = None
+    curate_sources: str | CurateSourcesCallable | None = None
+    generate_summary_prompt: str | GenerateSummaryPromptCallable | None = None
+    generate_subtopics_prompt: str | GenerateSubtopicsPromptCallable | None = None
+    generate_draft_titles_prompt: str | GenerateDraftTitlesPromptCallable | None = None


### PR DESCRIPTION
Hey, love the project. I thought of two improvements though to have more power over it and remove the need of monkey-patching files.

1. Add `custom_prompts` to Config for overriding prompts
2. Add `language` param to GPTResearcher constructor

## Custom Prompts

Prompts can now be overridden via config. Accepts either a callable (gets kwargs) or a format string:

```python
# callable
CustomPrompts(generate_report_prompt=lambda **kw: f"Write about {kw['question']}")

# or string template
CustomPrompts(generate_report_prompt="Report on {question} in {language}...")
```

##  Language

Setting the language with an env var is a bit unergonomic. This is clearer and discoverable

```python
researcher = GPTResearcher(query="...", language="german")
```