### PR TITLE
fix: normalize curate_sources() return type before assigning to researcher.context

### DIFF
--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -194,7 +194,21 @@ class ResearchConductor:
         self.researcher.context = research_data
         if self.researcher.cfg.curate_sources:
             self.logger.info("Curating sources")
-            self.researcher.context = await self.researcher.source_curator.curate_sources(research_data)
+            curated = await self.researcher.source_curator.curate_sources(research_data)
+            # curate_sources() returns List[dict] with Title/Content/Source keys.
+            # Normalize to str so downstream code that expects researcher.context
+            # to be a string (e.g. "\n".join, .split(), len()) doesn't crash.
+            if isinstance(curated, list):
+                self.researcher.context = "\n\n".join(
+                    "Title: {title}\nContent: {content}\nSource: {source}".format(
+                        title=s.get("Title", ""),
+                        content=s.get("Content", ""),
+                        source=s.get("Source", ""),
+                    ) if isinstance(s, dict) else str(s)
+                    for s in curated
+                )
+            else:
+                self.researcher.context = curated
 
         if self.researcher.verbose:
             await stream_output(


### PR DESCRIPTION
## Problem

`curate_sources()` returns `List[dict]` where each dict has `Title`, `Content`, and `Source` keys. This return value is assigned directly to `researcher.context`:

```python
self.researcher.context = await self.researcher.source_curator.curate_sources(research_data)
```

But `researcher.context` is expected to be a `str` throughout the rest of the codebase. This causes crashes wherever context is used as a string:

- `AttributeError: 'list' object has no attribute 'split'` (reported in #1279)
- `TypeError: sequence item N: expected str instance, dict found`
- `len(researcher.context)` returns item count instead of character count

## Fix

Capture the `curate_sources()` return value, detect if it is a `List[dict]`, and format each entry as a human-readable `Title / Content / Source` block joined by double newlines before assigning to `researcher.context`. Non-dict items fall back to `str()`. Non-list returns are passed through unchanged.

This keeps the curated content readable by the downstream report generator while preserving the expected type contract on `researcher.context`.

## Testing

Set `CURATE_SOURCES=True` and run any research task (not just deep research). The crash on `researcher.context.split()` or `"\n".join(...)` downstream will no longer occur.

Related to #1279