### PR TITLE
Added missing import

### DIFF
--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -29,7 +29,7 @@ from server.server_utils import (
 )
 
 from server.websocket_manager import run_agent
-from utils import write_md_to_word, write_md_to_pdf
+from backend.utils import write_md_to_word, write_md_to_pdf
 from gpt_researcher.utils.enum import Tone
 from chat.chat import ChatAgentWithMemory
 

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -9,7 +9,7 @@ from typing import Awaitable, Dict, List, Any
 from fastapi.responses import JSONResponse, FileResponse
 from gpt_researcher.document.document import DocumentLoader
 from gpt_researcher import GPTResearcher
-from utils import write_md_to_pdf, write_md_to_word, write_text_to_md
+from backend.utils import write_md_to_pdf, write_md_to_word, write_text_to_md
 from pathlib import Path
 from datetime import datetime
 from fastapi import HTTPException

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -3,12 +3,13 @@ import datetime
 import json
 import os
 import logging
+import os
 import traceback
 from typing import Dict, List
 
 from fastapi import WebSocket
 
-from report_type import BasicReport, DetailedReport
+from backend.report_type import BasicReport, DetailedReport
 
 from gpt_researcher.utils.enum import ReportType, Tone
 from gpt_researcher.actions import stream_output  # Import stream_output

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import json
+import os
 import logging
 import traceback
 from typing import Dict, List

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_websocket_manager_module_imports():
+    module = importlib.import_module("backend.server.websocket_manager")
+    assert hasattr(module, "WebSocketManager")
+
+
+def test_server_app_module_imports():
+    module = importlib.import_module("backend.server.app")
+    assert hasattr(module, "app")
+
+
+@pytest.mark.asyncio
+async def test_start_streaming_uses_config_path_from_env(monkeypatch):
+    module = importlib.import_module("backend.server.websocket_manager")
+    captured = {}
+
+    async def fake_run_agent(
+        task,
+        report_type,
+        report_source,
+        source_urls,
+        document_urls,
+        tone,
+        websocket,
+        stream_output=module.stream_output,
+        headers=None,
+        query_domains=None,
+        config_path="",
+        return_researcher=False,
+        mcp_enabled=False,
+        mcp_strategy="fast",
+        mcp_configs=None,
+        max_search_results=None,
+    ):
+        captured["task"] = task
+        captured["report_type"] = report_type
+        captured["report_source"] = report_source
+        captured["tone"] = tone.name
+        captured["config_path"] = config_path
+        return "ok"
+
+    monkeypatch.setenv("CONFIG_PATH", "test-config")
+    monkeypatch.setattr(module, "run_agent", fake_run_agent)
+
+    manager = module.WebSocketManager()
+    result = await manager.start_streaming(
+        task="research task",
+        report_type="research_report",
+        report_source="web",
+        source_urls=[],
+        document_urls=[],
+        tone="Objective",
+        websocket=None,
+    )
+
+    assert result == "ok"
+    assert captured["task"] == "research task"
+    assert captured["report_type"] == "research_report"
+    assert captured["report_source"] == "web"
+    assert captured["tone"] == "Objective"
+    assert captured["config_path"] == "test-config"


### PR DESCRIPTION
Issue 1712
 This fixes the web UI failure in `backend/server/websocket_manager.py` caused by a missing `os` import, and also cleans up related backend import path issues so the server modules import correctly as a
  package.

  I added regression smoke tests for:
  - `backend.server.websocket_manager`
  - `backend.server.app`
  - `WebSocketManager.start_streaming()` reading `CONFIG_PATH`

  Verification:
  - Installed `pytest` and `pytest-asyncio` in the project venv
  - Ran `tests/test_websocket_manager.py`
  - Result: `3 passed`

  This should make similar import-path regressions much easier to catch earlier.