### PR TITLE
feat: add scrape count option to FastAPI frontend

### DIFF
--- a/backend/report_type/basic_report/basic_report.py
+++ b/backend/report_type/basic_report/basic_report.py
@@ -21,6 +21,7 @@ class BasicReport:
         headers=None,
         mcp_configs=None,
         mcp_strategy=None,
+        max_search_results=None,
     ):
         self.query = query
         self.query_domains = query_domains
@@ -57,6 +58,10 @@ class BasicReport:
             gpt_researcher_params["mcp_strategy"] = mcp_strategy
 
         self.gpt_researcher = GPTResearcher(**gpt_researcher_params)
+
+        # Override max_search_results_per_query if provided by user
+        if max_search_results is not None:
+            self.gpt_researcher.cfg.max_search_results_per_query = int(max_search_results)
 
     def _generate_research_id(self, query: str) -> str:
         """Generate a unique research ID from query and timestamp."""

--- a/backend/report_type/detailed_report/detailed_report.py
+++ b/backend/report_type/detailed_report/detailed_report.py
@@ -24,6 +24,7 @@ class DetailedReport:
         complement_source_urls: bool = False,
         mcp_configs=None,
         mcp_strategy=None,
+        max_search_results=None,
     ):
         self.query = query
         self.report_type = report_type
@@ -37,6 +38,7 @@ class DetailedReport:
         self.subtopics = subtopics
         self.headers = headers or {}
         self.complement_source_urls = complement_source_urls
+        self.max_search_results = max_search_results
         
         # Generate a unique research ID for this report
         self.research_id = self._generate_research_id(query)
@@ -63,6 +65,10 @@ class DetailedReport:
             gpt_researcher_params["mcp_strategy"] = mcp_strategy
 
         self.gpt_researcher = GPTResearcher(**gpt_researcher_params)
+
+        # Override max_search_results_per_query if provided by user
+        if max_search_results is not None:
+            self.gpt_researcher.cfg.max_search_results_per_query = int(max_search_results)
         self.existing_headers: List[Dict] = []
         self.global_context: List[str] = []
         self.global_written_sections: List[str] = []
@@ -134,6 +140,10 @@ class DetailedReport:
             mcp_configs=self.gpt_researcher.mcp_configs,
             mcp_strategy=self.gpt_researcher.mcp_strategy
         )
+
+        # Propagate max_search_results override to subtopic researcher
+        if self.max_search_results is not None:
+            subtopic_assistant.cfg.max_search_results_per_query = int(self.max_search_results)
 
         subtopic_assistant.context = list(set(self.global_context))
         await subtopic_assistant.conduct_research()

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -137,6 +137,7 @@ async def handle_start_command(websocket, data: str, manager):
         mcp_enabled,
         mcp_strategy,
         mcp_configs,
+        max_search_results,
     ) = extract_command_data(json_data)
 
     if not task or not report_type:
@@ -168,6 +169,7 @@ async def handle_start_command(websocket, data: str, manager):
         mcp_enabled,
         mcp_strategy,
         mcp_configs,
+        max_search_results,
     )
     report = str(report)
     file_paths = await generate_report_files(report, sanitized_filename)
@@ -406,4 +408,5 @@ def extract_command_data(json_data: Dict) -> tuple:
         json_data.get("mcp_enabled", False),
         json_data.get("mcp_strategy", "fast"),
         json_data.get("mcp_configs", []),
+        json_data.get("max_search_results"),
     )

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -96,7 +96,7 @@ class WebSocketManager:
             except Exception:
                 pass  # If this fails too, there's nothing more we can do
 
-    async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[]):
+    async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None):
         """Start streaming the output."""
         tone = Tone[tone]
         # add customized JSON config file path here
@@ -106,11 +106,12 @@ class WebSocketManager:
         report = await run_agent(
             task, report_type, report_source, source_urls, document_urls, tone, websocket, 
             headers=headers, query_domains=query_domains, config_path=config_path,
-            mcp_enabled=mcp_enabled, mcp_strategy=mcp_strategy, mcp_configs=mcp_configs
+            mcp_enabled=mcp_enabled, mcp_strategy=mcp_strategy, mcp_configs=mcp_configs,
+            max_search_results=max_search_results
         )
         return report
 
-async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False, mcp_enabled=False, mcp_strategy="fast", mcp_configs=[]):
+async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False, mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None):
     """Run the agent."""    
     # Create logs handler for this research task
     logs_handler = CustomLogsHandler(websocket, task)
@@ -158,6 +159,7 @@ async def run_agent(task, report_type, report_source, source_urls, document_urls
             headers=headers,
             mcp_configs=mcp_configs if mcp_enabled else None,
             mcp_strategy=mcp_strategy if mcp_enabled else None,
+            max_search_results=max_search_results,
         )
         report = await researcher.run()
         
@@ -175,6 +177,7 @@ async def run_agent(task, report_type, report_source, source_urls, document_urls
             headers=headers,
             mcp_configs=mcp_configs if mcp_enabled else None,
             mcp_strategy=mcp_strategy if mcp_enabled else None,
+            max_search_results=max_search_results,
         )
         report = await researcher.run()
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -222,6 +222,11 @@
                 </select>
             </div>
             <div class="form-group">
+                <label for="maxSearchResults" class="agent-question">How many websites should be scraped per query?</label>
+                <input type="number" class="form-control highlight-connection" id="maxSearchResults" name="max_search_results" min="1" max="20" value="5">
+                <small class="text-muted">Controls the number of websites scraped per search query (default: 5)</small>
+            </div>
+            <div class="form-group">
                 <label for="queryDomains" class="form-label">Query Domains (Optional)</label>
                 <input type="text" class="form-control highlight-connection" id="queryDomains" name="query_domains" placeholder="Enter domains separated by commas" autocomplete="on">
                 <small class="text-muted">Example: techcrunch.com, forbes.com</small>

--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -985,6 +985,7 @@ const GPTResearcher = (() => {
         tone: tone,
         agent: agent,
         query_domains: query_domains,
+        max_search_results: parseInt(document.getElementById('maxSearchResults').value, 10) || 5,
       }
 
       // Add MCP configuration if enabled


### PR DESCRIPTION
## Summary

Add a user-facing option in the FastAPI frontend to control the number of websites scraped per search query, addressing the request for customizable scraping depth.

## Changes

### Frontend
- **`frontend/index.html`**: Added a numeric input field (`min=1, max=20, default=5`) labeled "How many websites should be scraped per query?" between the report source selector and query domains input
- **`frontend/scripts.js`**: Read the input value and include `max_search_results` in the WebSocket `requestData`

### Backend
- **`backend/server/server_utils.py`**: Extract `max_search_results` from the WebSocket JSON data via `extract_command_data`
- **`backend/server/websocket_manager.py`**: Thread `max_search_results` through `start_streaming` → `run_agent` → report constructors
- **`backend/report_type/basic_report/basic_report.py`**: Accept `max_search_results` and override `cfg.max_search_results_per_query` on the GPTResearcher instance
- **`backend/report_type/detailed_report/detailed_report.py`**: Same override, plus propagation to subtopic researchers

## How it works

The new numeric input defaults to 5 (matching the existing `MAX_SEARCH_RESULTS_PER_QUERY` default). When a user changes it, the value is sent through WebSocket and applied as a runtime override to `cfg.max_search_results_per_query` after the researcher is initialized. This means:
- Environment variable / config file settings still work as defaults
- The frontend value overrides them for that specific research session
- Fully backward-compatible: if the field is not sent (e.g., API calls), the config default is used

Fixes #1504