### PR TITLE
fix: Read all pages in PyMuPDFScraper instead of just first page

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -59,8 +59,10 @@ class PyMuPDFScraper:
 
             # Extract the content, image (if any), and title from the document.
             image = []
-            # Retrieve the content of the first page to minimize embedding costs.
-            return doc[0].page_content, image, doc[0].metadata["title"]
+            # Retrieve content from ALL pages to ensure PDFs with cover pages pass validation.
+            content = "\n".join(page.page_content for page in doc)
+            title = doc[0].metadata.get("title", "") if doc else ""
+            return content, image, title
 
         except requests.exceptions.Timeout:
             print(f"Download timed out. Please check the link : {self.link}")


### PR DESCRIPTION
## Summary 
                                                                                                                                                                                                                                                                                                                   
Fixes #1600 - PyMuPDFScraper only reads first page of PDFs

The current implementation extracts only `doc[0].page_content`, causing PDFs with minimal text on cover pages to fail the 100-character content validation check.

## Changes

- Modified `scrape()` to concatenate content from all pages
- Added safe title access with `.get()` and null check
- Updated comment to reflect new behavior

## Impact

Based on the reporter's testing, this fix resolves failures for 13/19 PDFs (68%) that were incorrectly rejected due to cover pages having < 100 characters.