### PR TITLE
feat: SearXNG self-hosted search + OPENAI_EMBEDDING_BASE_URL for custom embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@ OPENAI_API_KEY=
 TAVILY_API_KEY=
 DOC_PATH=./my-docs
 
+# ─── Self-hosted search (no API key required) ────────────────────────────────
+# Start SearXNG with: docker compose --profile searxng up -d
+# Then uncomment the lines below:
+# RETRIEVER=searx
+# SEARX_URL=http://searxng:8080   # when using Docker Compose
+# SEARX_URL=http://localhost:4000  # when running gpt-researcher outside Docker
+
 # NEXT_PUBLIC_GPTR_API_URL=http://0.0.0.0:8000  # Defaults to localhost:8000 if not set
 
 # Scraper Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,29 @@
 services:
+  # ─── SearXNG: self-hosted metasearch (no API key required) ───────────────────
+  # Start with: docker compose --profile searxng up -d
+  # Then set RETRIEVER=searx and SEARX_URL=http://searxng:8080 in .env
+  searxng:
+    image: searxng/searxng:latest
+    container_name: searxng
+    restart: unless-stopped
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    ports:
+      - 4000:8080
+    networks:
+      - default
+    profiles: ["searxng"]
+
   gpt-researcher:
     pull_policy: build
     image: gptresearcher/gpt-researcher
     build: ./
-    environment: 
+    environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL}
       TAVILY_API_KEY: ${TAVILY_API_KEY}
+      RETRIEVER: ${RETRIEVER:-tavily}
+      SEARX_URL: ${SEARX_URL:-http://searxng:8080}
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
       LOGGING_LEVEL: INFO
       # Image generation (optional - set to enable inline images in reports)

--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -87,15 +87,19 @@ class Memory:
             case "custom":
                 from langchain_openai import OpenAIEmbeddings
 
+                # Prefer OPENAI_EMBEDDING_BASE_URL so the embedding endpoint
+                # can differ from the LLM endpoint (e.g. TEI vs vLLM).
+                embedding_base_url = os.getenv(
+                    "OPENAI_EMBEDDING_BASE_URL",
+                    os.getenv("OPENAI_BASE_URL", "http://localhost:1234/v1"),
+                )
                 _embeddings = OpenAIEmbeddings(
                     model=model,
                     openai_api_key=os.getenv("OPENAI_API_KEY", "custom"),
-                    openai_api_base=os.getenv(
-                        "OPENAI_BASE_URL", "http://localhost:1234/v1"
-                    ),  # default for lmstudio
+                    openai_api_base=embedding_base_url,
                     check_embedding_ctx_length=False,
                     **embedding_kwargs,
-                )  # quick fix for lmstudio
+                )
             case "openai":
                 from langchain_openai import OpenAIEmbeddings
 

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -1,0 +1,55 @@
+# SearXNG configuration for GPT-Researcher integration
+# Docs: https://docs.searxng.org/admin/settings/index.html
+
+use_default_settings: true
+
+general:
+  debug: false
+  instance_name: "gptr-searxng"
+  privacypolicy_url: false
+  donation_url: false
+  contact_url: false
+  enable_metrics: false
+
+server:
+  # Secret key — change this to a random string in production
+  secret_key: "gptr-local-dev-secret-change-me"
+  bind_address: "0.0.0.0"
+  port: 8080
+  base_url: false
+  limiter: false
+  public_instance: false
+
+ui:
+  static_use_hash: false
+  default_locale: "en"
+  query_in_title: false
+  infinite_scroll: false
+  default_theme: simple
+
+# Enable JSON output — REQUIRED for GPT-Researcher API use
+search:
+  safe_search: 0
+  autocomplete: ""
+  default_lang: "en-US"
+  formats:
+    - html
+    - json      # ← Required by GPT-Researcher
+
+# Enable search engines
+engines:
+  - name: google
+    engine: google
+    use_mobile_ui: false
+    disabled: false
+    weight: 2
+
+  - name: bing
+    engine: bing
+    disabled: false
+    weight: 1
+
+  - name: duckduckgo
+    engine: duckduckgo
+    disabled: false
+    weight: 1


### PR DESCRIPTION
## Summary

Two additions for users who want to avoid paid external APIs:

### 1. SearXNG as a self-hosted search backend (no API key required)

GPT-Researcher already supports `RETRIEVER=searx`, but running SearXNG alongside required manual Docker setup. This PR adds it as a first-class `--profile searxng` option in `docker-compose.yml`.

```bash
# Start with self-hosted search (no Tavily key needed)
docker compose --profile searxng up -d
```

Then in `.env`:
```env
RETRIEVER=searx
SEARX_URL=http://searxng:8080
```

**What's included:**
- `searxng` service in `docker-compose.yml` under `--profile searxng`
- `searxng/settings.yml` with JSON format enabled (required by the `searx` retriever) and sensible defaults for Google, Bing, and DuckDuckGo
- `RETRIEVER` and `SEARX_URL` forwarded to the `gpt-researcher` service
- Default remains `RETRIEVER=tavily` — no breaking change for existing users

SearXNG aggregates results from multiple engines without any per-query API costs, making it ideal for local/private deployments.

### 2. `OPENAI_EMBEDDING_BASE_URL` for the `custom` embedding provider

When running a dedicated embedding service (e.g. [HuggingFace TEI](https://github.com/huggingface/text-embeddings-inference), [Infinity](https://github.com/michaelfeil/infinity)) alongside a separate LLM API, a single `OPENAI_BASE_URL` can't address both endpoints.

The `custom` embedding provider now checks `OPENAI_EMBEDDING_BASE_URL` first, falling back to `OPENAI_BASE_URL` and then the LM Studio default:

```env
OPENAI_BASE_URL=http://localhost:8000/v1        # LLM endpoint
OPENAI_EMBEDDING_BASE_URL=http://localhost:8080/v1  # Embedding endpoint
EMBEDDING=custom:BAAI/bge-large-en-v1.5
```

No behaviour change when `OPENAI_EMBEDDING_BASE_URL` is unset.

## Test plan

- [ ] `docker compose --profile searxng up -d` starts SearXNG on port 4000
- [ ] `curl "http://localhost:4000/search?q=test&format=json"` returns JSON results
- [ ] `RETRIEVER=searx SEARX_URL=http://localhost:4000` produces research results
- [ ] `RETRIEVER=tavily` (default) still works — no regression
- [ ] Setting `OPENAI_EMBEDDING_BASE_URL` routes custom embeddings to the specified endpoint
- [ ] Omitting `OPENAI_EMBEDDING_BASE_URL` falls back to `OPENAI_BASE_URL` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)