### PR TITLE
feat: add MiniMax as a native LLM and embedding provider (M2.7)

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -3,7 +3,7 @@
 As described in the [introduction](/docs/gpt-researcher/gptr/config), the default LLM and embedding is OpenAI due to its superior performance and speed. 
 With that said, GPT Researcher supports various open/closed source LLMs and embeddings, and you can easily switch between them by updating the `SMART_LLM`, `FAST_LLM` and `EMBEDDING` env variables. You might also need to include the provider API key and corresponding configuration params.
 
-Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `groq`, `bedrock` and `litellm`.
+Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `groq`, `bedrock`, `litellm` and `minimax`.
 
 Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `nomic` ,`voyageai` and `bedrock`.
 
@@ -378,6 +378,25 @@ SMART_LLM="aimlapi:openai/o4-mini-2025-04-16"
 STRATEGIC_LLM="aimlapi:x-ai/grok-3-mini-beta"
 EMBEDDING="aimlapi:text-embedding-3-small"
 ```
+
+## MiniMax
+
+[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. MiniMax-M2.5 features a 204K context window and competitive pricing.
+
+Sign up at [minimaxi.com](https://www.minimaxi.com) to get an API key, then set the following environment variables:
+
+```env
+MINIMAX_API_KEY=[Your Key]
+FAST_LLM=minimax:MiniMax-M2.5-highspeed
+SMART_LLM=minimax:MiniMax-M2.5
+STRATEGIC_LLM=minimax:MiniMax-M2.5
+
+EMBEDDING=minimax:embo-01
+```
+
+Available models:
+- `MiniMax-M2.5` — 204K context, high-quality general-purpose model
+- `MiniMax-M2.5-highspeed` — 204K context, optimized for speed
 
 ## Avian
 

--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -381,21 +381,23 @@ EMBEDDING="aimlapi:text-embedding-3-small"
 
 ## MiniMax
 
-[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. MiniMax-M2.5 features a 204K context window and competitive pricing.
+[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. The latest MiniMax-M2.7 features improved reasoning and competitive pricing.
 
 Sign up at [minimaxi.com](https://www.minimaxi.com) to get an API key, then set the following environment variables:
 
 ```env
 MINIMAX_API_KEY=[Your Key]
-FAST_LLM=minimax:MiniMax-M2.5-highspeed
-SMART_LLM=minimax:MiniMax-M2.5
-STRATEGIC_LLM=minimax:MiniMax-M2.5
+FAST_LLM=minimax:MiniMax-M2.7-highspeed
+SMART_LLM=minimax:MiniMax-M2.7
+STRATEGIC_LLM=minimax:MiniMax-M2.7
 
 EMBEDDING=minimax:embo-01
 ```
 
 Available models:
-- `MiniMax-M2.5` — 204K context, high-quality general-purpose model
+- `MiniMax-M2.7` — latest flagship model with improved reasoning
+- `MiniMax-M2.7-highspeed` — optimized for speed
+- `MiniMax-M2.5` — 204K context, general-purpose model
 - `MiniMax-M2.5-highspeed` — 204K context, optimized for speed
 
 ## Avian

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -35,6 +35,7 @@ _SUPPORTED_PROVIDERS = {
     "netmind",
     "forge",
     "avian",
+    "minimax",
 }
 
 NO_SUPPORT_TEMPERATURE_MODELS = [
@@ -257,6 +258,14 @@ class GenericLLMProvider:
 
             llm = ChatOpenAI(openai_api_base='https://api.avian.io/v1',
                      openai_api_key=os.environ["AVIAN_API_KEY"],
+                     **kwargs
+                )
+        elif provider == "minimax":
+            _check_pkg("langchain_openai")
+            from langchain_openai import ChatOpenAI
+
+            llm = ChatOpenAI(openai_api_base='https://api.minimax.io/v1',
+                     openai_api_key=os.environ["MINIMAX_API_KEY"],
                      **kwargs
                 )
         elif provider == 'netmind':

--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -49,6 +49,7 @@ _SUPPORTED_PROVIDERS = {
     "aimlapi",
     "netmind",
     "openrouter",
+    "minimax",
 }
 
 
@@ -199,6 +200,15 @@ class Memory:
                     model=model,
                     openai_api_key=os.getenv("OPENROUTER_API_KEY"),
                     openai_api_base="https://openrouter.ai/api/v1",
+                    **embedding_kwargs,
+                )
+            case "minimax":
+                from langchain_openai import OpenAIEmbeddings
+
+                _embeddings = OpenAIEmbeddings(
+                    model=model,
+                    openai_api_key=os.getenv("MINIMAX_API_KEY"),
+                    openai_api_base="https://api.minimax.io/v1",
                     **embedding_kwargs,
                 )
             case _:


### PR DESCRIPTION
## Summary

- Add MiniMax as a native LLM provider using their OpenAI-compatible API (`https://api.minimax.io/v1`)
- Add MiniMax embedding support (e.g. `embo-01`) via the same OpenAI-compatible endpoint
- Recommend MiniMax-M2.7 and M2.7-highspeed as the default models (upgraded from M2.5)
- Add documentation with configuration examples for all MiniMax models

## Details

[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. This PR adds first-class support so users can configure MiniMax models directly:

```env
MINIMAX_API_KEY=[Your Key]
FAST_LLM=minimax:MiniMax-M2.7-highspeed
SMART_LLM=minimax:MiniMax-M2.7
STRATEGIC_LLM=minimax:MiniMax-M2.7
EMBEDDING=minimax:embo-01
```

### Available Models
- **MiniMax-M2.7** — latest flagship model with improved reasoning
- **MiniMax-M2.7-highspeed** — optimized for speed
- **MiniMax-M2.5** — 204K context, general-purpose model
- **MiniMax-M2.5-highspeed** — 204K context, optimized for speed

### Implementation
- LLM: Uses `langchain_openai.ChatOpenAI` with `openai_api_base=https://api.minimax.io/v1`
- Embeddings: Uses `langchain_openai.OpenAIEmbeddings` with the same base URL
- No new dependencies required — reuses existing `langchain-openai` package

## Test Plan
- [x] Verified MiniMax-M2.7 model responds correctly via API
- [x] Verified MiniMax-M2.7-highspeed model responds correctly via API
- [x] Verified embedding endpoint works with embo-01 model
- [x] Documentation updated with configuration examples
