### PR TITLE
fix(deep_research): parse LLM output with json_repair + regex fallback

### DIFF
--- a/backend/report_type/deep_research/example.py
+++ b/backend/report_type/deep_research/example.py
@@ -4,6 +4,11 @@ import asyncio
 import logging
 from gpt_researcher import GPTResearcher
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
+from gpt_researcher.skills.deep_research import (
+    parse_follow_up_questions_response,
+    parse_research_results_response,
+    parse_search_queries_response,
+)
 from gpt_researcher.utils.llm import create_chat_completion
 from gpt_researcher.utils.enum import ReportType, ReportSource, Tone
 
@@ -50,8 +55,22 @@ class DeepResearch:
     async def generate_feedback(self, query: str, num_questions: int = 3) -> List[str]:
         """Generate follow-up questions to clarify research direction"""
         messages = [
-            {"role": "system", "content": "You are an expert researcher helping to clarify research directions."},
-            {"role": "user", "content": f"Given the following query from the user, ask some follow up questions to clarify the research direction. Return a maximum of {num_questions} questions, but feel free to return less if the original query is clear. Format each question on a new line starting with 'Question: ': {query}"}
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert researcher helping to clarify research directions. "
+                    "Return valid JSON only."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Given the following query from the user, ask some follow up questions to clarify the research direction. "
+                    f"Return a maximum of {num_questions} questions, but feel free to return less if the original query is clear.\n\n"
+                    'Return ONLY a JSON object using this exact schema:\n{"questions": ["<question 1>", "<question 2>"]}\n\n'
+                    f"Query: {query}"
+                ),
+            },
         ]
 
         response = await create_chat_completion(
@@ -63,17 +82,28 @@ class DeepResearch:
             reasoning_effort=ReasoningEfforts.High.value
         )
 
-        # Parse questions from response
-        questions = [q.replace('Question:', '').strip()
-                    for q in response.split('\n')
-                    if q.strip().startswith('Question:')]
-        return questions[:num_questions]
+        return parse_follow_up_questions_response(response, num_questions)
 
     async def generate_serp_queries(self, query: str, num_queries: int = 3) -> List[Dict[str, str]]:
         """Generate SERP queries for research"""
         messages = [
-            {"role": "system", "content": "You are an expert researcher generating search queries."},
-            {"role": "user", "content": f"Given the following prompt, generate {num_queries} unique search queries to research the topic thoroughly. For each query, provide a research goal. Format as 'Query: <query>' followed by 'Goal: <goal>' for each pair: {query}"}
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert researcher generating search queries. "
+                    "Return valid JSON only. Do not include markdown, code fences, bullets, numbering, or prose."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Given the following prompt, generate {num_queries} unique search queries to research the topic thoroughly. "
+                    "For each query, provide a research goal.\n\n"
+                    'Return ONLY a JSON array of objects using this exact schema:\n'
+                    '[{"query": "<search query>", "researchGoal": "<research goal>"}]\n\n'
+                    f"Prompt: {query}"
+                ),
+            },
         ]
 
         response = await create_chat_completion(
@@ -84,30 +114,29 @@ class DeepResearch:
             max_tokens=1000
         )
 
-        # Parse queries and goals from response
-        lines = response.split('\n')
-        queries = []
-        current_query = {}
-
-        for line in lines:
-            line = line.strip()
-            if line.startswith('Query:'):
-                if current_query:
-                    queries.append(current_query)
-                current_query = {'query': line.replace('Query:', '').strip()}
-            elif line.startswith('Goal:') and current_query:
-                current_query['researchGoal'] = line.replace('Goal:', '').strip()
-
-        if current_query:
-            queries.append(current_query)
-
-        return queries[:num_queries]
+        return parse_search_queries_response(response, num_queries)
 
     async def process_serp_result(self, query: str, context: str, num_learnings: int = 3) -> Dict[str, List[str]]:
         """Process research results to extract learnings and follow-up questions"""
         messages = [
-            {"role": "system", "content": "You are an expert researcher analyzing search results."},
-            {"role": "user", "content": f"Given the following research results for the query '{query}', extract key learnings and suggest follow-up questions. For each learning, include a citation to the source URL if available. Format each learning as 'Learning [source_url]: <insight>' and each question as 'Question: <question>':\n\n{context}"}
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert researcher analyzing search results. "
+                    "Return valid JSON only."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Given the following research results for the query '{query}', extract key learnings and suggest "
+                    "follow-up questions. For each learning, include a citation to the source URL if available.\n\n"
+                    'Return ONLY a JSON object using this exact schema:\n'
+                    '{"learnings": [{"insight": "<insight>", "sourceUrl": "<url or empty string>"}], '
+                    '"followUpQuestions": ["<question 1>", "<question 2>"]}\n\n'
+                    f"Research results:\n{context}"
+                ),
+            },
         ]
 
         response = await create_chat_completion(
@@ -119,33 +148,7 @@ class DeepResearch:
             reasoning_effort=ReasoningEfforts.High.value
         )
 
-        # Parse learnings and questions with citations
-        lines = response.split('\n')
-        learnings = []
-        questions = []
-        citations = {}
-
-        for line in lines:
-            line = line.strip()
-            if line.startswith('Learning'):
-                # Extract URL if present in square brackets
-                import re
-                url_match = re.search(r'\[(.*?)\]:', line)
-                if url_match:
-                    url = url_match.group(1)
-                    learning = line.split(':', 1)[1].strip()
-                    learnings.append(learning)
-                    citations[learning] = url
-                else:
-                    learnings.append(line.replace('Learning:', '').strip())
-            elif line.startswith('Question:'):
-                questions.append(line.replace('Question:', '').strip())
-
-        return {
-            'learnings': learnings[:num_learnings],
-            'followUpQuestions': questions[:num_learnings],
-            'citations': citations
-        }
+        return parse_research_results_response(response, num_learnings)
 
     async def deep_research(
         self,

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -1,8 +1,11 @@
 from typing import List, Dict, Any, Optional, Set
 import asyncio
 import logging
+import re
 import time
 from datetime import datetime, timedelta
+
+import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
 from ..utils.llm import create_chat_completion
@@ -13,6 +16,193 @@ logger = logging.getLogger(__name__)
 
 # Maximum words allowed in context (25k words for safety margin)
 MAX_CONTEXT_WORDS = 25000
+
+JSON_BLOCK_PATTERNS = [
+    re.compile(
+        r"```(?:json)?\s*(?P<payload>[\s\S]*?)```",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?P<payload>\[[\s\S]*\])"),
+    re.compile(r"(?P<payload>\{[\s\S]*\})"),
+]
+
+QUERY_LINE_PATTERN = re.compile(
+    r"^(?:[-*]|\d+[.)])?\s*Query:\s*(?P<query>.+)$",
+    re.IGNORECASE,
+)
+GOAL_LINE_PATTERN = re.compile(
+    r"^(?:[-*]|\d+[.)])?\s*(?:Goal|Research Goal):\s*(?P<goal>.+)$",
+    re.IGNORECASE,
+)
+QUESTION_LINE_PATTERN = re.compile(
+    r"^(?:[-*]|\d+[.)])?\s*(?:Question:\s*)?(?P<question>.+\?)$",
+    re.IGNORECASE,
+)
+LEARNING_LINE_PATTERN = re.compile(
+    r"^(?:[-*]|\d+[.)])?\s*Learning(?:\s*\[(?P<citation>[^\]]+)\])?:\s*(?P<learning>.+)$",
+    re.IGNORECASE,
+)
+URL_PATTERN = re.compile(r"https?://[^\s\]\)>\",;]+")
+
+
+def _extract_json_payloads(response: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    for pattern in JSON_BLOCK_PATTERNS:
+        for match in pattern.finditer(response):
+            candidate = match.group("payload").strip()
+            if candidate and candidate not in seen:
+                candidates.append(candidate)
+                seen.add(candidate)
+
+    return candidates
+
+
+def _load_repaired_json(response: str) -> Any:
+    for candidate in [response.strip(), *_extract_json_payloads(response)]:
+        if not candidate:
+            continue
+        try:
+            return json_repair.loads(candidate)
+        except Exception as exc:
+            logger.debug(
+                "json_repair failed on candidate (%d chars): %s",
+                len(candidate), exc,
+            )
+            continue
+    return None
+
+
+def parse_search_queries_response(response: str, num_queries: int) -> List[Dict[str, str]]:
+    parsed = _load_repaired_json(response)
+    candidate_queries = parsed
+    if isinstance(parsed, dict):
+        candidate_queries = parsed.get("queries") or parsed.get("searchQueries") or parsed.get("items")
+
+    if isinstance(candidate_queries, list):
+        queries = [
+            {
+                "query": item["query"].strip(),
+                "researchGoal": item["researchGoal"].strip(),
+            }
+            for item in candidate_queries
+            if isinstance(item, dict) and item.get("query") and item.get("researchGoal")
+        ]
+        if queries:
+            return queries[:num_queries]
+
+    queries: List[Dict[str, str]] = []
+    current_query: Dict[str, str] = {}
+
+    for raw_line in response.replace("```json", "").replace("```", "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        query_match = QUERY_LINE_PATTERN.match(line)
+        goal_match = GOAL_LINE_PATTERN.match(line)
+
+        if query_match:
+            if current_query.get("query") and current_query.get("researchGoal"):
+                queries.append(current_query)
+            current_query = {"query": query_match.group("query").strip()}
+        elif goal_match and current_query.get("query"):
+            current_query["researchGoal"] = goal_match.group("goal").strip()
+
+    if current_query.get("query") and current_query.get("researchGoal"):
+        queries.append(current_query)
+
+    return queries[:num_queries]
+
+
+def parse_follow_up_questions_response(response: str, num_questions: int) -> List[str]:
+    parsed = _load_repaired_json(response)
+    candidate_questions = parsed
+    if isinstance(parsed, dict):
+        candidate_questions = parsed.get("questions") or parsed.get("followUpQuestions") or parsed.get("items")
+
+    if isinstance(candidate_questions, list):
+        questions = [str(item).strip() for item in candidate_questions if str(item).strip()]
+        if questions:
+            return questions[:num_questions]
+
+    questions: List[str] = []
+    for raw_line in response.replace("```json", "").replace("```", "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        question_match = QUESTION_LINE_PATTERN.match(line)
+        if question_match:
+            questions.append(question_match.group("question").strip())
+
+    return questions[:num_questions]
+
+
+def parse_research_results_response(response: str, num_learnings: int) -> Dict[str, Any]:
+    parsed = _load_repaired_json(response)
+
+    if isinstance(parsed, dict):
+        learnings_payload = parsed.get("learnings", [])
+        follow_up_payload = parsed.get("followUpQuestions") or parsed.get("questions") or []
+        learnings: List[str] = []
+        citations: Dict[str, str] = {}
+
+        if isinstance(learnings_payload, list):
+            for item in learnings_payload:
+                if isinstance(item, dict):
+                    learning = str(item.get("insight") or item.get("learning") or "").strip()
+                    citation = str(item.get("sourceUrl") or item.get("citation") or "").strip()
+                else:
+                    learning = str(item).strip()
+                    citation = ""
+
+                if learning:
+                    learnings.append(learning)
+                    if citation:
+                        citations[learning] = citation
+
+        questions = [str(item).strip() for item in follow_up_payload if str(item).strip()]
+        if learnings or questions:
+            return {
+                "learnings": learnings[:num_learnings],
+                "followUpQuestions": questions[:num_learnings],
+                "citations": citations,
+            }
+
+    learnings: List[str] = []
+    questions: List[str] = []
+    citations: Dict[str, str] = {}
+
+    for raw_line in response.replace("```json", "").replace("```", "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        learning_match = LEARNING_LINE_PATTERN.match(line)
+        question_match = QUESTION_LINE_PATTERN.match(line)
+
+        if learning_match:
+            learning = learning_match.group("learning").strip()
+            citation = (learning_match.group("citation") or "").strip()
+            if not citation:
+                url_match = URL_PATTERN.search(learning)
+                if url_match:
+                    citation = url_match.group(0)
+                    learning = learning.replace(citation, "").strip(" -")
+            if learning:
+                learnings.append(learning)
+                if citation:
+                    citations[learning] = citation
+        elif question_match:
+            questions.append(question_match.group("question").strip())
+
+    return {
+        "learnings": learnings[:num_learnings],
+        "followUpQuestions": questions[:num_learnings],
+        "citations": citations,
+    }
 
 def count_words(text) -> int:
     """Count words in a text string. Handles both strings and lists."""
@@ -65,9 +255,23 @@ class DeepResearchSkill:
     async def generate_search_queries(self, query: str, num_queries: int = 3) -> List[Dict[str, str]]:
         """Generate SERP queries for research"""
         messages = [
-            {"role": "system", "content": "You are an expert researcher generating search queries."},
-            {"role": "user",
-             "content": f"Given the following prompt, generate {num_queries} unique search queries to research the topic thoroughly. For each query, provide a research goal. Format as 'Query: <query>' followed by 'Goal: <goal>' for each pair: {query}"}
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert researcher generating search queries. "
+                    "Return valid JSON only. Do not include markdown, code fences, bullets, numbering, or prose."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Given the following prompt, generate {num_queries} unique search queries to research the topic thoroughly. "
+                    "For each query, provide a research goal.\n\n"
+                    "Return ONLY a JSON array of objects using this exact schema:\n"
+                    '[{"query": "<search query>", "researchGoal": "<research goal>"}]\n\n'
+                    f"Prompt: {query}"
+                ),
+            },
         ]
 
         response = await create_chat_completion(
@@ -78,23 +282,7 @@ class DeepResearchSkill:
             temperature=0.4
         )
 
-        lines = response.split('\n')
-        queries = []
-        current_query = {}
-
-        for line in lines:
-            line = line.strip()
-            if line.startswith('Query:'):
-                if current_query:
-                    queries.append(current_query)
-                current_query = {'query': line.replace('Query:', '').strip()}
-            elif line.startswith('Goal:') and current_query:
-                current_query['researchGoal'] = line.replace('Goal:', '').strip()
-
-        if current_query:
-            queries.append(current_query)
-
-        return queries[:num_queries]
+        return parse_search_queries_response(response, num_queries)
 
     async def generate_research_plan(self, query: str, num_questions: int = 3) -> List[str]:
         """Generate follow-up questions to clarify research direction"""
@@ -117,7 +305,14 @@ class DeepResearchSkill:
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         messages = [
-            {"role": "system", "content": "You are an expert researcher. Your task is to analyze the original query and search results, then generate targeted questions that explore different aspects and time periods of the topic."},
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert researcher. Your task is to analyze the original query and search results, "
+                    "then generate targeted questions that explore different aspects and time periods of the topic. "
+                    "Return valid JSON only."
+                ),
+            },
             {"role": "user",
              "content": f"""Original query: {query}
 
@@ -128,7 +323,8 @@ Search results:
 
 Based on these results, the original query, and the current time, generate {num_questions} unique questions. Each question should explore a different aspect or time period of the topic, considering recent developments up to {current_time}.
 
-Format each question on a new line starting with 'Question: '"""}
+Return ONLY a JSON object using this exact schema:
+{{"questions": ["<question 1>", "<question 2>"]}}"""}
         ]
 
         response = await create_chat_completion(
@@ -139,17 +335,27 @@ Format each question on a new line starting with 'Question: '"""}
             temperature=0.4
         )
 
-        questions = [q.replace('Question:', '').strip()
-                     for q in response.split('\n')
-                     if q.strip().startswith('Question:')]
-        return questions[:num_questions]
+        return parse_follow_up_questions_response(response, num_questions)
 
     async def process_research_results(self, query: str, context: str, num_learnings: int = 3) -> Dict[str, List[str]]:
         """Process research results to extract learnings and follow-up questions"""
         messages = [
-            {"role": "system", "content": "You are an expert researcher analyzing search results."},
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert researcher analyzing search results. "
+                    "Return valid JSON only."
+                ),
+            },
             {"role": "user",
-             "content": f"Given the following research results for the query '{query}', extract key learnings and suggest follow-up questions. For each learning, include a citation to the source URL if available. Format each learning as 'Learning [source_url]: <insight>' and each question as 'Question: <question>':\n\n{context}"}
+             "content": (
+                 f"Given the following research results for the query '{query}', extract key learnings and suggest "
+                 "follow-up questions. For each learning, include a citation to the source URL if available.\n\n"
+                 "Return ONLY a JSON object using this exact schema:\n"
+                 '{"learnings": [{"insight": "<insight>", "sourceUrl": "<url or empty string>"}], '
+                 '"followUpQuestions": ["<question 1>", "<question 2>"]}\n\n'
+                 f"Research results:\n{context}"
+             )}
         ]
 
         response = await create_chat_completion(
@@ -161,40 +367,7 @@ Format each question on a new line starting with 'Question: '"""}
             max_tokens=1000
         )
 
-        lines = response.split('\n')
-        learnings = []
-        questions = []
-        citations = {}
-
-        for line in lines:
-            line = line.strip()
-            if line.startswith('Learning'):
-                import re
-                url_match = re.search(r'\[(.*?)\]:', line)
-                if url_match:
-                    url = url_match.group(1)
-                    learning = line.split(':', 1)[1].strip()
-                    learnings.append(learning)
-                    citations[learning] = url
-                else:
-                    # Try to find URL in the line itself
-                    url_match = re.search(
-                        r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', line)
-                    if url_match:
-                        url = url_match.group(0)
-                        learning = line.replace(url, '').replace('Learning:', '').strip()
-                        learnings.append(learning)
-                        citations[learning] = url
-                    else:
-                        learnings.append(line.replace('Learning:', '').strip())
-            elif line.startswith('Question:'):
-                questions.append(line.replace('Question:', '').strip())
-
-        return {
-            'learnings': learnings[:num_learnings],
-            'followUpQuestions': questions[:num_learnings],
-            'citations': citations
-        }
+        return parse_research_results_response(response, num_learnings)
 
     async def deep_research(
             self,

--- a/tests/test_deep_research_parsing.py
+++ b/tests/test_deep_research_parsing.py
@@ -1,0 +1,296 @@
+from types import SimpleNamespace
+
+import pytest
+
+import gpt_researcher.skills.deep_research as deep_research_module
+from gpt_researcher.skills.deep_research import (
+    DeepResearchSkill,
+    parse_follow_up_questions_response,
+    parse_research_results_response,
+    parse_search_queries_response,
+)
+
+
+def make_skill() -> DeepResearchSkill:
+    cfg = SimpleNamespace(
+        strategic_llm_provider="anthropic",
+        strategic_llm_model="claude-haiku-4-5",
+        reasoning_effort="medium",
+        deep_research_breadth=3,
+        deep_research_depth=2,
+        deep_research_concurrency=2,
+        config_path=None,
+    )
+    researcher = SimpleNamespace(
+        cfg=cfg,
+        websocket=None,
+        tone=None,
+        headers={},
+        visited_urls=set(),
+        retrievers=[SimpleNamespace()],
+        research_sources=[],
+        mcp_configs=None,
+        mcp_strategy=None,
+    )
+    return DeepResearchSkill(researcher)
+
+
+def stub_search_results(monkeypatch):
+    async def fake_get_search_results(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(deep_research_module, "get_search_results", fake_get_search_results)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (
+            '[{"query":"q1","researchGoal":"g1"},{"query":"q2","researchGoal":"g2"}]',
+            [
+                {"query": "q1", "researchGoal": "g1"},
+                {"query": "q2", "researchGoal": "g2"},
+            ],
+        ),
+        (
+            'Sure — here is the JSON.\n```json\n[{"query":"q1","researchGoal":"g1"}]\n```',
+            [{"query": "q1", "researchGoal": "g1"}],
+        ),
+        (
+            "1. Query: q1\n   Goal: g1\n2. Query: q2\n   Goal: g2",
+            [
+                {"query": "q1", "researchGoal": "g1"},
+                {"query": "q2", "researchGoal": "g2"},
+            ],
+        ),
+        (
+            "- Query: q1\n- Goal: g1\n- Query: q2\n- Goal: g2",
+            [
+                {"query": "q1", "researchGoal": "g1"},
+                {"query": "q2", "researchGoal": "g2"},
+            ],
+        ),
+        (
+            "Query: q1\nGoal: g1\nQuery: q2\nGoal: g2",
+            [
+                {"query": "q1", "researchGoal": "g1"},
+                {"query": "q2", "researchGoal": "g2"},
+            ],
+        ),
+    ],
+)
+async def test_generate_search_queries_parses_supported_formats(monkeypatch, response, expected):
+    skill = make_skill()
+
+    async def fake_create_chat_completion(**kwargs):
+        return response
+
+    monkeypatch.setattr(deep_research_module, "create_chat_completion", fake_create_chat_completion)
+
+    assert await skill.generate_search_queries("topic", num_queries=3) == expected
+
+
+@pytest.mark.asyncio
+async def test_generate_search_queries_prompt_requires_json(monkeypatch):
+    skill = make_skill()
+    captured = {}
+
+    async def fake_create_chat_completion(**kwargs):
+        captured["messages"] = kwargs["messages"]
+        return "[]"
+
+    monkeypatch.setattr(deep_research_module, "create_chat_completion", fake_create_chat_completion)
+
+    await skill.generate_search_queries("topic", num_queries=2)
+
+    system_prompt = captured["messages"][0]["content"]
+    user_prompt = captured["messages"][1]["content"]
+    assert "Return valid JSON only" in system_prompt
+    assert "Return ONLY a JSON array of objects" in user_prompt
+
+
+def test_parse_search_queries_response_repairs_trailing_comma():
+    response = '[{"query": "test query", "researchGoal": "test goal",}]'
+
+    result = parse_search_queries_response(response, num_queries=3)
+
+    assert result
+    assert result[0]["query"] == "test query"
+    assert result[0]["researchGoal"] == "test goal"
+
+
+def test_parse_search_queries_response_accepts_uppercase_json_fence():
+    response = '```JSON\n[{"query": "x", "researchGoal": "y"}]\n```'
+
+    result = parse_search_queries_response(response, num_queries=3)
+
+    assert result
+    assert result[0]["query"] == "x"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ('{"questions":["What changed in 2025?","What should we compare?"]}', ["What changed in 2025?", "What should we compare?"]),
+        ('Intro\n```json\n{"questions":["What changed in 2025?"]}\n```', ["What changed in 2025?"]),
+        ("1. Question: What changed in 2025?\n2. Question: What should we compare?", ["What changed in 2025?", "What should we compare?"]),
+        ("- What changed in 2025?\n- What should we compare?", ["What changed in 2025?", "What should we compare?"]),
+    ],
+)
+async def test_generate_research_plan_parses_supported_formats(monkeypatch, response, expected):
+    skill = make_skill()
+    stub_search_results(monkeypatch)
+
+    async def fake_create_chat_completion(**kwargs):
+        return response
+
+    monkeypatch.setattr(deep_research_module, "create_chat_completion", fake_create_chat_completion)
+
+    assert await skill.generate_research_plan("topic", num_questions=3) == expected
+
+
+@pytest.mark.asyncio
+async def test_generate_research_plan_prompt_requires_json(monkeypatch):
+    skill = make_skill()
+    captured = {}
+    stub_search_results(monkeypatch)
+
+    async def fake_create_chat_completion(**kwargs):
+        captured["messages"] = kwargs["messages"]
+        return '{"questions":[]}'
+
+    monkeypatch.setattr(deep_research_module, "create_chat_completion", fake_create_chat_completion)
+
+    await skill.generate_research_plan("topic", num_questions=2)
+
+    system_prompt = captured["messages"][0]["content"]
+    user_prompt = captured["messages"][1]["content"]
+    assert "Return valid JSON only" in system_prompt
+    assert '{"questions": ["<question 1>", "<question 2>"]}' in user_prompt
+
+
+def test_parse_follow_up_questions_response_repairs_missing_quote():
+    response = '{"questions": ["What is X", "Why is Y?]}'
+
+    result = parse_follow_up_questions_response(response, num_questions=3)
+
+    assert result
+    assert result[0] == "What is X"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (
+            '{"learnings":[{"insight":"Insight 1","sourceUrl":"https://a.test"},{"insight":"Insight 2","sourceUrl":""}],"followUpQuestions":["What next?","Why now?"]}',
+            {
+                "learnings": ["Insight 1", "Insight 2"],
+                "followUpQuestions": ["What next?", "Why now?"],
+                "citations": {"Insight 1": "https://a.test"},
+            },
+        ),
+        (
+            'Here is the JSON:\n```json\n{"learnings":[{"insight":"Insight 1","sourceUrl":"https://a.test"}],"followUpQuestions":["What next?"]}\n```',
+            {
+                "learnings": ["Insight 1"],
+                "followUpQuestions": ["What next?"],
+                "citations": {"Insight 1": "https://a.test"},
+            },
+        ),
+        (
+            "1. Learning [https://a.test]: Insight 1\n2. Learning [https://b.test]: Insight 2\n3. Question: What next?",
+            {
+                "learnings": ["Insight 1", "Insight 2"],
+                "followUpQuestions": ["What next?"],
+                "citations": {
+                    "Insight 1": "https://a.test",
+                    "Insight 2": "https://b.test",
+                },
+            },
+        ),
+        (
+            "- Learning [https://a.test]: Insight 1\n- Learning: Insight 2 https://b.test\n- What next?",
+            {
+                "learnings": ["Insight 1", "Insight 2"],
+                "followUpQuestions": ["What next?"],
+                "citations": {
+                    "Insight 1": "https://a.test",
+                    "Insight 2": "https://b.test",
+                },
+            },
+        ),
+        (
+            "Learning [https://a.test]: Insight 1\nQuestion: What next?",
+            {
+                "learnings": ["Insight 1"],
+                "followUpQuestions": ["What next?"],
+                "citations": {"Insight 1": "https://a.test"},
+            },
+        ),
+    ],
+)
+async def test_process_research_results_parses_supported_formats(monkeypatch, response, expected):
+    skill = make_skill()
+
+    async def fake_create_chat_completion(**kwargs):
+        return response
+
+    monkeypatch.setattr(deep_research_module, "create_chat_completion", fake_create_chat_completion)
+
+    assert await skill.process_research_results("topic", "context", num_learnings=3) == expected
+
+
+@pytest.mark.asyncio
+async def test_process_research_results_prompt_requires_json(monkeypatch):
+    skill = make_skill()
+    captured = {}
+
+    async def fake_create_chat_completion(**kwargs):
+        captured["messages"] = kwargs["messages"]
+        return '{"learnings":[],"followUpQuestions":[]}'
+
+    monkeypatch.setattr(deep_research_module, "create_chat_completion", fake_create_chat_completion)
+
+    await skill.process_research_results("topic", "context", num_learnings=2)
+
+    system_prompt = captured["messages"][0]["content"]
+    user_prompt = captured["messages"][1]["content"]
+    assert "Return valid JSON only" in system_prompt
+    assert '"learnings": [{"insight": "<insight>", "sourceUrl": "<url or empty string>"}]' in user_prompt
+
+
+def test_parse_responses_return_empty_values_for_blank_input():
+    expected_research_results = {
+        "learnings": [],
+        "followUpQuestions": [],
+        "citations": {},
+    }
+
+    for response in ("", "   \n  \t  "):
+        assert parse_search_queries_response(response, num_queries=3) == []
+        assert parse_follow_up_questions_response(response, num_questions=3) == []
+        assert parse_research_results_response(response, num_learnings=3) == expected_research_results
+
+
+def test_parse_research_results_response_preserves_full_json_url():
+    response = (
+        '{"learnings": [{"insight": "fact",'
+        ' "sourceUrl": "https://example.com/path?x=1&y=2"}],'
+        ' "followUpQuestions": []}'
+    )
+
+    result = parse_research_results_response(response, num_learnings=3)
+
+    assert result["citations"]["fact"] == "https://example.com/path?x=1&y=2"
+
+
+def test_parse_research_results_response_extracts_inline_legacy_url():
+    response = "Learning: stuff happened at https://example.com/api/v1?key=value"
+
+    result = parse_research_results_response(response, num_learnings=3)
+
+    assert result["learnings"] == ["stuff happened at"]
+    assert result["citations"]["stuff happened at"] == "https://example.com/api/v1?key=value"


### PR DESCRIPTION
Fixes #1772

## What

Replaces the free-form string parsing in Deep Research
(`startswith('Query:')`, `startswith('Question:')`,
`startswith('Learning')`) with:

1. JSON-strict prompts that request a specific schema.
2. Primary parsing via `json_repair` (same library used in
   `gpt_researcher/actions/query_processing.py`).
3. A regex fallback for the legacy `Query: ...` / `Goal: ...` /
   `Learning [url]: ...` formats, to avoid breaking users running
   custom models that produce the previous output style.

## Why

See #1772 for the bug context. The short version: the existing
parser fails silently on any LLM whose output doesn't match the
hardcoded literal prefixes (reproduced with Claude Haiku 4.5).
The standard pipeline already solves this with `json_repair` on
a JSON-constrained prompt; this PR brings Deep Research in line
with that approach while keeping a fallback for backwards
compatibility.

## Changes

- `gpt_researcher/skills/deep_research.py`:
  - Prompts in `generate_search_queries`, `generate_research_plan`,
    `process_research_results` updated to request strict JSON with
    an explicit schema.
  - New module-level parsers: `parse_search_queries_response`,
    `parse_follow_up_questions_response`,
    `parse_research_results_response`. Each tries `json_repair`
    first (including extraction from markdown fences), then falls
    back to regex line parsing for legacy formats.
  - Minor robustness improvements: debug log on `json_repair`
    failure (previously swallowed silently); case-insensitive
    markdown fence detection; simplified URL extraction pattern.
- `backend/report_type/deep_research/example.py`: standalone
  example updated to use the new parsers.
- `tests/test_deep_research_parsing.py`: new test file covering
  clean JSON, fenced JSON (lowercase and uppercase), malformed
  but `json_repair`-repairable JSON (trailing comma, missing
  quote), empty / whitespace input, legacy `Query:` / `Learning:`
  formats, and URL preservation in both JSON and legacy paths.

## Validation

- 23/23 tests pass locally
  (`pytest tests/test_deep_research_parsing.py -v`).
- End-to-end Deep Research run completes with Claude Haiku 4.5 as
  the configured LLM (previously failed with `Generated 0 queries`
  and a report generated on zero context).
- Standard (non-deep) research pipeline unchanged — patch is
  scoped to Deep Research only.
- Diff: 3 files changed, +592 / -120.

## Notes

- No new dependency: `json_repair` is already in `requirements.txt`
  and used in `actions/query_processing.py`.
- No public API change.
- Regex fallback can be removed in a follow-up once the new prompt
  format is confirmed in production, but keeping it here makes the
  change non-breaking.