### PR TITLE
fix: make search query prompt retriever-agnostic, prohibit operator syntax

### DIFF
--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -245,7 +245,11 @@ Use this context to inform and refine your search queries. The context provides 
 
         dynamic_example = ", ".join([f'"query {i+1}"' for i in range(max_iterations)])
 
-        return f"""Write {max_iterations} google search queries to search online that form an objective opinion from the following task: "{task}"
+        return f"""Write {max_iterations} search queries to research the following task: "{task}"
+
+Each query must be a plain natural language phrase. Do not use search operator syntax
+such as site:, filetype:, inurl:, intitle:, OR, AND, or NOT — these operators are
+not universally supported and will return empty results on many search backends.
 
 Assume the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if required.
 


### PR DESCRIPTION
## Problem

`generate_search_queries_prompt()` in `prompts.py` instructs the LLM to write **"google search queries"**:

```python
return f"""Write {max_iterations} google search queries to search online..."""
```

Instruction-following models (e.g. GPT-4, GPT-5.4) interpret this literally and autonomously inject Google-specific operator syntax into the generated queries:

```
"site:arxiv.org machine learning 2024"
"filetype:pdf neural networks survey"
"site:acm.org OR site:ieee.org distributed systems"
```

**Most search backends do not support these operators.** Tavily, DuckDuckGo, Semantic Scholar, Exa, Bing, and others return zero results when `site:`, `filetype:`, `inurl:`, or boolean `OR`/`AND`/`NOT` operators appear in the query string. This silently kills individual sub-query result sets mid-research, causing the final report to be sourced from far fewer documents than expected — with no warning to the user.

The bug is most visible on non-default backends (any `RETRIEVER` value other than Google), but also affects users who route their Google-type retriever through an API that strips operator syntax before forwarding.

## Fix

- Remove the word `google` from the prompt (this single word is the trigger for operator injection)
- Add an explicit one-sentence instruction not to use operator syntax and explain why (unsupported on many backends)
- Keep the change backend-neutral — the fix is correct regardless of which retriever(s) are configured and does not degrade result quality on Google-backed retrievers

## Testing

Set any non-Google retriever (e.g. `RETRIEVER=tavily`) and run a research task on a technical topic. Before this fix, many sub-queries contain `site:` or `filetype:` operators and return zero results. After this fix, all queries are plain natural language phrases and return results normally.