### PR TITLE
fix: add table styles to FastAPI frontend report container

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -301,6 +301,30 @@ footer a:hover {
     font-style: italic;
 }
 
+#reportContainer table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1em 0;
+    overflow-x: auto;
+    display: block;
+}
+
+#reportContainer th,
+#reportContainer td {
+    border: 1px solid #444;
+    padding: 8px 12px;
+    text-align: left;
+}
+
+#reportContainer th {
+    background-color: rgba(255, 255, 255, 0.08);
+    font-weight: bold;
+}
+
+#reportContainer tr:nth-child(even) {
+    background-color: rgba(255, 255, 255, 0.03);
+}
+
 .tags-input {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
Add CSS styles for Markdown tables in the FastAPI frontend report view.

## Problem
The showdown Markdown converter is configured with `tables: true`, so it correctly generates `<table>` HTML elements. However, the CSS had no styles for `table`, `th`, `td`, or `tr` elements inside `#reportContainer`, so tables rendered without borders, padding, or visual structure.

## Fix
Added table styles to `frontend/styles.css` scoped under `#reportContainer`:
- `border-collapse: collapse` with 1px borders on cells
- Padding for readability
- Subtle header and striped row backgrounds for contrast
- `overflow-x: auto` with `display: block` for wide tables

## Changed Files
- `frontend/styles.css`: Added table styling rules for `#reportContainer`.

Fixes #1578