### PR TITLE
feat: add Avian as LLM provider

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -379,6 +379,25 @@ STRATEGIC_LLM="aimlapi:x-ai/grok-3-mini-beta"
 EMBEDDING="aimlapi:text-embedding-3-small"
 ```
 
+## Avian
+
+[Avian](https://avian.io) provides an OpenAI-compatible API with access to cost-effective frontier models including DeepSeek-V3.2, Kimi-K2.5, GLM-5, and MiniMax-M2.5.
+
+Sign up at [avian.io](https://avian.io) to get an API key, then set the following environment variables:
+
+```env
+AVIAN_API_KEY=[Your Key]
+FAST_LLM=avian:deepseek/deepseek-v3.2
+SMART_LLM=avian:moonshotai/kimi-k2.5
+STRATEGIC_LLM=avian:z-ai/glm-5
+```
+
+Available models:
+- `deepseek/deepseek-v3.2` — 164K context, $0.26/$0.38 per 1M tokens
+- `moonshotai/kimi-k2.5` — 131K context, $0.45/$2.20 per 1M tokens
+- `z-ai/glm-5` — 131K context, $0.30/$2.55 per 1M tokens
+- `minimax/minimax-m2.5` — 1M context, $0.30/$1.10 per 1M tokens
+
 ## vLLM
 ```env
 VLLM_OPENAI_API_KEY=[Your Key] # you can set this to 'EMPTY' or anything

--- a/docs/docs/gpt-researcher/llms/supported-llms.md
+++ b/docs/docs/gpt-researcher/llms/supported-llms.md
@@ -22,6 +22,7 @@ The following LLMs are supported by GPTR (though you'll need to install the rele
 - litellm
 - openrouter
 - forge
+- avian
 - vllm
 
 If you'd like to know the name of the langchain package for each LLM, you can check the [Langchain documentation](https://python.langchain.com/v0.2/docs/integrations/platforms/), or run GPTR as is and inspect the error message.

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -34,6 +34,7 @@ _SUPPORTED_PROVIDERS = {
     "aimlapi",
     "netmind",
     "forge",
+    "avian",
 }
 
 NO_SUPPORT_TEMPERATURE_MODELS = [
@@ -248,6 +249,14 @@ class GenericLLMProvider:
 
             llm = ChatOpenAI(openai_api_base='https://api.forge.tensorblock.co/v1',
                      openai_api_key=os.environ["FORGE_API_KEY"],
+                     **kwargs
+                )
+        elif provider == "avian":
+            _check_pkg("langchain_openai")
+            from langchain_openai import ChatOpenAI
+
+            llm = ChatOpenAI(openai_api_base='https://api.avian.io/v1',
+                     openai_api_key=os.environ["AVIAN_API_KEY"],
                      **kwargs
                 )
         elif provider == 'netmind':


### PR DESCRIPTION
## Summary
- Adds [Avian](https://avian.io) as a new LLM provider using the OpenAI-compatible API pattern
- Avian provides cost-effective access to frontier models via a single OpenAI-compatible endpoint (`https://api.avian.io/v1`)
- Uses `AVIAN_API_KEY` env var for authentication, following the same convention as other providers

## Available Models
| Model | Context | Max Output | Input/Output Price (per 1M tokens) |
|-------|---------|------------|-------------------------------------|
| `deepseek/deepseek-v3.2` | 164K | 65K | $0.26 / $0.38 |
| `moonshotai/kimi-k2.5` | 131K | 8K | $0.45 / $2.20 |
| `z-ai/glm-5` | 131K | 16K | $0.30 / $2.55 |
| `minimax/minimax-m2.5` | 1M | 1M | $0.30 / $1.10 |

## Usage
```env
AVIAN_API_KEY=[Your Key]
FAST_LLM=avian:deepseek/deepseek-v3.2
SMART_LLM=avian:moonshotai/kimi-k2.5
STRATEGIC_LLM=avian:z-ai/glm-5
```

## Changes
- `gpt_researcher/llm_provider/generic/base.py` — Added `"avian"` to `_SUPPORTED_PROVIDERS` and `elif` branch using `ChatOpenAI` with Avian base URL
- `docs/docs/gpt-researcher/llms/llms.md` — Added Avian configuration section with model details and pricing
- `docs/docs/gpt-researcher/llms/supported-llms.md` — Added `avian` to the supported providers list

## Test plan
- [ ] Set `AVIAN_API_KEY` and `FAST_LLM=avian:deepseek/deepseek-v3.2`, run `python tests/test-your-llm.py`
- [ ] Verify chat completion and streaming work end-to-end
- [ ] Confirm the provider correctly rejects missing `AVIAN_API_KEY` with a clear error

cc @assafelovic @rotemweiss57