### PR TITLE
fix: invalidate import caches after runtime package install

### DIFF
--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -96,6 +96,7 @@ class Scraper:
                 subprocess.check_call(
                     [sys.executable, "-m", "pip", "install", pkg_inst_name]
                 )
+                importlib.invalidate_caches()
                 print(Fore.GREEN + f"{pkg_inst_name} installed successfully.")
             except subprocess.CalledProcessError:
                 raise ImportError(


### PR DESCRIPTION
## Summary
Fix the runtime package installation fallback in `_check_pkg` so that dynamically installed packages can be imported.

## Problem
When `SCRAPER=tavily_extract` is configured in Docker, `_check_pkg` correctly installs `tavily-python` via subprocess pip, but the running Python process's import finder caches are stale. The subsequent `from tavily import TavilyClient` fails with `ModuleNotFoundError` even though pip reported success.

## Fix
Add `importlib.invalidate_caches()` after the subprocess pip install completes, so the import system discovers the newly installed package.

## Changed Files
- `gpt_researcher/scraper/scraper.py`: Added `importlib.invalidate_caches()` after successful pip install in `_check_pkg()`.

Fixes #1625