### PR TITLE
feat: add pondering questions section to FastAPI frontend

### DIFF
--- a/frontend/scripts.js
+++ b/frontend/scripts.js
@@ -868,6 +868,9 @@ const GPTResearcher = (() => {
       updateWebSocketStatus();
 
       if (data.type === 'logs') {
+        if (data.content === 'subqueries' && data.metadata && Array.isArray(data.metadata)) {
+          displaySubQuestions(data.metadata)
+        }
         addAgentResponse(data)
       } else if (data.type === 'images') {
         console.log("Received images:", data);  // Debug log
@@ -1041,6 +1044,31 @@ const GPTResearcher = (() => {
     responseDiv.className = 'agent_response';
     responseDiv.innerHTML = data.output; // Assuming data.output is safe HTML or simple text from agent
     output.appendChild(responseDiv);
+    output.scrollTop = output.scrollHeight;
+    output.style.display = 'block';
+  }
+
+  const displaySubQuestions = (questions) => {
+    const output = document.getElementById('output');
+    const container = document.createElement('div');
+    container.className = 'sub-questions';
+
+    const heading = document.createElement('p');
+    heading.className = 'sub-questions-heading';
+    heading.textContent = '🤔 Pondering your question from several angles';
+    container.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'sub-questions-list';
+    questions.forEach((q) => {
+      const pill = document.createElement('span');
+      pill.className = 'sub-question-pill';
+      pill.textContent = q;
+      list.appendChild(pill);
+    });
+    container.appendChild(list);
+
+    output.appendChild(container);
     output.scrollTop = output.scrollHeight;
     output.style.display = 'block';
   }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -240,6 +240,36 @@ footer a:hover {
     animation: fadeIn 0.5s ease;
 }
 
+.sub-questions {
+    margin: 10px;
+    padding: 12px 16px;
+    border-radius: 12px;
+    background-color: rgba(152, 103, 240, 0.12);
+    border: 1px solid rgba(152, 103, 240, 0.25);
+    animation: fadeIn 0.5s ease;
+}
+
+.sub-questions-heading {
+    font-weight: bold;
+    margin: 0 0 10px 0;
+    font-size: 0.95rem;
+}
+
+.sub-questions-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.sub-question-pill {
+    display: inline-block;
+    padding: 6px 14px;
+    border-radius: 20px;
+    border: 1px solid rgba(193, 193, 193, 0.4);
+    background-color: rgba(255, 255, 255, 0.08);
+    font-size: 0.85rem;
+}
+
 @keyframes fadeIn {
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary

Add a "pondering questions" section to the FastAPI frontend that displays sub-queries generated during research, bringing feature parity with the Next.js frontend.

## Changes

### `frontend/scripts.js`
- Added check in the WebSocket message handler: when a `logs` message has `content === 'subqueries'` and a `metadata` array, call the new `displaySubQuestions()` function
- Added `displaySubQuestions(questions)` function that renders a visually distinct container with pill-shaped tags for each sub-query

### `frontend/styles.css`
- Added `.sub-questions` container styles (subtle purple-tinted background to distinguish from regular logs)
- Added `.sub-questions-heading` for the "Pondering your question from several angles" title
- Added `.sub-questions-list` flex container and `.sub-question-pill` rounded tags

## How it works

The backend already sends sub-queries via WebSocket as:
```json
{"type": "logs", "content": "subqueries", "output": "🗂️ ...", "metadata": ["query1", "query2", ...]}
```

The FastAPI frontend previously treated all `type: logs` messages identically. Now it detects the `subqueries` content type and renders the metadata array as pondering question pills, matching the Next.js frontend's `SubQuestions` component behavior.

Fixes #1503