### PR TITLE
fix: dynamically retrieve agent role if missing in ReportGenerator

### DIFF
--- a/gpt_researcher/skills/writer.py
+++ b/gpt_researcher/skills/writer.py
@@ -94,6 +94,8 @@ class ReportGenerator:
             )
 
         report_params = self.research_params.copy()
+        if not report_params["agent_role_prompt"]:
+            report_params["agent_role_prompt"] = self.researcher.cfg.agent_role or self.researcher.role
         report_params["context"] = context
         report_params["custom_prompt"] = custom_prompt
         report_params["available_images"] = available_images  # Pass pre-generated images


### PR DESCRIPTION
## Summary
This PR fixes a bug where the dynamically selected expert role (via `choose_agent`) was being ignored during the final report generation phase, leading to generic report outputs.

## The Problem
Currently, `ReportGenerator` initializes its `research_params` dictionary during the `GPTResearcher.__init__` call. At this early stage, `self.researcher.role` is typically `None`. When the research process later determines a professional role (e.g., "Finance Agent"), the `ReportGenerator` continues to use the stale `None` value, causing the final report to lose its professional tone.

## The Solution
Implemented a defensive check in `ReportGenerator.write_report`. If the `agent_role_prompt` is missing or `None`, the system dynamically pulls the latest role from the parent `researcher` instance.

## Benefits
- **Consistency**: Aligns the writing phase with the expert curation phase.
- **Robustness**: Prevents generic output when no role is provided at initialization.
- **Verification**: Confirmed that this specific issue has not been addressed in existing PRs like #534 or #1048.