### PR TITLE
Persist /api/reports history to local JSON store (enables Next.js history sync)

### DIFF
--- a/backend/server/report_store.py
+++ b/backend/server/report_store.py
@@ -1,0 +1,57 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class ReportStore:
+    def __init__(self, path: Path):
+        self._path = path
+        self._lock = asyncio.Lock()
+
+    async def _ensure_parent_dir(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def _read_all_unlocked(self) -> Dict[str, Dict[str, Any]]:
+        if not self._path.exists():
+            return {}
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data  # type: ignore[return-value]
+        except Exception:
+            return {}
+        return {}
+
+    async def _write_all_unlocked(self, data: Dict[str, Dict[str, Any]]) -> None:
+        await self._ensure_parent_dir()
+        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        tmp_path.replace(self._path)
+
+    async def list_reports(self, report_ids: List[str] | None = None) -> List[Dict[str, Any]]:
+        async with self._lock:
+            data = await self._read_all_unlocked()
+            if report_ids is None:
+                return list(data.values())
+            return [data[report_id] for report_id in report_ids if report_id in data]
+
+    async def get_report(self, report_id: str) -> Dict[str, Any] | None:
+        async with self._lock:
+            data = await self._read_all_unlocked()
+            return data.get(report_id)
+
+    async def upsert_report(self, report_id: str, report: Dict[str, Any]) -> None:
+        async with self._lock:
+            data = await self._read_all_unlocked()
+            data[report_id] = report
+            await self._write_all_unlocked(data)
+
+    async def delete_report(self, report_id: str) -> bool:
+        async with self._lock:
+            data = await self._read_all_unlocked()
+            existed = report_id in data
+            if existed:
+                del data[report_id]
+                await self._write_all_unlocked(data)
+            return existed


### PR DESCRIPTION
## Summary
Fixes the "research history sync" flow by adding lightweight persistence for [/api/reports](cci:7://file:///C:/Users/brass/OneDrive/Desktop/Work/App/Prisca/gpt-researcher/frontend/nextjs/app/api/reports:0:0-0:0) on the backend.
Previously the backend always returned an empty list and didn't persist report data, so the Next.js frontend’s history sync and report CRUD calls could never work.

## Changes
- Added [backend/server/report_store.py](cci:7://file:///C:/Users/brass/OneDrive/Desktop/Work/App/Prisca/gpt-researcher/backend/server/report_store.py:0:0-0:0):
  - Simple JSON-file-backed store with an async lock and atomic writes
  - Path configurable via `REPORT_STORE_PATH` (default: `data/reports.json`)
- Updated [backend/server/app.py](cci:7://file:///C:/Users/brass/OneDrive/Desktop/Work/App/Prisca/gpt-researcher/backend/server/app.py:0:0-0:0) to implement report persistence:
  - `GET /api/reports` (supports `?report_ids=...`)
  - `POST /api/reports` (upsert)
  - `GET /api/reports/{id}`
  - `PUT /api/reports/{id}`
  - `DELETE /api/reports/{id}`
  - `GET /api/reports/{id}/chat`
  - `POST /api/reports/{id}/chat`

## Impact
- Frontend report history can be synced with the backend instead of relying purely on `localStorage`.
- Chat messages for a report can be stored/retrieved consistently.
- Does not require adding a database; remains "local mode" friendly.

## Env vars
- `REPORT_STORE_PATH` (optional): override storage file path