### PR TITLE
Attempt to load config path from env var if no path provided at runtime

### DIFF
--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -157,7 +157,7 @@ class Config:
     def load_config(cls, config_path: str | None) -> Dict[str, Any]:
         """Load a configuration by name."""
         config_path = config_path or os.environ.get("CONFIG_PATH")
-        if config_path is None:
+        if not config_path:
             return DEFAULT_CONFIG
 
         # config_path = os.path.join(cls.CONFIG_DIR, config_path)


### PR DESCRIPTION
When deploying with Docker, currently it's cumbersome to provide a custom configuration file. The way to do it with no code changes would be to create a `default.py` dictionary and override-mount the existing file in the `/gpt_researcher/config/variables` folder.

This is not optimal, especially since there's already a robust way to load a JSON configuration file when instantiating GPT Researcher from a Python script. Therefore, I propose this minimal alteration:

If no `config_path` is provided at runtime, try loading it from the environment variables.