### PR TITLE
fix: add error handling to BoCha search retriever

### DIFF
--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -20,38 +20,65 @@ class BoChaSearch():
         """
         self.query = query
         self.query_domains = query_domains or None
-        self.api_key = os.environ["BOCHA_API_KEY"]
+        self.api_key = self.get_api_key()
+        self.logger = logging.getLogger(__name__)
+
+    def get_api_key(self):
+        """
+        Gets the BoCha API key
+        Returns:
+            str: The API key
+        """
+        try:
+            api_key = os.environ["BOCHA_API_KEY"]
+        except KeyError:
+            raise Exception(
+                "BoCha API key not found. Please set the BOCHA_API_KEY environment variable.")
+        return api_key
 
     def search(self, max_results=7) -> list[dict[str]]:
         """
         Searches the query
         Returns:
-
+            list: List of search results with title, href and body
         """
         url = 'https://api.bochaai.com/v1/web-search'
         headers = {
-            'Authorization': f'Bearer {self.api_key}',  # 请替换为你的API密钥
+            'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json'
         }
         data = {
             "query": self.query,
-            "freshness": "noLimit",  # 搜索的时间范围，
-            "summary": True,  # 是否返回长文本摘要
+            "freshness": "noLimit",
+            "summary": True,
             "count": max_results
         }
 
-        response = requests.post(url, headers=headers, json=data)
+        try:
+            response = requests.post(url, headers=headers, json=data, timeout=30)
 
-        json_response = response.json()
-        results = json_response["data"]["webPages"]["value"]
+            if response.status_code != 200:
+                self.logger.error(
+                    f"BoCha search failed with status {response.status_code}: {response.text}")
+                return []
+
+            json_response = response.json()
+            results = json_response.get("data", {}).get("webPages", {}).get("value", [])
+        except requests.exceptions.RequestException as e:
+            self.logger.error(f"BoCha search request failed: {e}")
+            return []
+        except (json.JSONDecodeError, ValueError) as e:
+            self.logger.error(f"Error parsing BoCha search response: {e}")
+            return []
+
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
             search_result = {
-                "title": result["name"],
-                "href": result["url"],
-                "body": result["snippet"],
+                "title": result.get("name", ""),
+                "href": result.get("url", ""),
+                "body": result.get("snippet", ""),
             }
             search_results.append(search_result)
 

--- a/tests/test_bocha_retriever.py
+++ b/tests/test_bocha_retriever.py
@@ -1,0 +1,132 @@
+"""Tests for BoCha search retriever error handling."""
+import json
+import os
+import sys
+import importlib.util
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Import the module directly to avoid triggering the full gpt_researcher import chain
+_spec = importlib.util.spec_from_file_location(
+    "bocha",
+    os.path.join(os.path.dirname(__file__), "..", "gpt_researcher", "retrievers", "bocha", "bocha.py"),
+)
+_bocha_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_bocha_mod)
+BoChaSearch = _bocha_mod.BoChaSearch
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv("BOCHA_API_KEY", "test-key")
+
+
+class TestBoChaSearch:
+    def test_successful_search(self):
+        """Verify normal search results are parsed correctly."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "webPages": {
+                    "value": [
+                        {"name": "Result 1", "url": "https://example.com/1", "snippet": "Body 1"},
+                        {"name": "Result 2", "url": "https://example.com/2", "snippet": "Body 2"},
+                    ]
+                }
+            }
+        }
+
+        with patch.object(_bocha_mod.requests, "post", return_value=mock_response):
+            searcher = BoChaSearch("test query")
+            results = searcher.search(max_results=2)
+
+        assert len(results) == 2
+        assert results[0]["title"] == "Result 1"
+        assert results[0]["href"] == "https://example.com/1"
+        assert results[0]["body"] == "Body 1"
+
+    def test_api_error_returns_empty_list(self):
+        """When the API returns a non-200 status, search should return [] instead of crashing."""
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.text = "Rate limit exceeded"
+
+        with patch.object(_bocha_mod.requests, "post", return_value=mock_response):
+            searcher = BoChaSearch("test query")
+            results = searcher.search()
+
+        assert results == []
+
+    def test_malformed_json_returns_empty_list(self):
+        """When the API returns invalid JSON, search should return [] instead of crashing."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = json.JSONDecodeError("", "", 0)
+
+        with patch.object(_bocha_mod.requests, "post", return_value=mock_response):
+            searcher = BoChaSearch("test query")
+            results = searcher.search()
+
+        assert results == []
+
+    def test_missing_keys_returns_empty_list(self):
+        """When response JSON is missing expected keys, search should return [] instead of crashing."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"error": "something went wrong"}
+
+        with patch.object(_bocha_mod.requests, "post", return_value=mock_response):
+            searcher = BoChaSearch("test query")
+            results = searcher.search()
+
+        assert results == []
+
+    def test_network_error_returns_empty_list(self):
+        """When the request fails due to network issues, search should return [] instead of crashing."""
+        import requests as req
+
+        with patch.object(_bocha_mod.requests, "post", side_effect=req.exceptions.ConnectionError("Connection refused")):
+            searcher = BoChaSearch("test query")
+            results = searcher.search()
+
+        assert results == []
+
+    def test_timeout_returns_empty_list(self):
+        """When the request times out, search should return [] instead of crashing."""
+        import requests as req
+
+        with patch.object(_bocha_mod.requests, "post", side_effect=req.exceptions.Timeout("Request timed out")):
+            searcher = BoChaSearch("test query")
+            results = searcher.search()
+
+        assert results == []
+
+    def test_missing_api_key_raises(self):
+        """When BOCHA_API_KEY is not set, constructor should raise with a helpful message."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(Exception, match="BOCHA_API_KEY"):
+                BoChaSearch("test query")
+
+    def test_partial_result_fields(self):
+        """When result items are missing some fields, search should use empty strings as defaults."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "webPages": {
+                    "value": [
+                        {"name": "Only Title"},
+                    ]
+                }
+            }
+        }
+
+        with patch.object(_bocha_mod.requests, "post", return_value=mock_response):
+            searcher = BoChaSearch("test query")
+            results = searcher.search()
+
+        assert len(results) == 1
+        assert results[0]["title"] == "Only Title"
+        assert results[0]["href"] == ""
+        assert results[0]["body"] == ""


### PR DESCRIPTION
Ran into this while testing with the BoCha retriever on a self-hosted instance. When the BoCha API returns a non-200 status (rate limit, invalid key, server error) or a response whose body doesn't match the expected structure, the retriever crashes with an unhandled `KeyError` or `JSONDecodeError`. This kills the entire research session instead of letting the agent fall back to other sources.

The root cause is that `bocha.py` does not check the HTTP status code, does not wrap `response.json()` in a try-except, and accesses nested dictionary keys (`json_response["data"]["webPages"]["value"]`) directly without any safety.

Every other retriever in the project handles these cases — for example, `bing.py` wraps JSON parsing in try-except and returns `[]` on error (lines 71-77), `searx.py` calls `response.raise_for_status()` (line 62), and `google.py` checks the status code and uses `.get()` for dict access.

**Before:** any API error crashes with `KeyError` or `JSONDecodeError`, terminating the research.

**After:** non-200 responses and malformed JSON are logged and the retriever returns `[]`, matching the behavior of the other retrievers so the agent can continue with alternative search sources.

Changes:
- Check HTTP status code before parsing response body
- Wrap the request and JSON parsing in try-except for `RequestException` and `JSONDecodeError`
- Use `.get()` with defaults for nested dict access
- Add a 30-second request timeout
- Extract API key handling into `get_api_key()` with a helpful error message (same pattern as `bing.py` and `serper.py`)
- Add unit tests covering success, API errors, malformed JSON, missing keys, network errors, timeouts, missing API key, and partial result fields