### PR TITLE
fix: properly resolve report_type imports in websocket_manager and re…

### DIFF
--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 
 from fastapi import WebSocket
 
-from report_type import BasicReport, DetailedReport
+from backend.report_type import BasicReport, DetailedReport
 
 from gpt_researcher.utils.enum import ReportType, Tone
 from gpt_researcher.actions import stream_output  # Import stream_output

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -24,6 +24,7 @@ def _load_websocket_manager_module():
         "gpt_researcher.actions",
         "gpt_researcher.utils.enum",
         "report_type",
+        "backend.report_type",
         "fastapi",
     ):
         sys.modules.pop(module_name, None)
@@ -31,7 +32,7 @@ def _load_websocket_manager_module():
     fastapi_module = types.ModuleType("fastapi")
     fastapi_module.WebSocket = type("WebSocket", (), {})
 
-    report_type_module = types.ModuleType("report_type")
+    report_type_module = types.ModuleType("backend.report_type")
     report_type_module.BasicReport = type("BasicReport", (), {})
     report_type_module.DetailedReport = type("DetailedReport", (), {})
 
@@ -64,6 +65,7 @@ def _load_websocket_manager_module():
         {
             "fastapi": fastapi_module,
             "report_type": report_type_module,
+            "backend.report_type": report_type_module,
             "gpt_researcher.utils.enum": enum_module,
             "gpt_researcher.actions": actions_module,
             "backend.server.multi_agent_runner": multi_agent_runner_module,
@@ -74,6 +76,14 @@ def _load_websocket_manager_module():
 
 
 class WebSocketManagerTests(unittest.IsolatedAsyncioTestCase):
+    def test_websocket_manager_module_imports(self):
+        module = importlib.import_module("backend.server.websocket_manager")
+        self.assertTrue(hasattr(module, "WebSocketManager"))
+
+    def test_server_app_module_imports(self):
+        module = importlib.import_module("backend.server.app")
+        self.assertTrue(hasattr(module, "app"))
+
     async def test_start_streaming_reads_config_path_from_environment(self):
         websocket_manager = _load_websocket_manager_module()
         manager = websocket_manager.WebSocketManager()


### PR DESCRIPTION
Fixed Import Crash: Restored the backend. prefix to imports in websocket_manager.py. This prevents the code from crashing when run by external test tools that don't share the server's custom path settings.
Restored "Smoke Tests": Added back real import tests to verify that all dependencies load correctly in the actual Python environment (not just in a mocked setup).

Updated Test Mocks: Aligned the unit tests to match these improved import paths so the existing test suite stays healthy.