### PR TITLE
feat(server): add Agent Discovery Protocol manifest endpoint

### DIFF
--- a/backend/server/agent_discovery.py
+++ b/backend/server/agent_discovery.py
@@ -1,0 +1,68 @@
+from typing import Dict, List, Optional
+
+
+def _to_websocket_origin(origin: str) -> str:
+    if origin.startswith("https://"):
+        return "wss://" + origin[len("https://"):]
+    if origin.startswith("http://"):
+        return "ws://" + origin[len("http://"):]
+    return origin
+
+
+def build_agent_discovery_document(
+    origin: str,
+    domain: str,
+    contact: Optional[str] = None,
+) -> Dict[str, object]:
+    normalized_origin = origin.rstrip("/")
+    websocket_origin = _to_websocket_origin(normalized_origin)
+
+    services: List[Dict[str, object]] = [
+        {
+            "name": "research",
+            "description": "Submit a research job and generate a report.",
+            "endpoint": f"{normalized_origin}/report/",
+            "protocol": "http",
+            "auth": "none",
+            "governance": "none",
+            "free_tier": True,
+        },
+        {
+            "name": "reports",
+            "description": "Create, list, and manage generated research reports.",
+            "endpoint": f"{normalized_origin}/api/reports",
+            "protocol": "http",
+            "auth": "none",
+            "governance": "none",
+            "free_tier": True,
+        },
+        {
+            "name": "chat",
+            "description": "Ask follow-up questions against a generated report.",
+            "endpoint": f"{normalized_origin}/api/chat",
+            "protocol": "http",
+            "auth": "none",
+            "governance": "none",
+            "free_tier": True,
+        },
+        {
+            "name": "research_stream",
+            "description": "Realtime WebSocket stream for interactive research runs.",
+            "endpoint": f"{websocket_origin}/ws",
+            "protocol": "websocket",
+            "auth": "none",
+            "governance": "none",
+            "free_tier": True,
+        },
+    ]
+
+    document: Dict[str, object] = {
+        "agent_discovery_version": "0.1",
+        "domain": domain,
+        "services": services,
+    }
+
+    if contact:
+        document["contact"] = contact
+
+    return document

--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -27,6 +27,7 @@ from server.server_utils import (
     update_environment_variables, handle_file_upload, handle_file_deletion,
     execute_multi_agents, handle_websocket_communication
 )
+from server.agent_discovery import build_agent_discovery_document
 
 from server.websocket_manager import run_agent
 from utils import write_md_to_word, write_md_to_pdf
@@ -156,6 +157,19 @@ async def serve_frontend():
         content = f.read()
     
     return HTMLResponse(content=content)
+
+
+@app.get("/.well-known/agent-discovery.json")
+async def agent_discovery(request: Request):
+    """Advertise GPT Researcher services via the Agent Discovery Protocol."""
+    origin = str(request.base_url).rstrip("/")
+    domain = request.url.hostname or request.headers.get("host", "")
+    contact = os.getenv("AGENT_DISCOVERY_CONTACT")
+
+    document = build_agent_discovery_document(origin=origin, domain=domain, contact=contact)
+    response = JSONResponse(content=document)
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    return response
 
 @app.get("/report/{research_id}")
 async def read_report(request: Request, research_id: str):

--- a/tests/test_agent_discovery.py
+++ b/tests/test_agent_discovery.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+for path in (ROOT, ROOT / "backend"):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+from backend.server.agent_discovery import build_agent_discovery_document
+
+
+def test_build_agent_discovery_document_exposes_expected_services():
+    document = build_agent_discovery_document(
+        origin="https://gptr.dev",
+        domain="gptr.dev",
+        contact="team@gptr.dev",
+    )
+
+    assert document["agent_discovery_version"] == "0.1"
+    assert document["domain"] == "gptr.dev"
+    assert document["contact"] == "team@gptr.dev"
+
+    services = {service["name"]: service for service in document["services"]}
+
+    assert services["research"]["endpoint"] == "https://gptr.dev/report/"
+    assert services["reports"]["endpoint"] == "https://gptr.dev/api/reports"
+    assert services["chat"]["endpoint"] == "https://gptr.dev/api/chat"
+    assert services["research_stream"]["endpoint"] == "wss://gptr.dev/ws"
+    assert services["research_stream"]["protocol"] == "websocket"
+
+
+def test_build_agent_discovery_document_omits_empty_contact():
+    document = build_agent_discovery_document(
+        origin="http://localhost:8000/",
+        domain="localhost",
+    )
+
+    assert "contact" not in document
+
+    services = {service["name"]: service for service in document["services"]}
+    assert services["research"]["endpoint"] == "http://localhost:8000/report/"
+    assert services["research_stream"]["endpoint"] == "ws://localhost:8000/ws"
+
+
+def test_app_exposes_agent_discovery_route():
+    source = (ROOT / "backend" / "server" / "app.py").read_text()
+
+    assert '@app.get("/.well-known/agent-discovery.json")' in source
+    assert 'build_agent_discovery_document(origin=origin, domain=domain, contact=contact)' in source


### PR DESCRIPTION
## Summary
- add a `/.well-known/agent-discovery.json` endpoint to the FastAPI server
- generate an ADP v0.1 document that advertises the existing research, reports, chat, and websocket services
- support an optional `AGENT_DISCOVERY_CONTACT` environment variable for operators who want to publish a contact address
- add regression tests for manifest generation and route wiring

## Why
Issue #1735 asks GPT Researcher to support the Agent Discovery Protocol so agent clients can discover the app's services from a standard well-known URL instead of relying on out-of-band configuration.

This keeps the change small and focused by exposing the server deployment surface that GPT Researcher already provides today:
- `POST /report/`
- `GET/POST /api/reports`
- `POST /api/chat`
- `WS /ws`

## Test plan
- `python3 -m pytest -q tests/test_agent_discovery.py`
- `python3 -m py_compile backend/server/agent_discovery.py backend/server/app.py tests/test_agent_discovery.py`

Closes #1735