### PR TITLE
fix: handle list context in deep research to prevent AttributeError

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 # Maximum words allowed in context (25k words for safety margin)
 MAX_CONTEXT_WORDS = 25000
 
-def count_words(text: str) -> int:
-    """Count words in a text string"""
-    return len(text.split())
+def count_words(text) -> int:
+    """Count words in a text string. Handles both strings and lists."""
+    if isinstance(text, list):
+        text = " ".join(str(item) for item in text)
+    return len(str(text).split())
 
 def trim_context_to_word_limit(context_list: List[str], max_words: int = MAX_CONTEXT_WORDS) -> List[str]:
     """Trim context list to stay within word limit while preserving most recent/relevant items"""
@@ -274,7 +276,7 @@ Format each question on a new line starting with 'Question: '"""}
                         'followUpQuestions': results['followUpQuestions'],
                         'researchGoal': serp_query['researchGoal'],
                         'citations': results['citations'],
-                        'context': context if context else "",
+                        'context': "\n".join(context) if isinstance(context, list) else (context or ""),
                         'sources': sources if sources else []
                     }
 


### PR DESCRIPTION
- count_words() now handles both string and list inputs defensively
- context is normalized to string when returned from nested research
- Prevents 'list' object has no attribute 'split' error during recursive deep research when LLM returns unexpected types