### PR TITLE
fix: NameError when STRATEGIC_LLM lacks colon separator (#1673)

### DIFF
--- a/multi_agents/main.py
+++ b/multi_agents/main.py
@@ -33,7 +33,7 @@ def open_task():
         model_name = strategic_llm.split(":", 1)[1]
         task["model"] = model_name
     elif strategic_llm:
-        task["model"] = model_name
+        task["model"] = strategic_llm
 
     return task
 


### PR DESCRIPTION
Fixes #1673

**Problem:** `open_task()` crashes with `NameError: name 'model_name' is not defined` when `STRATEGIC_LLM` is set without colon (e.g., 'gpt-4o').

**Fix:** Line 36: `task["model"] = model_name` → `task["model"] = strategic_llm`

**Behavior:**
- STRATEGIC_LLM='openai:gpt-4o' → task['model']='gpt-4o' (unchanged)
- STRATEGIC_LLM='gpt-4o' → task['model']='gpt-4o' (was crash, now works)