### PR TITLE
fix: improve retry handling in create_chat_completion

### DIFF
--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
+import asyncio
 
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import PromptTemplate
@@ -97,10 +98,32 @@ async def create_chat_completion(
     provider = get_llm(llm_provider, **provider_kwargs)
     response = ""
     # create response
-    for _ in range(10):  # maximum of 10 attempts
-        response = await provider.get_chat_response(
-            messages, stream, websocket, **kwargs
-        )
+    max_attempts = 1 if (stream and websocket is not None) else 10
+    last_exception: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = await provider.get_chat_response(
+                messages, stream, websocket, **kwargs
+            )
+        except Exception as exc:
+            last_exception = exc
+            logging.getLogger(__name__).warning(
+                f"LLM request failed (attempt {attempt}/{max_attempts}): {exc}"
+            )
+            if attempt < max_attempts:
+                await asyncio.sleep(min(2 ** (attempt - 1), 8))
+                continue
+            break
+
+        if not response:
+            last_exception = RuntimeError("Empty response from LLM provider")
+            logging.getLogger(__name__).warning(
+                f"LLM returned empty response (attempt {attempt}/{max_attempts})"
+            )
+            if attempt < max_attempts:
+                await asyncio.sleep(min(2 ** (attempt - 1), 8))
+                continue
+            break
 
         if cost_callback:
             llm_costs = estimate_llm_cost(str(messages), response)
@@ -109,7 +132,7 @@ async def create_chat_completion(
         return response
 
     logging.error(f"Failed to get response from {llm_provider} API")
-    raise RuntimeError(f"Failed to get response from {llm_provider} API")
+    raise RuntimeError(f"Failed to get response from {llm_provider} API") from last_exception
 
 
 async def construct_subtopics(


### PR DESCRIPTION
## Summary
This PR fixes the retry behavior in `create_chat_completion` in `gpt_researcher/utils/llm.py`.

## Changes
- add actual retry handling for exceptions raised by `provider.get_chat_response(...)`
- retry when the LLM provider returns an empty response
- add exponential backoff between retry attempts
- limit retries to a single attempt for streaming websocket requests
- preserve the last exception when raising the final `RuntimeError`

## Why
The previous implementation used a retry loop, but it returned immediately after the first successful call and did not actually retry request failures unless exceptions were explicitly handled. As a result, transient provider or network errors were not retried as intended.

## Issue
Fixes #1663