### PR TITLE
Fix PyMuPDFScraper to extract all PDF pages

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -57,10 +57,15 @@ class PyMuPDFScraper:
                 loader = PyMuPDFLoader(self.link)
                 doc = loader.load()
 
-            # Extract the content, image (if any), and title from the document.
+            # Extract content from all pages, images (if any), and title from the document.
             image = []
-            # Retrieve the content of the first page to minimize embedding costs.
-            return doc[0].page_content, image, doc[0].metadata["title"]
+            # Concatenate all pages to ensure sufficient content for downstream processing.
+            content = "\n\n".join([page.page_content for page in doc])
+
+            # Handle edge case where metadata might be missing
+            title = doc[0].metadata.get("title", "") if doc else ""
+
+            return content, image, title
 
         except requests.exceptions.Timeout:
             print(f"Download timed out. Please check the link : {self.link}")


### PR DESCRIPTION
## Summary
Fixes #1600 - PyMuPDFScraper only reads first page, causing PDFs with cover pages to fail content length checks.

## Changes
- Concatenate ALL pages instead of only the first page
- Use safer metadata access with fallback for missing title
- Handle empty document edge case

## Impact
This fixes the reported 13/19 PDF failure rate for PDFs with cover pages (e.g., ESG reports with minimal cover text).

## Root Cause
The original code only returned `doc[0].page_content`, which for PDFs with cover pages often contains <100 characters, causing downstream validation to reject valid documents.

## Testing
- [ ] Test with multi-page PDFs
- [ ] Test with single-page PDFs  
- [ ] Test with PDFs that have cover pages (<100 chars on first page)

## Checklist
- [x] Code follows project style
- [x] Minimal focused change
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

---
**Note:** This is a draft PR for initial review.
