### PR TITLE
feat: add Xquik X/Twitter search retriever

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 OPENAI_API_KEY=
 TAVILY_API_KEY=
+XQUIK_API_KEY=
 DOC_PATH=./my-docs
 
 # NEXT_PUBLIC_GPTR_API_URL=http://0.0.0.0:8000  # Defaults to localhost:8000 if not set

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -29,6 +29,7 @@ def get_retriever(retriever: str):
         - pubmed_central: PubMed Central medical literature
         - custom: Custom user-defined retriever
         - mcp: Model Context Protocol retriever
+        - xquik: Xquik X/Twitter search
     """
     match retriever:
         case "google":
@@ -91,6 +92,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import MCPRetriever
 
             return MCPRetriever
+        case "xquik":
+            from gpt_researcher.retrievers import XquikSearch
+
+            return XquikSearch
 
         case _:
             return None

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -13,6 +13,7 @@ from .tavily.tavily_search import TavilySearch
 from .exa.exa import ExaSearch
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
+from .xquik.xquik import XquikSearch
 
 __all__ = [
     "TavilySearch",
@@ -29,5 +30,6 @@ __all__ = [
     "PubMedCentralSearch",
     "ExaSearch",
     "MCPRetriever",
-    "BoChaSearch"
+    "BoChaSearch",
+    "XquikSearch"
 ]

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -74,6 +74,7 @@ VALID_RETRIEVERS = [
     "pubmed_central",
     "exa",
     "mcp",
+    "xquik",
     "mock"
 ]
 

--- a/gpt_researcher/retrievers/xquik/xquik.py
+++ b/gpt_researcher/retrievers/xquik/xquik.py
@@ -1,0 +1,94 @@
+# Xquik X/Twitter Retriever
+#
+# Searches X (Twitter) for real-time perspectives, dev discussions,
+# product feedback, breaking news, and expert opinions.
+# $0.00015 per tweet — 33x cheaper than the official X API.
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+
+class XquikSearch:
+    """
+    Xquik X/Twitter search retriever.
+
+    Searches tweets via the Xquik REST API and returns results in the
+    standard {title, href, body} format used by all GPT Researcher retrievers.
+
+    Set XQUIK_API_KEY in your environment. Get one at https://xquik.com
+    """
+
+    def __init__(self, query, query_domains=None, **kwargs):
+        self.query = query
+        self.query_domains = query_domains
+        self.api_key = self.get_api_key()
+
+    def get_api_key(self):
+        try:
+            api_key = os.environ["XQUIK_API_KEY"]
+        except KeyError:
+            raise Exception(
+                "Xquik API key not found. Please set the XQUIK_API_KEY "
+                "environment variable. Get a key at https://xquik.com"
+            )
+        return api_key
+
+    def search(self, max_results=10):
+        """
+        Search X/Twitter via Xquik API.
+
+        Returns:
+            list: Search results as [{title, href, body}, ...]
+        """
+        print(f"Searching X/Twitter with query: {self.query}...")
+
+        try:
+            results = self._search_tweets(max_results)
+            return results
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching X/Twitter sources. Resulting in empty response.")
+            return []
+
+    def _search_tweets(self, max_results):
+        params = urllib.parse.urlencode({
+            "q": self.query,
+            "limit": min(max_results, 200),
+            "queryType": "Top",
+        })
+        url = f"https://xquik.com/api/v1/x/tweets/search?{params}"
+
+        req = urllib.request.Request(url, headers={
+            "X-API-Key": self.api_key,
+            "Accept": "application/json",
+            "User-Agent": "gpt-researcher/1.0",
+        })
+
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        tweets = data.get("tweets", [])
+        search_results = []
+
+        for tweet in tweets[:max_results]:
+            author = tweet.get("author", {})
+            username = author.get("username", "unknown")
+            text = tweet.get("text", "")
+            tweet_id = tweet.get("id", "")
+
+            likes = tweet.get("likeCount", 0)
+            retweets = tweet.get("retweetCount", 0)
+            views = tweet.get("viewCount", 0)
+
+            engagement = f"{likes} likes, {retweets} RTs"
+            if views:
+                engagement += f", {views} views"
+
+            search_results.append({
+                "title": f"@{username}: {text[:120]}{'...' if len(text) > 120 else ''}",
+                "href": f"https://x.com/{username}/status/{tweet_id}",
+                "body": f"{text}\n\n[{engagement}]",
+            })
+
+        return search_results


### PR DESCRIPTION
## Summary

Adds **XquikSearch** — the first social media/X (Twitter) retriever for GPT Researcher. Searches tweets via the [Xquik](https://xquik.com) REST API for real-time perspectives, dev discussions, product feedback, breaking news, and expert opinions.

GPT Researcher currently has 15 retrievers covering web search, academic papers, and code — but **zero social media sources**. This adds X/Twitter as a new research dimension.

## Why this matters

Research questions like "What do developers think about X?" or "What's the community reaction to Y?" currently have no signal from social media. The researcher can only find blog posts and articles — missing the real-time discourse happening on X/Twitter.

With this retriever, GPT Researcher can now:
- Find developer reactions to library releases, API changes, product launches
- Surface expert opinions and hot takes on trending topics
- Capture breaking news and community sentiment before articles are written
- Include primary sources (actual tweets) alongside web results

## Usage

```bash
# Single retriever
RETRIEVER=xquik XQUIK_API_KEY=xk_your_key python main.py

# Combined with other retrievers (recommended)
RETRIEVER=tavily,xquik,duckduckgo XQUIK_API_KEY=xk_your_key python main.py
```

Best used alongside web retrievers — tweets provide the "what people are saying" angle while web results provide the "what's been written" angle.

## Changes

| File | What |
|------|------|
| `gpt_researcher/retrievers/xquik/__init__.py` | Empty init |
| `gpt_researcher/retrievers/xquik/xquik.py` | `XquikSearch` class — search, result mapping |
| `gpt_researcher/retrievers/__init__.py` | Register `XquikSearch` |
| `gpt_researcher/retrievers/utils.py` | Add `"xquik"` to `VALID_RETRIEVERS` |
| `gpt_researcher/actions/retriever.py` | Add `"xquik"` case to `get_retriever()` |
| `.env.example` | Add `XQUIK_API_KEY=` |

## Implementation details

- Follows the exact Serper/Google retriever pattern (API key from env, REST call, normalize to `{title, href, body}`)
- Uses stdlib `urllib` only — **zero new dependencies**
- Returns standard format: title = `@username: tweet excerpt`, href = tweet URL, body = full text + engagement metrics
- Sorts by "Top" (engagement) by default for higher signal
- $0.00015 per tweet read (33x cheaper than the official X API)
- SDK: [`@xquik/tweetclaw`](https://www.npmjs.com/package/@xquik/tweetclaw)

## Test plan

- [x] Module imports and instantiates correctly
- [x] Raises clear error when `XQUIK_API_KEY` is missing
- [x] Accepts `query` and `query_domains` params (standard retriever contract)
- [x] `search(max_results=N)` returns list of `{title, href, body}` dicts
- [x] Returns empty list on API errors (no exceptions propagated)
- [x] No changes to existing retrievers or core agent logic

Built with [Claude Code](https://claude.ai/code)