### PR TITLE
fix(llm): raise max_tokens cap from 32k to 200k for modern long-output models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,21 @@ DOC_PATH=./my-docs
 # LANGCHAIN_ENDPOINT="https://api.smith.langchain.com"
 # LANGCHAIN_API_KEY=
 # LANGCHAIN_PROJECT="gpt-researcher"
+
+# Token Limits
+# ------------
+# Maximum output tokens per LLM call. Leaving unset uses package defaults
+# (FAST=3000, SMART=6000, STRATEGIC=4000) suited to GPT-4o-class models.
+# Modern long-output models (Claude 4.x, GPT-5) truncate reports at
+# these defaults.
+#
+# Recommended values by model class:
+#   GPT-4o family (16k max output):   SMART_TOKEN_LIMIT=8000
+#   Claude Haiku 4.5 (64k max):       SMART_TOKEN_LIMIT=16000
+#   Claude Sonnet 4.6 (64k max):      SMART_TOKEN_LIMIT=16000
+#   Claude Opus 4.7 (128k max):       SMART_TOKEN_LIMIT=32000
+#   GPT-5 family (128k max):          SMART_TOKEN_LIMIT=32000
+#
+# FAST_TOKEN_LIMIT=8000
+# SMART_TOKEN_LIMIT=16000
+# STRATEGIC_TOKEN_LIMIT=16000

--- a/docs/docs/gpt-researcher/gptr/config.md
+++ b/docs/docs/gpt-researcher/gptr/config.md
@@ -26,8 +26,8 @@ The config JSON should follow the format/keys in the default config. Below is a 
   "STRATEGIC_LLM": "openai:o4-mini",
   "LANGUAGE": "english",
   "CURATE_SOURCES": false,
-  "FAST_TOKEN_LIMIT": 2000,
-  "SMART_TOKEN_LIMIT": 4000,
+  "FAST_TOKEN_LIMIT": 3000,
+  "SMART_TOKEN_LIMIT": 6000,
   "STRATEGIC_TOKEN_LIMIT": 4000,
   "BROWSE_CHUNK_MAX_LENGTH": 8192,
   "SUMMARY_TOKEN_LIMIT": 700,
@@ -58,9 +58,28 @@ Below is a list of current supported options:
 - **`STRATEGIC_LLM`**: Model name for strategic operations like generating research plans and strategies. Defaults to `openai:gpt-5-mini`.
 - **`LANGUAGE`**: Language to be used for the final research report. Defaults to `english`.
 - **`CURATE_SOURCES`**: Whether to curate sources for research. This step adds an LLM run which may increase costs and total run time but improves quality of source selection. Defaults to `False`.
-- **`FAST_TOKEN_LIMIT`**: Maximum token limit for fast LLM responses. Defaults to `2000`.
-- **`SMART_TOKEN_LIMIT`**: Maximum token limit for smart LLM responses. Defaults to `4000`.
+- **`FAST_TOKEN_LIMIT`**: Maximum token limit for fast LLM responses. Defaults to `3000`.
+- **`SMART_TOKEN_LIMIT`**: Maximum token limit for smart LLM responses. Defaults to `6000`.
 - **`STRATEGIC_TOKEN_LIMIT`**: Maximum token limit for strategic LLM responses. Defaults to `4000`.
+
+#### Recommended values for modern long-output models
+
+The default token limits are calibrated for GPT-4o-class models
+(16k max output). For models with larger output capacity, increase
+these limits to avoid truncated reports:
+
+| Model family            | Max output | Recommended SMART_TOKEN_LIMIT |
+|-------------------------|-----------:|------------------------------:|
+| GPT-4o / GPT-4.1        |        16k |                          8000 |
+| Claude Haiku 4.5        |        64k |                         16000 |
+| Claude Sonnet 4.6       |        64k |                         16000 |
+| Claude Opus 4.7         |       128k |                         32000 |
+| GPT-5 family            |       128k |                         32000 |
+
+Apply proportional values to `FAST_TOKEN_LIMIT` and
+`STRATEGIC_TOKEN_LIMIT` if you use distinct models for those roles.
+The hard upper bound is 200k (sanity guard against typos).
+
 - **`BROWSE_CHUNK_MAX_LENGTH`**: Maximum length of text chunks to browse in web sources. Defaults to `8192`.
 - **`SUMMARY_TOKEN_LIMIT`**: Maximum token limit for generating summaries. Defaults to `700`.
 - **`TEMPERATURE`**: Sampling temperature for LLM responses, typically between 0 and 1. A higher value results in more randomness and creativity, while a lower value results in more focused and deterministic responses. Defaults to `0.4`.

--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -10,6 +10,12 @@ Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_ver
 To learn more about support customization options see [here](/docs/gpt-researcher/gptr/config).
 
 **Please note**: GPT Researcher is optimized and heavily tested on GPT models. Some other models might run into context limit errors, and unexpected responses.
+> **Token limits**: Modern long-output models (Claude 4.x, GPT-5)
+> require raising `SMART_TOKEN_LIMIT` and related variables above
+> their defaults to avoid truncated reports. See
+> [config documentation](../gptr/config#recommended-values-for-modern-long-output-models)
+> for recommended values.
+
 Please provide any feedback in our [Discord community](https://discord.gg/QgZXvJAccX) channel, so we can better improve the experience and performance.
 
 Below you can find examples for how to configure the various supported LLMs.

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -70,9 +70,15 @@ async def create_chat_completion(
     # validate input
     if model is None:
         raise ValueError("Model cannot be None")
-    if max_tokens is not None and max_tokens > 32001:
+    # Sanity guard against absurd values (e.g., env var typos). The actual
+    # per-model output limits are enforced by the upstream provider.
+    if max_tokens is not None and max_tokens > 200_000:
         raise ValueError(
-            f"Max tokens cannot be more than 32,000, but got {max_tokens}")
+            f"max_tokens={max_tokens} exceeds the largest output limit of "
+            "any currently available model (128k as of late 2025). "
+            "Check your FAST_TOKEN_LIMIT / SMART_TOKEN_LIMIT / "
+            "STRATEGIC_TOKEN_LIMIT env vars for typos."
+        )
 
     # Get the provider from supported providers
     provider_kwargs = {'model': model}

--- a/tests/test_llm_max_tokens.py
+++ b/tests/test_llm_max_tokens.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gpt_researcher.utils.llm import create_chat_completion
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_accepts_max_tokens_above_old_32k_cap():
+    provider = MagicMock()
+    provider.get_chat_response = AsyncMock(side_effect=["ok-64000", "ok-128000"])
+
+    with patch("gpt_researcher.utils.llm.get_llm", return_value=provider) as mock_get_llm:
+        accepted_values = (
+            (64_000, "ok-64000"),
+            (128_000, "ok-128000"),
+        )
+
+        for max_tokens, expected in accepted_values:
+            result = await create_chat_completion(
+                messages=[{"role": "user", "content": "Generate a report"}],
+                model="claude-sonnet-4-6",
+                max_tokens=max_tokens,
+                llm_provider="anthropic",
+            )
+
+            assert result == expected
+
+    assert [call.kwargs["max_tokens"] for call in mock_get_llm.call_args_list] == [64_000, 128_000]
+
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_rejects_absurd_max_tokens():
+    with patch("gpt_researcher.utils.llm.get_llm") as mock_get_llm:
+        with pytest.raises(ValueError, match="env vars|typos"):
+            await create_chat_completion(
+                messages=[{"role": "user", "content": "Generate a report"}],
+                model="claude-sonnet-4-6",
+                max_tokens=1_000_000,
+                llm_provider="anthropic",
+            )
+
+    mock_get_llm.assert_not_called()


### PR DESCRIPTION
## Problem

`create_chat_completion` in `gpt_researcher/utils/llm.py` rejects any `max_tokens > 32001` with a hardcoded `ValueError`. This predates modern LLMs with 64k–128k output capacity (Claude 4.x family, GPT-5 family) and silently breaks long-form report generation:

1. The user sets `SMART_TOKEN_LIMIT=64000` to leverage their model
2. Report generation hits the cap and raises `ValueError`
3. `report_generation.py` catches it in a broad `except` and returns `""`
4. The user gets an empty report with no actionable error

This bug was reported in #1335 (April 2025), closed without a verified fix. The cap is still present in `main` as of today.

## Fix

The cap is **raised, not removed**. It still serves as a sanity guard against absurd typos (e.g., `SMART_TOKEN_LIMIT=1000000`), which matters for providers like Ollama or litellm-routed backends where the upstream API may not surface a clear error. Cloud APIs (Anthropic, OpenAI) already enforce model-specific limits with descriptive errors, so we defer to them for the precise per-model boundary.

The new cap is 200k, leaving ~50% headroom above the largest currently available cloud output limit (128k). The error message now points at the relevant env vars instead of stating an arbitrary number.

Three atomic commits:

1. **fix(llm)**: raise the cap from 32k to 200k, improve error message, add unit tests covering both accepted (64k, 128k) and rejected (1M) cases.

2. **docs(env)**: add commented `TOKEN_LIMIT` examples to `.env.example` with recommended values per model class. Default behavior unchanged.

3. **docs(config)**: correct outdated default values in `config.md` (runtime defaults are 3000/6000/4000, docs said 2000/4000/4000) and add a recommended-values table for modern models.

## Related follow-ups (out of scope)

- `report_generation.py:290-306` swallows exceptions silently and returns `""`. The 32k cap was its main trigger, but other failures will still surface as empty reports. Worth a separate PR with proper error propagation.
- `agent_creator.py` and `tools.py` still use hardcoded `max_tokens=4000` defaults independent of config. Same pattern, separate sweep.

## Tests

- `tests/test_llm_max_tokens.py` (new): asserts that `create_chat_completion` accepts `max_tokens` values previously blocked (64000, 128000), and still rejects absurd values (1000000) with an actionable error message.
- New test passes locally in asyncio strict mode.

Closes #1335
