### PR TITLE
fix: nodriver scraper Docker compatibility and browser pool deadlock

### DIFF
--- a/gpt_researcher/scraper/browser/nodriver_scraper.py
+++ b/gpt_researcher/scraper/browser/nodriver_scraper.py
@@ -15,8 +15,8 @@ from ..utils import get_relevant_images, extract_title, get_text_from_soup, clea
 
 class NoDriverScraper:
     logger = logging.getLogger(__name__)
-    max_browsers = 3
-    browser_load_threshold = 5
+    max_browsers = 5
+    browser_load_threshold = 8
     browsers: set["NoDriverScraper.Browser"] = set()
     browsers_lock = asyncio.Lock()
 
@@ -147,7 +147,7 @@ class NoDriverScraper:
 
             config = zendriver.Config(
                 headless=headless,
-                browser_connection_timeout=1,
+                browser_connection_timeout=10,
             )
             driver = await zendriver.start(config)
             browser = cls.Browser(driver)
@@ -206,6 +206,12 @@ class NoDriverScraper:
                 return str(e), [], ""
 
             page = await browser.get(self.url)
+            if page is None:
+                # browser.get() increments processing_count before returning;
+                # a None result means the connection timed out. Decrement to
+                # avoid leaking the slot and deadlocking the browser pool.
+                browser.processing_count -= 1
+                return "Browser failed to open page (returned None)", [], ""
             await browser.wait_or_timeout(page, "complete", 2)
             # wait for potential redirection
             await page.sleep(random.uniform(0.3, 0.7))


### PR DESCRIPTION
## Summary

Three targeted fixes to `NoDriverScraper` for containerised and concurrent workloads:

### 1. `browser_connection_timeout` 1 → 10 s

Chrome's CDP socket takes 3-8 s to become available when running as root in a Docker container. The 1 s default causes an immediate timeout even when Chrome started successfully, making the scraper silently fail in **every Docker deployment**.

### 2. `max_browsers` 3 → 5 / `browser_load_threshold` 5 → 8

Deep research spawns several concurrent sub-researchers, each issuing scrape requests simultaneously. The previous pool limits caused unnecessary browser creation/teardown churn under load. Raising them lets the pool absorb concurrent deep-research workloads without thrashing.

### 3. Guard against `browser.get()` returning `None` (deadlock fix)

When the CDP connection times out, `browser.get()` can return `None` instead of raising an exception. Two problems follow:

- The caller crashes with `AttributeError: 'NoneType' object has no attribute 'wait'`
- More critically: `browser.get()` already **incremented `processing_count`** before returning. Without the guard, that slot is never released — eventually deadlocking the entire pool (no new browsers can be acquired and existing ones appear permanently busy).

The fix decrements `processing_count` and returns a safe error tuple when `page is None`.

## Files changed

- `gpt_researcher/scraper/browser/nodriver_scraper.py` — 9 lines changed

## Test plan

- [ ] `docker compose up -d` + research query — scraper completes instead of timing out immediately
- [ ] Deep research with breadth=4, depth=2 — browser pool handles concurrent sub-researchers without deadlock
- [ ] Non-Docker (local) usage — no regression, timeout increase is invisible when Chrome starts fast

Fixes the class of errors reported in #1602 (concurrent scraper failures under deep research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)