### PR TITLE
Fix CORS defaults: remove wildcard origins when allow_credentials=true

### DIFF
--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -93,12 +93,16 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # Configure allowed origins for CORS
-ALLOWED_ORIGINS = [
-    "http://localhost:3000",   # Local development
-    "http://127.0.0.1:3000",   # Local development alternative
-    "https://app.gptr.dev",    # Production frontend
-    "*",                      # Allow all origins for testing
-]
+allowed_origins_env = os.getenv("CORS_ALLOW_ORIGINS")
+ALLOWED_ORIGINS = (
+    [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+    if allowed_origins_env
+    else [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "https://app.gptr.dev",
+    ]
+)
 
 # Standard JSON response - no custom MongoDB encoding needed
 


### PR DESCRIPTION
## Summary
Fixes invalid CORS defaults where `allow_origins` included `"*"` while `allow_credentials=True`.
Browsers reject credentialed CORS responses with wildcard origins, leading to confusing failures and unsafe defaults.

## Changes
- [backend/server/app.py](cci:7://file:///C:/Users/brass/OneDrive/Desktop/Work/App/Prisca/gpt-researcher/backend/server/app.py:0:0-0:0)
  - `ALLOWED_ORIGINS` now comes from `CORS_ALLOW_ORIGINS` (comma-separated) when provided
  - Otherwise defaults to explicit safe origins:
    - http://localhost:3000
    - http://127.0.0.1:3000
    - https://app.gptr.dev

## Impact
- Credentialed CORS requests work reliably in browsers.
- Safer default behavior for deployments.

## Env vars
- `CORS_ALLOW_ORIGINS` (optional): comma-separated list of allowed origins