### PR TITLE
Limit multi-agent human plan revisions

### DIFF
--- a/multi_agents/README.md
+++ b/multi_agents/README.md
@@ -66,6 +66,7 @@ To change the research query and customize the report, edit the `task.json` file
 - `query` - The research query or task.
 - `model` - The OpenAI LLM to use for the agents.
 - `max_sections` - The maximum number of sections in the report. Each section is a subtopic of the research query.
+- `max_plan_revisions` - The maximum number of human-requested plan revisions before the workflow exits with a clear error. Set to `null` to rely on LangGraph's recursion limit instead.
 - `include_human_feedback` - If true, the user can provide feedback to the agents. If false, the agents will work autonomously.
 - `publish_formats` - The formats to publish the report in. The reports will be written in the `output` directory.
 - `source` - The location from which to conduct the research. Options: `web` or `local`. For local, please add `DOC_PATH` env var.
@@ -78,7 +79,8 @@ To change the research query and customize the report, edit the `task.json` file
 {
   "query": "Is AI in a hype cycle?",
   "model": "gpt-4o",
-  "max_sections": 3, 
+  "max_sections": 3,
+  "max_plan_revisions": 3,
   "publish_formats": { 
     "markdown": true,
     "pdf": true,

--- a/multi_agents/agent.py
+++ b/multi_agents/agent.py
@@ -3,6 +3,7 @@ from multi_agents.agents import ChiefEditorAgent
 chief_editor = ChiefEditorAgent({
   "query": "Is AI in a hype cycle?",
   "max_sections": 3,
+  "max_plan_revisions": 3,
   "follow_guidelines": False,
   "model": "gpt-4o",
   "guidelines": [

--- a/multi_agents/agents/human.py
+++ b/multi_agents/agents/human.py
@@ -47,6 +47,13 @@ class HumanAgent:
         if user_feedback and "no" in user_feedback.strip().lower():
             user_feedback = None
 
+        plan_revision_count = research_state.get("plan_revision_count", 0)
+        if user_feedback:
+            plan_revision_count += 1
+
         print(f"User feedback before return: {user_feedback}")
 
-        return {"human_feedback": user_feedback}
+        return {
+            "human_feedback": user_feedback,
+            "plan_revision_count": plan_revision_count,
+        }

--- a/multi_agents/agents/orchestrator.py
+++ b/multi_agents/agents/orchestrator.py
@@ -6,6 +6,10 @@ from langgraph.graph import StateGraph, END
 from .utils.views import print_agent_output
 from ..memory.research import ResearchState
 from .utils.utils import sanitize_filename
+from .plan_review import (
+    DEFAULT_MAX_PLAN_REVISIONS,
+    route_human_feedback,
+)
 
 # Import agent classes
 from . import \
@@ -76,9 +80,14 @@ class ChiefEditorAgent:
         # Add human in the loop
         workflow.add_conditional_edges(
             'human',
-            lambda review: "accept" if review['human_feedback'] is None else "revise",
+            self._route_human_feedback,
             {"accept": "researcher", "revise": "planner"}
         )
+
+    def _route_human_feedback(self, review):
+        max_plan_revisions = self.task.get(
+            "max_plan_revisions", DEFAULT_MAX_PLAN_REVISIONS)
+        return route_human_feedback(review, max_plan_revisions)
 
     def init_research_team(self):
         """Initialize and create a workflow for the research team."""

--- a/multi_agents/agents/plan_review.py
+++ b/multi_agents/agents/plan_review.py
@@ -1,0 +1,23 @@
+DEFAULT_MAX_PLAN_REVISIONS = 3
+
+
+class MaxPlanRevisionsExceededError(RuntimeError):
+    """Raised when human feedback requests exceed the configured planning limit."""
+
+
+def route_human_feedback(review, max_plan_revisions=DEFAULT_MAX_PLAN_REVISIONS):
+    if review.get("human_feedback") is None:
+        return "accept"
+
+    if max_plan_revisions is None:
+        return "revise"
+
+    plan_revision_count = review.get("plan_revision_count", 0)
+    if plan_revision_count > max_plan_revisions:
+        raise MaxPlanRevisionsExceededError(
+            "Plan revision limit exceeded. "
+            f"Received {plan_revision_count} revision requests; "
+            f"max_plan_revisions is {max_plan_revisions}."
+        )
+
+    return "revise"

--- a/multi_agents/memory/research.py
+++ b/multi_agents/memory/research.py
@@ -8,6 +8,7 @@ class ResearchState(TypedDict):
     sections: List[str]
     research_data: List[dict]
     human_feedback: str
+    plan_revision_count: int
     # Report layout
     title: str
     headers: dict
@@ -17,5 +18,4 @@ class ResearchState(TypedDict):
     conclusion: str
     sources: List[str]
     report: str
-
 

--- a/multi_agents/task.json
+++ b/multi_agents/task.json
@@ -1,6 +1,7 @@
 {
   "query": "Is AI in a hype cycle?",
   "max_sections": 3,
+  "max_plan_revisions": 3,
   "publish_formats": {
     "markdown": true,
     "pdf": true,

--- a/tests/test_multi_agents_plan_revisions.py
+++ b/tests/test_multi_agents_plan_revisions.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+PLAN_REVIEW_PATH = (
+    Path(__file__).resolve().parents[1] /
+    "multi_agents" / "agents" / "plan_review.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "plan_review",
+    PLAN_REVIEW_PATH,
+)
+plan_review = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plan_review)
+
+
+def test_human_feedback_route_accepts_when_no_feedback():
+    assert plan_review.route_human_feedback({"human_feedback": None}) == "accept"
+
+
+def test_human_feedback_route_revises_until_limit():
+    assert plan_review.route_human_feedback({
+        "human_feedback": "add a section",
+        "plan_revision_count": 2,
+    }, max_plan_revisions=2) == "revise"
+
+
+def test_human_feedback_route_raises_after_limit():
+    with pytest.raises(plan_review.MaxPlanRevisionsExceededError):
+        plan_review.route_human_feedback({
+            "human_feedback": "try again",
+            "plan_revision_count": 3,
+        }, max_plan_revisions=2)
+
+
+def test_human_feedback_route_can_disable_limit():
+    assert plan_review.route_human_feedback({
+        "human_feedback": "keep revising",
+        "plan_revision_count": 99,
+    }, max_plan_revisions=None) == "revise"


### PR DESCRIPTION
## Summary

- Adds a `max_plan_revisions` task option for the multi-agent human feedback loop, defaulting to `3`.
- Tracks `plan_revision_count` in `HumanAgent.review_plan`.
- Routes human feedback through a small guard that raises `MaxPlanRevisionsExceededError` once the configured limit is exceeded, instead of falling through to LangGraph's recursion limit.
- Documents the new option in `multi_agents/README.md`, `task.json`, and the example `agent.py`.

Closes #1766.

## Testing

- `python3 -m py_compile multi_agents/agents/orchestrator.py multi_agents/agents/human.py multi_agents/agents/plan_review.py multi_agents/memory/research.py tests/test_multi_agents_plan_revisions.py`
- `PYTHONPATH=/tmp/gpt-researcher-pytest-target python3 -m pytest tests/test_multi_agents_plan_revisions.py -q`

The focused pytest run passed (`4 passed`). It was run with pytest installed into a throwaway `/tmp` target because this container does not have `python3-venv` or pytest preinstalled. Pytest emitted two config warnings for missing async pytest plugin options, but this test file does not use async fixtures.
