### PR TITLE
fix: make OLLAMA_BASE_URL optional with sensible default

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -169,7 +169,12 @@ class GenericLLMProvider:
             _check_pkg("langchain_ollama")
             from langchain_ollama import ChatOllama
 
-            llm = ChatOllama(base_url=os.environ["OLLAMA_BASE_URL"], **kwargs)
+            # Use OLLAMA_BASE_URL from env if not already supplied in kwargs;
+            # fall back to the Ollama default so OLLAMA_BASE_URL is optional.
+            if "base_url" not in kwargs:
+                kwargs["base_url"] = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+
+            llm = ChatOllama(**kwargs)
         elif provider == "together":
             _check_pkg("langchain_together")
             from langchain_together import ChatTogether


### PR DESCRIPTION
Fixes #1087

## Problem

`base.py` always reads `os.environ["OLLAMA_BASE_URL"]` with a hard dict
lookup, which raises `KeyError` for any user who runs Ollama on the
default `localhost:11434` and hasn't set the environment variable.

A second related failure occurs when a caller already supplies `base_url`
in kwargs: the code also injects it from the env variable, causing
`ChatOllama() got multiple values for keyword argument 'base_url'`.

Both of these were reported in #1087.

## Solution

- Replace `os.environ["OLLAMA_BASE_URL"]` with
  `os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")` so users
  running a stock Ollama install get the correct default without setting
  any environment variable.
- Only inject the `base_url` kwarg when the caller hasn't already
  supplied it, eliminating the "multiple values" error.

```python
if "base_url" not in kwargs:
    kwargs["base_url"] = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")

llm = ChatOllama(**kwargs)
```

## Testing

1. **Without `OLLAMA_BASE_URL`**: `get_llm("ollama", model="llama3")` no longer raises `KeyError`.
2. **With `OLLAMA_BASE_URL`**: the env value is used as before.
3. **With explicit `base_url` in kwargs**: no "multiple values" error.