### PR TITLE
feat: add OpenAlex retriever

### DIFF
--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -27,6 +27,7 @@ def get_retriever(retriever: str):
         - exa: Exa search
         - semantic_scholar: Semantic Scholar academic search
         - pubmed_central: PubMed Central medical literature
+        - openalex: OpenAlex scholarly works catalog
         - custom: Custom user-defined retriever
         - mcp: Model Context Protocol retriever
         - xquik: Xquik X/Twitter search
@@ -96,6 +97,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import XquikSearch
 
             return XquikSearch
+        case "openalex":
+            from gpt_researcher.retrievers import OpenAlexSearch
+
+            return OpenAlexSearch
 
         case _:
             return None

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -14,6 +14,7 @@ from .exa.exa import ExaSearch
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
+from .openalex.openalex import OpenAlexSearch
 
 __all__ = [
     "TavilySearch",
@@ -31,5 +32,6 @@ __all__ = [
     "ExaSearch",
     "MCPRetriever",
     "BoChaSearch",
-    "XquikSearch"
+    "XquikSearch",
+    "OpenAlexSearch"
 ]

--- a/gpt_researcher/retrievers/openalex/openalex.py
+++ b/gpt_researcher/retrievers/openalex/openalex.py
@@ -1,0 +1,117 @@
+import os
+from typing import Dict, List, Optional
+
+import requests
+
+
+class OpenAlexSearch:
+    """
+    OpenAlex API Retriever.
+
+    OpenAlex (https://openalex.org) is an open catalog of scholarly works.
+    No API key is required for default usage.
+
+    Optional environment variables:
+    - OPENALEX_EMAIL: adds the caller to OpenAlex's polite pool for more
+      predictable rate limits (recommended for production use).
+    - OPENALEX_API_KEY: authenticated access with higher rate limits
+      (register for free at https://openalex.org/).
+
+    See https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication
+    for current rate limit details.
+    """
+
+    BASE_URL = "https://api.openalex.org/works"
+    VALID_SORT_CRITERIA = [
+        "relevance_score:desc",
+        "cited_by_count:desc",
+        "publication_date:desc",
+    ]
+
+    def __init__(self, query: str, sort: str = "relevance_score:desc", query_domains=None):
+        """
+        Initialize the OpenAlexSearch class with a query and sort criterion.
+
+        :param query: Search query string.
+        :param sort: Sort criterion. One of VALID_SORT_CRITERIA.
+        """
+        self.query = query
+        assert sort in self.VALID_SORT_CRITERIA, f"Invalid sort criterion: {sort}"
+        self.sort = sort
+        self.email: Optional[str] = os.environ.get("OPENALEX_EMAIL")
+        self.api_key: Optional[str] = os.environ.get("OPENALEX_API_KEY")
+
+    def search(self, max_results: int = 20) -> List[Dict[str, str]]:
+        """
+        Perform the search on OpenAlex and return results.
+
+        :param max_results: Maximum number of results to retrieve (capped at 25 per request).
+        :return: List of dictionaries containing title, href, and body of each work.
+        """
+        params = {
+            "search": self.query,
+            "per_page": min(max_results, 25),
+            "sort": self.sort,
+        }
+        if self.email:
+            params["mailto"] = self.email
+        if self.api_key:
+            params["api_key"] = self.api_key
+
+        try:
+            response = requests.get(self.BASE_URL, params=params, timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            print(f"An error occurred while accessing OpenAlex API: {e}")
+            return []
+
+        results = response.json().get("results", [])
+        search_result = []
+        for result in results:
+            title = result.get("title") or "No Title"
+            href = self._pick_href(result)
+            body = self._reconstruct_abstract(result.get("abstract_inverted_index"))
+
+            if href:
+                search_result.append(
+                    {
+                        "title": title,
+                        "href": href,
+                        "body": body or "Abstract not available",
+                    }
+                )
+
+        return search_result
+
+    @staticmethod
+    def _pick_href(result: dict) -> Optional[str]:
+        """
+        Prefer the open-access PDF URL, then the landing page URL from
+        primary_location, then the OpenAlex work URL as fallback.
+        """
+        oa_location = result.get("best_oa_location") or {}
+        pdf_url = oa_location.get("pdf_url")
+        if pdf_url:
+            return pdf_url
+
+        primary = result.get("primary_location") or {}
+        landing = primary.get("landing_page_url")
+        if landing:
+            return landing
+
+        return result.get("id")
+
+    @staticmethod
+    def _reconstruct_abstract(inverted: Optional[dict]) -> Optional[str]:
+        """
+        OpenAlex returns abstracts as an inverted index (word -> positions).
+        Reconstruct the original text.
+        """
+        if not inverted:
+            return None
+        positions: List[tuple] = []
+        for word, indexes in inverted.items():
+            for i in indexes:
+                positions.append((i, word))
+        positions.sort(key=lambda x: x[0])
+        return " ".join(word for _, word in positions)

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -75,6 +75,7 @@ VALID_RETRIEVERS = [
     "exa",
     "mcp",
     "xquik",
+    "openalex",
     "mock"
 ]
 


### PR DESCRIPTION
Addresses #1264, which asked how to add an OpenAlex retriever a year ago.

OpenAlex (https://openalex.org) is an open catalog of ~300M scholarly works, with no API key required.

## Implementation notes

- Structure mirrors the existing `semantic_scholar` and `pubmed_central` retrievers: single file, class with `__init__` and `search`, returns the standard `{title, href, body}` dict.
- Abstracts are returned by OpenAlex as an inverted index (word -> positions) for copyright reasons; the retriever reconstructs the original text.
- `href` prefers the open-access PDF URL, falls back to the publisher landing page, and finally to the OpenAlex work URL, so non-OA results are not dropped.
- Two optional environment variables are read: `OPENALEX_EMAIL` joins the polite pool, and `OPENALEX_API_KEY` enables the authenticated pool with higher rate limits. Neither is required.
- Registration follows the pattern used by the recent Xquik retriever PR (#1734).

## Local verification

- Live call: `OpenAlexSearch("protein language models").search(max_results=5)` returns 5 results with reconstructed abstracts and working hrefs.
- Ran with and without `OPENALEX_EMAIL` set; both succeed.

Closes #1264
