### PR TITLE
docs: fix invalid Discord invite link in LLM docs

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -10,7 +10,7 @@ Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_ver
 To learn more about support customization options see [here](/docs/gpt-researcher/gptr/config).
 
 **Please note**: GPT Researcher is optimized and heavily tested on GPT models. Some other models might run into context limit errors, and unexpected responses.
-Please provide any feedback in our [Discord community](https://discord.gg/DUmbTebB) channel, so we can better improve the experience and performance.
+Please provide any feedback in our [Discord community](https://discord.gg/QgZXvJAccX) channel, so we can better improve the experience and performance.
 
 Below you can find examples for how to configure the various supported LLMs.
 


### PR DESCRIPTION
## Summary
Replace the expired Discord invite link in the LLM documentation page.

## Changes
- Updated `docs/docs/gpt-researcher/llms/llms.md`: replaced the invalid invite code `DUmbTebB` (returns 404) with the current valid one `QgZXvJAccX`.

## Verification
```bash
# Old link - 404
curl -s -o /dev/null -w '%{http_code}' 'https://discord.com/api/v9/invites/DUmbTebB'
# 404

# New link - 200
curl -s -o /dev/null -w '%{http_code}' 'https://discord.com/api/v9/invites/QgZXvJAccX'
# 200
```

Fixes #1474