### PR TITLE
fix(retrieval): send Brave snippets to scraper

### DIFF
--- a/PR_pr_fix-brave-snippet-bypasses-scraper.md
+++ b/PR_pr_fix-brave-snippet-bypasses-scraper.md
@@ -1,0 +1,35 @@
+# One-line summary
+
+Fix Brave search result classification so snippet-only results are sent to the scraper instead of being treated as already-fetched full content.
+
+## Problem
+
+Brave search results populate `body` with snippet text, not full-page content. In `ResearchConductor._search_relevant_source_urls()`, results were classified as already-fetched whenever `len(raw_content) > 100`, where `raw_content` fell back to `result["body"]`. That caused Brave results with long snippets to bypass scraping entirely.
+
+In the failing reproduction, this manifested as every sub-query logging **"Scraping content from 0 URLs"** because all Brave hits were treated as prefetched content before the scraper ever saw them.
+
+This PR intentionally contains only the snippet-classification fix. The separate scraped-count tracking used by local safeguard logic belongs to the safeguards PR, not this one.
+
+## Solution
+
+- Stop treating `body` as full page content in `_search_relevant_source_urls()`
+- Use only explicit `raw_content` to identify retriever results that already contain full text
+- Leave snippet-only results in the URL list so the normal scraper path runs
+- Add focused tests covering:
+  - snippet-only retriever results are queued for scraping
+  - explicit `raw_content` results remain prefetched
+
+## Testing
+
+Verified locally with:
+
+- `uv run python -c "from gpt_researcher.skills.researcher import ResearchConductor; print('ok')"`
+- `uv run python -m unittest tests.test_research_conductor_retrieval`
+
+## Breaking changes
+
+None.
+
+## Related issues
+
+- Potentially related: #1263

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -776,9 +776,10 @@ class ResearchConductor:
                 # Separate results that already have content from those needing scraping
                 for result in search_results:
                     url = result.get("href") or result.get("url")
-                    raw_content = result.get("raw_content") or result.get("body")
+                    raw_content = result.get("raw_content")
                     if url and raw_content and len(raw_content) > 100:
-                        # Retriever already fetched full content (e.g. PubMed Central)
+                        # Only raw_content signals that a retriever already fetched the full page.
+                        # body is snippet-sized text for most web retrievers and still needs scraping.
                         prefetched_content.append({
                             "url": url,
                             "raw_content": raw_content,

--- a/tests/test_research_conductor_retrieval.py
+++ b/tests/test_research_conductor_retrieval.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+
+from gpt_researcher.skills.researcher import ResearchConductor
+
+
+class FakeSnippetRetriever:
+    def __init__(self, query, query_domains=None):
+        self.query = query
+        self.query_domains = query_domains or []
+
+    def search(self, max_results=10):
+        return [
+            {
+                "href": "https://example.com/one",
+                "body": "A" * 180,
+            },
+            {
+                "href": "https://example.com/two",
+                "body": "B" * 220,
+            },
+        ]
+
+
+class FakeFullContentRetriever:
+    def __init__(self, query, query_domains=None):
+        self.query = query
+        self.query_domains = query_domains or []
+
+    def search(self, max_results=10):
+        return [
+            {
+                "href": "https://example.com/full",
+                "body": "short summary",
+                "raw_content": "C" * 500,
+            }
+        ]
+
+
+class ResearchConductorRetrievalTests(unittest.IsolatedAsyncioTestCase):
+    def make_researcher(self, retriever_class):
+        class FakeResearcher:
+            def __init__(self):
+                self.retrievers = [retriever_class]
+                self.cfg = SimpleNamespace(max_search_results_per_query=5)
+                self.verbose = False
+                self.websocket = None
+                self.visited_urls = set()
+                self.research_sources = []
+
+            def add_research_sources(self, sources):
+                self.research_sources.extend(sources)
+
+        return FakeResearcher()
+
+    async def test_snippet_only_results_are_sent_to_scraper(self):
+        researcher = self.make_researcher(FakeSnippetRetriever)
+        conductor = ResearchConductor(researcher)
+
+        urls, prefetched = await conductor._search_relevant_source_urls("rust async runtimes")
+
+        self.assertCountEqual(
+            urls,
+            ["https://example.com/one", "https://example.com/two"],
+        )
+        self.assertEqual(prefetched, [])
+
+    async def test_raw_content_results_stay_prefetched(self):
+        researcher = self.make_researcher(FakeFullContentRetriever)
+        conductor = ResearchConductor(researcher)
+
+        urls, prefetched = await conductor._search_relevant_source_urls("pubmed article")
+
+        self.assertEqual(urls, [])
+        self.assertEqual(
+            prefetched,
+            [{"url": "https://example.com/full", "raw_content": "C" * 500}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# One-line summary

Fix Brave search result classification so snippet-only results are sent to the scraper instead of being treated as already-fetched full content.

## Problem

Brave search results populate `body` with snippet text, not full-page content. In `ResearchConductor._search_relevant_source_urls()`, results were classified as already-fetched whenever `len(raw_content) > 100`, where `raw_content` fell back to `result["body"]`. That caused Brave results with long snippets to bypass scraping entirely.

In the failing reproduction, this manifested as every sub-query logging **"Scraping content from 0 URLs"** because all Brave hits were treated as prefetched content before the scraper ever saw them.

This PR intentionally contains only the snippet-classification fix. The separate scraped-count tracking used by local safeguard logic belongs to the safeguards PR, not this one.

## Solution

- Stop treating `body` as full page content in `_search_relevant_source_urls()`
- Use only explicit `raw_content` to identify retriever results that already contain full text
- Leave snippet-only results in the URL list so the normal scraper path runs
- Add focused tests covering:
  - snippet-only retriever results are queued for scraping
  - explicit `raw_content` results remain prefetched

## Testing

Verified locally with:

- `uv run python -c "from gpt_researcher.skills.researcher import ResearchConductor; print('ok')"`
- `uv run python -m unittest tests.test_research_conductor_retrieval`

## Breaking changes

None.

## Related issues

- Potentially related: #1263
