### PR TITLE
feat: Add Forge LLM provider support

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -351,6 +351,19 @@ OPENROUTER_LIMIT_RPS=1  # Ratelimit request per secound
 EMBEDDING=google_genai:models/text-embedding-004 # openrouter doesn't support embedding models, use google instead its free
 GOOGLE_API_KEY=[Your *google gemini* key]
 ```
+## Forge
+
+[Forge](https://github.com/TensorBlock/forge) is an open-source LLM router that provides unified access to 40+ AI providers through a single API.
+
+```env
+FORGE_API_KEY=[Your Key]
+FAST_LLM=forge:OpenAI/gpt-4o-mini
+SMART_LLM=forge:OpenAI/gpt-4o
+STRATEGIC_LLM=forge:OpenAI/gpt-4o
+```
+
+Model names use the `Provider/model-name` format (e.g., `OpenAI/gpt-4o`, `Anthropic/claude-sonnet-4-5`).
+
 ## AI/ML API
 #### AI/ML API provides 300+ AI models including Deepseek, Gemini, ChatGPT. The models run at enterprise-grade rate limits and uptimes.
 You can check provider docs [_here_](https://docs.aimlapi.com/?utm_source=gptr&utm_medium=github&utm_campaign=integration)

--- a/docs/docs/gpt-researcher/llms/supported-llms.md
+++ b/docs/docs/gpt-researcher/llms/supported-llms.md
@@ -21,6 +21,7 @@ The following LLMs are supported by GPTR (though you'll need to install the rele
 - deepseek
 - litellm
 - openrouter
+- forge
 - vllm
 
 If you'd like to know the name of the langchain package for each LLM, you can check the [Langchain documentation](https://python.langchain.com/v0.2/docs/integrations/platforms/), or run GPTR as is and inspect the error message.

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -33,6 +33,7 @@ _SUPPORTED_PROVIDERS = {
     "vllm_openai",
     "aimlapi",
     "netmind",
+    "forge",
 }
 
 NO_SUPPORT_TEMPERATURE_MODELS = [
@@ -241,6 +242,14 @@ class GenericLLMProvider:
                              openai_api_key=os.environ["AIMLAPI_API_KEY"],
                              **kwargs
                              )
+        elif provider == "forge":
+            _check_pkg("langchain_openai")
+            from langchain_openai import ChatOpenAI
+
+            llm = ChatOpenAI(openai_api_base='https://api.forge.tensorblock.co/v1',
+                     openai_api_key=os.environ["FORGE_API_KEY"],
+                     **kwargs
+                )
         elif provider == 'netmind':
             _check_pkg("langchain_netmind")
             from langchain_netmind import ChatNetmind


### PR DESCRIPTION
## Changes

- Added forge to _SUPPORTED_PROVIDERS and ChatOpenAI elif branch in llm_provider/generic/base.py, added Forge section to LLM docs
- Environment variable: FORGE_API_KEY
- Base URL: https://api.forge.tensorblock.co/v1
- Model format: Provider/model-name (e.g., OpenAI/gpt-4o)
- Non-breaking: purely additive, existing providers are untouched

## About Forge

Forge (https://github.com/TensorBlock/forge) is an open-source middleware that routes inference across 40+ upstream providers (including OpenAI, Anthropic, Gemini, DeepSeek, and OpenRouter). It is OpenAI API compatible — works with the standard OpenAI SDK by changing base_url and api_key.

## Motivation

We have seen growing interest from users who standardize on Forge for their model management and want to use it natively with GPT Researcher. This integration aims to bridge that gap.

## Key Benefits

- Self-Hosted & Privacy-First: Forge is open-source and designed to be self-hosted, critical for users who require data sovereignty
- Future-Proofing: acts as a decoupling layer — instead of maintaining individual adapters for every new provider, Forge users can access them immediately
- Compatibility: supports established aggregators (like OpenRouter) as well as direct provider connections (BYOK)

## References

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview
- Main Page: https://www.tensorblock.co/