### PR TITLE
fix: use all configured retrievers in deep research planning

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -98,13 +98,19 @@ class DeepResearchSkill:
 
     async def generate_research_plan(self, query: str, num_questions: int = 3) -> List[str]:
         """Generate follow-up questions to clarify research direction"""
-        # Get initial search results to inform query generation
-        # Pass the researcher so MCP retriever receives cfg and mcp_configs
-        search_results = await get_search_results(
-            query,
-            self.researcher.retrievers[0],
-            researcher=self.researcher
-        )
+        # Get initial search results from all retrievers to inform query generation
+        all_search_results = []
+        for retriever in self.researcher.retrievers:
+            try:
+                results = await get_search_results(
+                    query,
+                    retriever,
+                    researcher=self.researcher
+                )
+                all_search_results.extend(results)
+            except Exception as e:
+                logger.warning(f"Error with retriever {retriever.__name__}: {e}")
+        search_results = all_search_results
         logger.info(f"Initial web knowledge obtained: {len(search_results)} results")
 
         # Get current time for context


### PR DESCRIPTION
## Summary
Fix `generate_research_plan` in deep research mode to use all configured retrievers instead of only the first one.

## Problem
In `deep_research.py`, the `generate_research_plan` method used `self.researcher.retrievers[0]`, which ignores any additional configured retrievers. This means the initial context used to generate follow-up questions only reflects results from one retriever.

## Fix
Iterate through all retrievers in `self.researcher.retrievers`, aggregate search results, and use the combined results for planning. Each retriever call is wrapped in a try/except to handle failures gracefully.

## Changed Files
- `gpt_researcher/skills/deep_research.py`: Updated `generate_research_plan` to iterate through all retrievers.

Fixes #1574