### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "gpt-researcher",
+  "version": "0.1.0",
+  "description": "Autonomous deep research from Codex via MCP",
+  "author": {
+    "name": "assafelovic",
+    "url": "https://github.com/assafelovic/gpt-researcher"
+  },
+  "homepage": "https://github.com/assafelovic/gpt-researcher",
+  "repository": "https://github.com/assafelovic/gpt-researcher",
+  "keywords": [
+    "mcp",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "GPT Researcher",
+    "shortDescription": "Autonomous deep research from Codex via MCP",
+    "longDescription": "An autonomous agent that conducts deep research on any data using any LLM providers.",
+    "category": "Research",
+    "websiteURL": "https://github.com/assafelovic/gpt-researcher"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "gpt-researcher": {
+      "command": "uvx",
+      "args": [
+        "gpt-researcher"
+      ]
+    }
+  }
+}

--- a/skills/gpt-researcher/SKILL.md
+++ b/skills/gpt-researcher/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: gpt-researcher
+description: Autonomous deep research from Codex via MCP
+---
+
+# GPT Researcher for Codex
+
+Use GPT Researcher from Codex via MCP.
+
+## When to use
+- When you need gpt-researcher capabilities in your Codex workflow
+- See https://github.com/assafelovic/gpt-researcher for full setup instructions


### PR DESCRIPTION
Adds a Codex CLI plugin manifest so GPT Researcher can be installed as a Codex plugin.

**What this adds:** .codex-plugin/plugin.json, .mcp.json, skills/gpt-researcher/SKILL.md

**Related:** [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) | [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner)