### PR TITLE
#1673: Fixed the reference error in code.

### DIFF
--- a/multi_agents/main.py
+++ b/multi_agents/main.py
@@ -33,7 +33,7 @@ def open_task():
         model_name = strategic_llm.split(":", 1)[1]
         task["model"] = model_name
     elif strategic_llm:
-        task["model"] = model_name
+        task["model"] = strategic_llm
 
     return task
 


### PR DESCRIPTION
Fix model_name NameError in open_task

This PR fixes a bug where the open_task function could raise a NameError when the STRATEGIC_LLM environment variable is set without a provider prefix (e.g., "gpt-4o").

Previously, the code attempted to use model_name in an elif block even when it was never defined, causing the application to crash.

This update ensures that the value of STRATEGIC_LLM is handled safely and correctly assigned to task["model"] even when no provider prefix (provider:model) is provided.