### PR TITLE
fix: increase PyMuPDF download timeout and add SSL fallback

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -41,8 +41,16 @@ class PyMuPDFScraper:
         """
         try:
             if self.is_url():
-                response = requests.get(self.link, timeout=5, stream=True)
-                response.raise_for_status()
+                try:
+                    response = requests.get(self.link, timeout=(5, 30), stream=True)
+                    response.raise_for_status()
+                except requests.exceptions.SSLError:
+                    import logging
+                    logging.getLogger(__name__).warning(
+                        f"SSL verification failed for {self.link}, retrying without verification"
+                    )
+                    response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
+                    response.raise_for_status()
 
                 with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
                     temp_filename = temp_file.name  # Get the temporary file name


### PR DESCRIPTION
## Summary
Fix two network-related issues in `PyMuPDFScraper` that cause PDF downloads to fail silently.

## Problem
1. **Timeout too short**: `timeout=5` is a single value that limits the entire download. Large PDFs (10-21MB) exceed this.
2. **SSL verification failures**: Corporate/government sites with misconfigured SSL certificates cause `SSLCertVerificationError`.

## Fix
- Changed `timeout=5` to `timeout=(5, 30)` — 5s connect timeout, 30s read timeout.
- Added SSL fallback: tries with verification first, on `SSLError` retries with `verify=False` and logs a warning.

## Changed Files
- `gpt_researcher/scraper/pymupdf/pymupdf.py`: Updated `requests.get()` call with proper timeout tuple and SSL error handling.

Fixes #1601