### PR TITLE
Fix incorrect config file path in Chinese README

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -116,8 +116,8 @@ $ export TAVILY_API_KEY={Your Tavily API Key here}
 # $ export LANGCHAIN_API_KEY={Your LangChain API Key here}
 ```
 
-- **LLM，我们推荐使用 [OpenAI GPT](https://platform.openai.com/docs/guides/gpt)**，但您也可以使用 [Langchain Adapter](https://python.langchain.com/docs/guides/adapters/openai) 支持的任何其他 LLM 模型（包括开源），只需在 config/config.py 中更改 llm 模型和提供者即可。请按照 [这份指南](https://python.langchain.com/docs/integrations/llms/) 学习如何将 LLM 与 Langchain 集成。
-- **对于搜索引擎，我们推荐使用 [Tavily Search API](https://app.tavily.com)（已针对 LLM 进行优化）**，但您也可以选择其他搜索引擎，只需将 config/config.py 中的搜索提供程序更改为 "duckduckgo"、"googleAPI"、"searchapi"、"googleSerp "或 "searx "即可。然后在 config.py 文件中添加相应的 env API 密钥。
+- **LLM，我们推荐使用 [OpenAI GPT](https://platform.openai.com/docs/guides/gpt)**，但您也可以使用 [Langchain Adapter](https://python.langchain.com/docs/guides/adapters/openai) 支持的任何其他 LLM 模型（包括开源），只需在 gpt_researcher/config/variables/default.py 中更改 llm 模型和提供者即可。请按照 [这份指南](https://python.langchain.com/docs/integrations/llms/) 学习如何将 LLM 与 Langchain 集成。
+- **对于搜索引擎，我们推荐使用 [Tavily Search API](https://app.tavily.com)（已针对 LLM 进行优化）**，但您也可以选择其他搜索引擎，只需将 gpt_researcher/config/variables/default.py 中的搜索提供程序更改为 "duckduckgo"、"googleAPI"、"searchapi"、"googleSerp "或 "searx "即可。然后在 gpt_researcher/config/variables/default.py 文件中添加相应的 env API 密钥。
 - **我们强烈建议使用 [OpenAI GPT](https://platform.openai.com/docs/guides/gpt) 模型和 [Tavily Search API](https://app.tavily.com) 以获得最佳性能。**
 <br />
 


### PR DESCRIPTION
This PR fixes incorrect configuration file references in the Chinese README.

### What was wrong
The README pointed users to `config/config.py`, which is not the correct file for updating default model/search settings.

### What I changed
- Updated the referenced path to `gpt_researcher/config/variables/default.py` in the Chinese README.
- Corrected related wording so users can find the right file directly.

### Why this matters
New contributors and users can now update LLM/search defaults without confusion, reducing setup friction.

### Scope
- Documentation only
- No runtime/code behavior changes