### PR TITLE
fix: fallback to OPENAI_API_VERSION for Azure embeddings

### DIFF
--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -111,7 +111,10 @@ class Memory:
                     model=model,
                     azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
                     openai_api_key=os.environ["AZURE_OPENAI_API_KEY"],
-                    openai_api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+                    openai_api_version=os.environ.get(
+                        "AZURE_OPENAI_API_VERSION",
+                        os.environ.get("OPENAI_API_VERSION"),
+                    ),
                     **embedding_kwargs,
                 )
             case "cohere":


### PR DESCRIPTION
## Summary
Fix `KeyError: 'AZURE_OPENAI_API_VERSION'` when using Azure OpenAI embeddings.

## Problem
The documentation instructs users to set `OPENAI_API_VERSION`, but `embeddings.py` reads `os.environ["AZURE_OPENAI_API_VERSION"]` which raises `KeyError` if only `OPENAI_API_VERSION` is set.

## Fix
Changed to `os.environ.get()` with fallback chain: `AZURE_OPENAI_API_VERSION` → `OPENAI_API_VERSION`. Both env var names now work.

## Changed Files
- `gpt_researcher/memory/embeddings.py`: Use `os.environ.get()` with fallback for the API version parameter.

Fixes #1469