### PR TITLE
fix: replace 9 bare except clauses with except Exception

### DIFF
--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -92,7 +92,7 @@ class WebSocketManager:
             # Still try to close the connection if possible
             try:
                 await websocket.close()
-            except:
+            except Exception:
                 pass  # If this fails too, there's nothing more we can do
 
     async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[]):

--- a/gpt_researcher/actions/report_generation.py
+++ b/gpt_researcher/actions/report_generation.py
@@ -287,7 +287,7 @@ Place each image on its own line after the relevant section header or paragraph.
             cost_callback=cost_callback,
             **kwargs
         )
-    except:
+    except Exception:
         try:
             report = await create_chat_completion(
                 model=cfg.smart_llm_model,

--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -31,7 +31,7 @@ class BingSearch():
         """
         try:
             api_key = os.environ["BING_API_KEY"]
-        except:
+        except Exception:
             raise Exception(
                 "Bing API key not found. Please set the BING_API_KEY environment variable.")
         return api_key

--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -31,7 +31,7 @@ class GoogleSearch:
         # Get the API key
         try:
             api_key = os.environ["GOOGLE_API_KEY"]
-        except:
+        except Exception:
             raise Exception("Google API key not found. Please set the GOOGLE_API_KEY environment variable. "
                             "You can get a key at https://developers.google.com/custom-search/v1/overview")
         return api_key
@@ -45,7 +45,7 @@ class GoogleSearch:
         # Get the API key
         try:
             api_key = os.environ["GOOGLE_CX_KEY"]
-        except:
+        except Exception:
             raise Exception("Google CX key not found. Please set the GOOGLE_CX_KEY environment variable. "
                             "You can get a key at https://developers.google.com/custom-search/v1/overview")
         return api_key
@@ -93,7 +93,7 @@ class GoogleSearch:
                     "href": result["link"],
                     "body": result["snippet"],
                 }
-            except:
+            except Exception:
                 continue
             search_results.append(search_result)
 

--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -27,7 +27,7 @@ class SearchApiSearch():
         """
         try:
             api_key = os.environ["SEARCHAPI_API_KEY"]
-        except:
+        except Exception:
             raise Exception("SearchApi key not found. Please set the SEARCHAPI_API_KEY environment variable. "
                             "You can get a key at https://www.searchapi.io/")
         return api_key

--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -28,7 +28,7 @@ class SerpApiSearch():
         """
         try:
             api_key = os.environ["SERPAPI_API_KEY"]
-        except:
+        except Exception:
             raise Exception("SerpApi API key not found. Please set the SERPAPI_API_KEY environment variable. "
                             "You can get a key at https://serpapi.com/")
         return api_key

--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -49,7 +49,7 @@ class SerperSearch():
         """
         try:
             api_key = os.environ["SERPER_API_KEY"]
-        except:
+        except Exception:
             raise Exception("Serper API key not found. Please set the SERPER_API_KEY environment variable. "
                             "You can get a key at https://serper.dev/")
         return api_key


### PR DESCRIPTION
## What
Replace 9 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.