### PR TITLE
fix: PubMed Central retriever returns no results

### DIFF
--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -112,9 +112,11 @@ class PubMedCentralSearch:
                     url = f"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC{article_id}/"
                 
                 return {
+                    "href": url,
                     "url": url,
+                    "body": full_content,
                     "raw_content": full_content,
-                    "title": title_text  # Extra field for convenience
+                    "title": title_text
                 }
                 
             except ET.ParseError as e:

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -750,6 +750,7 @@ class ResearchConductor:
 
     async def _search_relevant_source_urls(self, query, query_domains: list | None = None):
         new_search_urls = []
+        prefetched_content = []
         if query_domains is None:
             query_domains = []
 
@@ -759,7 +760,7 @@ class ResearchConductor:
             # Skip MCP retrievers as they don't provide URLs for scraping
             if "mcpretriever" in retriever_class.__name__.lower():
                 continue
-                
+
             try:
                 # Instantiate the retriever with the sub-query
                 retriever = retriever_class(query, query_domains=query_domains)
@@ -769,9 +770,22 @@ class ResearchConductor:
                     retriever.search, max_results=self.researcher.cfg.max_search_results_per_query
                 )
 
-                # Collect new URLs from search results
-                search_urls = [url.get("href") for url in search_results if url.get("href")]
-                new_search_urls.extend(search_urls)
+                if not search_results:
+                    continue
+
+                # Separate results that already have content from those needing scraping
+                for result in search_results:
+                    url = result.get("href") or result.get("url")
+                    raw_content = result.get("raw_content") or result.get("body")
+                    if url and raw_content and len(raw_content) > 100:
+                        # Retriever already fetched full content (e.g. PubMed Central)
+                        prefetched_content.append({
+                            "url": url,
+                            "raw_content": raw_content,
+                        })
+                        self.researcher.add_research_sources([{"url": url}])
+                    elif url:
+                        new_search_urls.append(url)
             except Exception as e:
                 self.logger.error(f"Error searching with {retriever_class.__name__}: {e}")
 
@@ -779,11 +793,13 @@ class ResearchConductor:
         new_search_urls = await self._get_new_urls(new_search_urls)
         random.shuffle(new_search_urls)
 
-        return new_search_urls
+        return new_search_urls, prefetched_content
 
     async def _scrape_data_by_urls(self, sub_query, query_domains: list | None = None):
         """
         Runs a sub-query across multiple retrievers and scrapes the resulting URLs.
+        Retrievers that already provide full content (e.g. PubMed Central) have their
+        content passed through directly without re-scraping.
 
         Args:
             sub_query (str): The sub-query to search for.
@@ -794,7 +810,7 @@ class ResearchConductor:
         if query_domains is None:
             query_domains = []
 
-        new_search_urls = await self._search_relevant_source_urls(sub_query, query_domains)
+        new_search_urls, prefetched_content = await self._search_relevant_source_urls(sub_query, query_domains)
 
         # Log the research process if verbose mode is on
         if self.researcher.verbose:
@@ -805,8 +821,11 @@ class ResearchConductor:
                 self.researcher.websocket,
             )
 
-        # Scrape the new URLs
+        # Scrape URLs that need fetching (skip those already provided by retrievers)
         scraped_content = await self.researcher.scraper_manager.browse_urls(new_search_urls)
+
+        # Merge pre-fetched content from retrievers that already provide full text
+        scraped_content.extend(prefetched_content)
 
         if self.researcher.vector_store:
             self.researcher.vector_store.load(scraped_content)


### PR DESCRIPTION
## Summary

Fixes #1301 — PubMed Central retriever consistently returns "No content found" despite finding articles.

**Root cause:** Two issues in the retriever → research pipeline integration:

1. **Key mismatch:** PubMed retriever returned `url`/`raw_content` but `_search_relevant_source_urls()` extracts `href` — so 0 URLs were collected.
2. **Re-scraping discards content:** Even with URLs fixed, the pipeline re-scrapes all URLs via web scraper. PMC URLs block web scraping (content too short/empty), so the full-text content already fetched via PubMed's NCBI API was thrown away.

**Fix:**

- **`pubmed_central.py`**: Added `href` and `body` keys to match the retriever interface expected by the pipeline (backwards-compatible — existing keys preserved).
- **`researcher.py`**: `_search_relevant_source_urls` now detects results that already contain full content (`raw_content` > 100 chars) and passes them through as pre-fetched content, skipping the web scraper. URLs without content are still scraped normally. This benefits any retriever that fetches content at search time (PubMed, arXiv, Semantic Scholar, etc.).

## Tested with

```bash
RETRIEVER="pubmed_central" \
NCBI_API_KEY="..." \
SMART_LLM="bedrock:eu.anthropic.claude-sonnet-4-20250514-v1:0" \
EMBEDDING="bedrock:amazon.titan-embed-text-v2:0" \
python3 -c "
from gpt_researcher import GPTResearcher
import asyncio
async def main():
    r = GPTResearcher(query='microneedling for hair loss', report_type='research_report', report_source='web')
    await r.conduct_research()
    print(await r.write_report())
asyncio.run(main())
"
```

**Before:** 0 sources, hallucinated report with no citations.
**After:** 4 PubMed Central citations (PMC12883901, PMC11890238, PMC10334345, PMC7764156) with data from actual full-text articles.

## Test plan

- [x] PubMed Central retriever returns full-text articles with correct keys
- [x] Pre-fetched content flows through to context compressor
- [x] Report cites actual PMC article URLs
- [ ] Non-PubMed retrievers (Tavily, DuckDuckGo) still work normally (no regression — URL-only results still go through web scraper)