### PR TITLE
fix(server): resolve multi-agent run_research_task NameError

### DIFF
--- a/backend/server/multi_agent_runner.py
+++ b/backend/server/multi_agent_runner.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from typing import Any, Awaitable, Callable
+
+RunResearchTask = Callable[..., Awaitable[Any]]
+
+
+def _ensure_repo_root_on_path() -> None:
+    """Ensure top-level repo root is importable for multi-agent modules."""
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+
+
+def _resolve_run_research_task() -> RunResearchTask:
+    _ensure_repo_root_on_path()
+
+    try:
+        from multi_agents.main import run_research_task
+        return run_research_task
+    except Exception:
+        try:
+            from multi_agents_ag2.main import run_research_task
+            return run_research_task
+        except Exception as ag2_error:
+            raise ImportError(
+                "Could not import run_research_task from multi_agents or multi_agents_ag2"
+            ) from ag2_error
+
+
+async def run_multi_agent_task(*args, **kwargs) -> Any:
+    run_research_task = _resolve_run_research_task()
+    return await run_research_task(*args, **kwargs)

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -16,6 +16,8 @@ from fastapi import HTTPException
 import logging
 import hashlib
 
+from .multi_agent_runner import run_multi_agent_task
+
 # Import chat agent
 try:
     import sys
@@ -314,7 +316,7 @@ async def handle_file_deletion(filename: str, DOC_PATH: str) -> JSONResponse:
 async def execute_multi_agents(manager) -> Any:
     websocket = manager.active_connections[0] if manager.active_connections else None
     if websocket:
-        report = await run_research_task("Is AI in a hype cycle?", websocket, stream_output)
+        report = await run_multi_agent_task("Is AI in a hype cycle?", websocket, stream_output)
         return {"report": report}
     else:
         return JSONResponse(status_code=400, content={"message": "No active WebSocket connection"})

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -11,6 +11,7 @@ from report_type import BasicReport, DetailedReport
 
 from gpt_researcher.utils.enum import ReportType, Tone
 from gpt_researcher.actions import stream_output  # Import stream_output
+from .multi_agent_runner import run_multi_agent_task
 from .server_utils import CustomLogsHandler
 
 logger = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ async def run_agent(task, report_type, report_source, source_urls, document_urls
 
     # Initialize researcher based on report type
     if report_type == "multi_agents":
-        report = await run_research_task(
+        report = await run_multi_agent_task(
             query=task, 
             websocket=logs_handler,  # Use logs_handler instead of raw websocket
             stream_output=stream_output, 


### PR DESCRIPTION
## Summary\n- add a dedicated multi-agent task loader for backend server code\n- resolve  dynamically from  or \n- replace direct calls in websocket and utils paths to prevent  in multi-agent mode\n\n## Why\nRailway backend crashes in multi-agent flow with:\n\nThis patch fixes the import resolution at runtime and unblocks WebSocket research tasks.