### PR TITLE
Update dependencies and add missing os import

### DIFF
--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import json
 import logging
+import os
 import traceback
 from typing import Dict, List
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,15 +25,17 @@ google-genai>=1.0.0  # For image generation with Imagen
 
 # Search & Research
 tavily-python>=0.7.12
-duckduckgo-search>=4.1.1
+ddgs>=9.0.0
 arxiv>=2.0.0
 
 # Document Processing
 beautifulsoup4>=4.12.2
 pymupdf>=1.23.6
 python-docx>=1.1.0
+python-pptx>=1.0.0
 unstructured>=0.13
 lxml>=4.9.2
+pandas>=2.0.0
 
 # Vector Store & Embeddings
 tiktoken>=0.7.0


### PR DESCRIPTION
## Summary
- Replace deprecated `duckduckgo-search` with `ddgs>=9.0.0` in requirements.txt
- Add `python-pptx>=1.0.0` and `pandas>=2.0.0` to requirements.txt
- Add missing `import os` in `backend/server/websocket_manager.py`

## Test plan
- [x] Verified `ddgs` package installs correctly and search functionality works
- [x] Verified `python-pptx` and `pandas` imports work as expected
- [x] Verified websocket manager runs without import errors