### PR TITLE
feat(cli): add preflight, retrieval, and budget safeguards

### DIFF
--- a/PR_pr_feat-preflight-and-budget-safeguards.md
+++ b/PR_pr_feat-preflight-and-budget-safeguards.md
@@ -1,0 +1,34 @@
+# One-line summary
+
+Add fail-fast retrieval and budget safeguards, richer run metadata, and a stronger multi-probe retriever preflight.
+
+## Problem
+
+The CLI could start expensive research runs without proving that retrieval was healthy, and it would continue through repeated empty web-retrieval steps. Budget enforcement also missed deep-research child work because nested researchers did not share the same budget accumulator. Run artifacts also lacked enough metadata to diagnose failures after the fact.
+
+Companion PR: `pr/fix-deep-research-abort-propagation` depends on this one.
+
+## Solution
+
+- introduce `RetrievalFailureError` and abort after repeated empty retrieval steps
+- make `_scrape_data_by_urls()` report actual usable scraped entries so the safeguard counts real content, not just discovered URLs
+- add CLI retriever preflight checks before LLM work starts
+- persist run metadata in markdown frontmatter and sidecar `.meta.json` outputs
+- add `MAX_COST_USD` enforcement and make deep-research child researchers share the parent budget state
+- refine preflight to use three probe queries with delays and optional rate-limit logging when a retriever exposes that metadata
+- add safeguard-focused tests for preflight and deep-research budget propagation
+
+## Testing
+
+Verified locally with:
+
+- `uv run python -c "import gpt_researcher; print('ok')"`
+- `uv run python -m unittest tests.test_cli_preflight tests.test_budget_cap_binding`
+
+## Breaking changes
+
+None.
+
+## Related issues
+
+None identified.

--- a/backend/report_type/detailed_report/detailed_report.py
+++ b/backend/report_type/detailed_report/detailed_report.py
@@ -155,7 +155,8 @@ class DetailedReport:
             source_urls=self.source_urls,
             # Propagate MCP configuration so follow-up researchers can use MCP
             mcp_configs=self.gpt_researcher.mcp_configs,
-            mcp_strategy=self.gpt_researcher.mcp_strategy
+            mcp_strategy=self.gpt_researcher.mcp_strategy,
+            budget_state=self.gpt_researcher.budget_state,
         )
 
         # Propagate max_search_results override to subtopic researcher

--- a/backend/report_type/detailed_report/detailed_report.py
+++ b/backend/report_type/detailed_report/detailed_report.py
@@ -72,6 +72,7 @@ class DetailedReport:
         self.existing_headers: List[Dict] = []
         self.global_context: List[str] = []
         self.global_written_sections: List[str] = []
+        self.subtopic_researchers: List[GPTResearcher] = []
         self.global_urls: Set[str] = set(
             self.source_urls) if self.source_urls else set()
 
@@ -161,6 +162,7 @@ class DetailedReport:
         if self.max_search_results is not None:
             subtopic_assistant.cfg.max_search_results_per_query = int(self.max_search_results)
 
+        self.subtopic_researchers.append(subtopic_assistant)
         subtopic_assistant.context = list(set(self._hashable_context(self.global_context)))
         await subtopic_assistant.conduct_research()
 
@@ -203,3 +205,15 @@ class DetailedReport:
         
         # Note: Images are now pre-generated during conduct_research() and embedded during write_report()
         return report
+
+    def get_costs(self) -> float:
+        researchers = [self.gpt_researcher, *self.subtopic_researchers]
+        return sum(researcher.get_costs() for researcher in researchers)
+
+    def get_total_sub_queries(self) -> int:
+        researchers = [self.gpt_researcher, *self.subtopic_researchers]
+        return sum(researcher.get_total_sub_queries() for researcher in researchers)
+
+    def get_successful_scrapes(self) -> int:
+        researchers = [self.gpt_researcher, *self.subtopic_researchers]
+        return sum(researcher.get_successful_scrapes() for researcher in researchers)

--- a/cli.py
+++ b/cli.py
@@ -13,10 +13,14 @@ import argparse
 from argparse import RawTextHelpFormatter
 from uuid import uuid4
 import os
+import sys
 
 from dotenv import load_dotenv
 
 from gpt_researcher import GPTResearcher
+from gpt_researcher.actions.retriever import get_retriever
+from gpt_researcher.config.config import Config
+from gpt_researcher.exceptions import RetrievalFailureError
 from gpt_researcher.utils.enum import ReportType, ReportSource, Tone
 from backend.report_type import DetailedReport
 from backend.utils import write_md_to_pdf, write_md_to_word
@@ -135,54 +139,108 @@ cli.add_argument(
 # Main
 # =============================================================================
 
+def _env_status(name: str) -> str:
+    return "present" if os.getenv(name) else "missing"
+
+
+def _abort_run(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+def _log_resolved_config(cfg: Config) -> None:
+    print(
+        f"[CONFIG] retriever={cfg.retriever}, fast_llm={cfg.fast_llm}, "
+        f"smart_llm={cfg.smart_llm}, strategic_llm={cfg.strategic_llm}, "
+        f"embedding={cfg.embedding_model}"
+    )
+    print(
+        f"[CONFIG] BRAVE_API_KEY={_env_status('BRAVE_API_KEY')}, "
+        f"TAVILY_API_KEY={_env_status('TAVILY_API_KEY')}, "
+        f"OPENAI_API_KEY={_env_status('OPENAI_API_KEY')}, "
+        f"ANTHROPIC_API_KEY={_env_status('ANTHROPIC_API_KEY')}"
+    )
+
+
+async def _run_retriever_preflight(cfg: Config) -> None:
+    retriever_names = cfg.retrievers if isinstance(cfg.retrievers, list) else [cfg.retrievers]
+    first_retriever = retriever_names[0]
+    retriever_class = get_retriever(first_retriever)
+
+    if retriever_class is None:
+        _abort_run(f"[PREFLIGHT] Unknown retriever '{first_retriever}'.")
+
+    try:
+        retriever = retriever_class("test connectivity", query_domains=[])
+        results = await asyncio.to_thread(retriever.search, max_results=3)
+    except Exception as exc:
+        _abort_run(
+            f"[PREFLIGHT] Retriever probe failed for '{first_retriever}': {exc}"
+        )
+
+    print(f"[PREFLIGHT] retriever={first_retriever} results={len(results)}")
+    if not results:
+        _abort_run(
+            f"[PREFLIGHT] Retriever '{first_retriever}' returned 0 results for "
+            "'test connectivity'. Aborting before any LLM calls."
+        )
 async def main(args):
     """
     Conduct research on the given query, generate the report, and write
     it as a markdown file to the output directory.
     """
     query_domains = args.query_domains.split(",") if args.query_domains else []
+    cfg = Config()
 
-    if args.report_type == 'detailed_report':
-        detailed_report = DetailedReport(
-            query=args.query,
-            query_domains=query_domains,
-            report_type="research_report",
-            report_source="web_search",
+    _log_resolved_config(cfg)
+    await _run_retriever_preflight(cfg)
+
+    try:
+        if args.report_type == 'detailed_report':
+            detailed_report = DetailedReport(
+                query=args.query,
+                query_domains=query_domains,
+                report_type="research_report",
+                report_source="web_search",
+            )
+
+            report = await detailed_report.run()
+        else:
+            # Convert the simple keyword to the full Tone enum value
+            tone_map = {
+                "objective": Tone.Objective,
+                "formal": Tone.Formal,
+                "analytical": Tone.Analytical,
+                "persuasive": Tone.Persuasive,
+                "informative": Tone.Informative,
+                "explanatory": Tone.Explanatory,
+                "descriptive": Tone.Descriptive,
+                "critical": Tone.Critical,
+                "comparative": Tone.Comparative,
+                "speculative": Tone.Speculative,
+                "reflective": Tone.Reflective,
+                "narrative": Tone.Narrative,
+                "humorous": Tone.Humorous,
+                "optimistic": Tone.Optimistic,
+                "pessimistic": Tone.Pessimistic
+            }
+
+            researcher = GPTResearcher(
+                query=args.query,
+                query_domains=query_domains,
+                report_type=args.report_type,
+                report_source=args.report_source,
+                tone=tone_map[args.tone],
+                encoding=args.encoding
+            )
+
+            await researcher.conduct_research()
+            report = await researcher.write_report()
+    except RetrievalFailureError as exc:
+        _abort_run(
+            "[RETRIEVAL] Aborting after 3 consecutive empty retrieval steps. "
+            f"Last queries: {', '.join(exc.failed_queries)}"
         )
-
-        report = await detailed_report.run()
-    else:
-        # Convert the simple keyword to the full Tone enum value
-        tone_map = {
-            "objective": Tone.Objective,
-            "formal": Tone.Formal,
-            "analytical": Tone.Analytical,
-            "persuasive": Tone.Persuasive,
-            "informative": Tone.Informative,
-            "explanatory": Tone.Explanatory,
-            "descriptive": Tone.Descriptive,
-            "critical": Tone.Critical,
-            "comparative": Tone.Comparative,
-            "speculative": Tone.Speculative,
-            "reflective": Tone.Reflective,
-            "narrative": Tone.Narrative,
-            "humorous": Tone.Humorous,
-            "optimistic": Tone.Optimistic,
-            "pessimistic": Tone.Pessimistic
-        }
-
-        researcher = GPTResearcher(
-            query=args.query,
-            query_domains=query_domains,
-            report_type=args.report_type,
-            report_source=args.report_source,
-            tone=tone_map[args.tone],
-            encoding=args.encoding
-        )
-
-        await researcher.conduct_research()
-
-        report = await researcher.write_report()
 
     # Write the report to markdown file
     task_id = str(uuid4())

--- a/cli.py
+++ b/cli.py
@@ -190,24 +190,45 @@ async def _run_retriever_preflight(cfg: Config) -> None:
     retriever_names = cfg.retrievers if isinstance(cfg.retrievers, list) else [cfg.retrievers]
     first_retriever = retriever_names[0]
     retriever_class = get_retriever(first_retriever)
+    probe_queries = [
+        "test connectivity",
+        "rust programming language",
+        "python decorators tutorial",
+    ]
 
     if retriever_class is None:
         _abort_run(f"[PREFLIGHT] Unknown retriever '{first_retriever}'.")
 
-    try:
-        retriever = retriever_class("test connectivity", query_domains=[])
-        results = await asyncio.to_thread(retriever.search, max_results=3)
-    except Exception as exc:
-        _abort_run(
-            f"[PREFLIGHT] Retriever probe failed for '{first_retriever}': {exc}"
-        )
+    for index, probe_query in enumerate(probe_queries, start=1):
+        try:
+            retriever = retriever_class(probe_query, query_domains=[])
+            results = await asyncio.to_thread(retriever.search, max_results=3)
+        except Exception as exc:
+            _abort_run(
+                f"[PREFLIGHT] Retriever probe failed for '{first_retriever}' on "
+                f"query {probe_query!r}: {exc}"
+            )
 
-    print(f"[PREFLIGHT] retriever={first_retriever} results={len(results)}")
-    if not results:
-        _abort_run(
-            f"[PREFLIGHT] Retriever '{first_retriever}' returned 0 results for "
-            "'test connectivity'. Aborting before any LLM calls."
+        rate_limit_remaining = getattr(retriever, "last_rate_limit_remaining", None)
+        rate_limit_reset = getattr(retriever, "last_rate_limit_reset", None)
+        rate_limit_metadata = ""
+        if rate_limit_remaining is not None:
+            rate_limit_metadata = f" rate_limit_remaining={rate_limit_remaining}"
+            if rate_limit_reset is not None:
+                rate_limit_metadata += f" rate_limit_reset={rate_limit_reset}"
+
+        print(
+            f"[PREFLIGHT] retriever={first_retriever} probe={index} "
+            f"query={probe_query!r} results={len(results)}{rate_limit_metadata}"
         )
+        if not results:
+            _abort_run(
+                f"[PREFLIGHT] Retriever '{first_retriever}' returned 0 results for "
+                f"{probe_query!r}. Aborting before any LLM calls."
+            )
+
+        if index < len(probe_queries):
+            await asyncio.sleep(1.5)
 
 
 def _build_run_metadata(run_context, cfg: Config, query: str, runtime_seconds: float) -> dict[str, object]:

--- a/cli.py
+++ b/cli.py
@@ -10,12 +10,15 @@ python cli.py "<query>" --report_type <report_type> --tone <tone> --query_domain
 """
 import asyncio
 import argparse
+import json
 from argparse import RawTextHelpFormatter
-from uuid import uuid4
 import os
 import sys
+import time
+from uuid import uuid4
 
 from dotenv import load_dotenv
+import yaml
 
 from gpt_researcher import GPTResearcher
 from gpt_researcher.actions.retriever import get_retriever
@@ -151,6 +154,24 @@ def _env_status(name: str) -> str:
 def _abort_run(message: str) -> None:
     print(message, file=sys.stderr)
     sys.exit(1)
+
+
+def _resolved_env_statuses() -> dict[str, str]:
+    tracked_env_vars = (
+        "RETRIEVER",
+        "FAST_LLM",
+        "SMART_LLM",
+        "STRATEGIC_LLM",
+        "EMBEDDING",
+        "MAX_COST_USD",
+        "BRAVE_API_KEY",
+        "TAVILY_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    )
+    return {name: _env_status(name) for name in tracked_env_vars}
+
+
 def _log_resolved_config(cfg: Config) -> None:
     print(
         f"[CONFIG] retriever={cfg.retriever}, fast_llm={cfg.fast_llm}, "
@@ -187,13 +208,36 @@ async def _run_retriever_preflight(cfg: Config) -> None:
             f"[PREFLIGHT] Retriever '{first_retriever}' returned 0 results for "
             "'test connectivity'. Aborting before any LLM calls."
         )
+
+
+def _build_run_metadata(run_context, cfg: Config, query: str, runtime_seconds: float) -> dict[str, object]:
+    return {
+        "retriever": cfg.retriever,
+        "fast_llm": cfg.fast_llm,
+        "smart_llm": cfg.smart_llm,
+        "strategic_llm": cfg.strategic_llm,
+        "total_sub_queries": run_context.get_total_sub_queries(),
+        "successful_scrapes": run_context.get_successful_scrapes(),
+        "total_cost_usd": round(run_context.get_costs(), 6),
+        "runtime_seconds": round(runtime_seconds, 3),
+        "query": query,
+    }
+
+
+def _prepend_frontmatter(report: str, metadata: dict[str, object]) -> str:
+    frontmatter = yaml.safe_dump(metadata, sort_keys=False, allow_unicode=True).strip()
+    return f"---\n{frontmatter}\n---\n\n{report}"
+
+
 async def main(args):
     """
     Conduct research on the given query, generate the report, and write
     it as a markdown file to the output directory.
     """
+    start_time = time.monotonic()
     query_domains = args.query_domains.split(",") if args.query_domains else []
     cfg = Config()
+    run_context = None
 
     _log_resolved_config(cfg)
     await _run_retriever_preflight(cfg)
@@ -207,6 +251,7 @@ async def main(args):
                 report_source="web_search",
             )
 
+            run_context = detailed_report
             report = await detailed_report.run()
         else:
             # Convert the simple keyword to the full Tone enum value
@@ -237,6 +282,7 @@ async def main(args):
                 encoding=args.encoding
             )
 
+            run_context = researcher
             await researcher.conduct_research()
             report = await researcher.write_report()
     except RetrievalFailureError as exc:
@@ -246,12 +292,25 @@ async def main(args):
         )
 
     # Write the report to markdown file
+    runtime_seconds = time.monotonic() - start_time
+    metadata = _build_run_metadata(run_context, cfg, args.query, runtime_seconds)
     task_id = str(uuid4())
     artifact_filepath = f"outputs/{task_id}.md"
+    meta_filepath = f"outputs/{task_id}.meta.json"
     os.makedirs("outputs", exist_ok=True)
     with open(artifact_filepath, "w", encoding="utf-8") as f:
-        f.write(report)
+        f.write(_prepend_frontmatter(report, metadata))
+    with open(meta_filepath, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                **metadata,
+                "resolved_env_vars": _resolved_env_statuses(),
+            },
+            f,
+            indent=2,
+        )
     print(f"Report written to '{artifact_filepath}'")
+    print(f"Run metadata written to '{meta_filepath}'")
 
     # Generate PDF if not disabled
     if not args.no_pdf:

--- a/cli.py
+++ b/cli.py
@@ -23,7 +23,7 @@ import yaml
 from gpt_researcher import GPTResearcher
 from gpt_researcher.actions.retriever import get_retriever
 from gpt_researcher.config.config import Config
-from gpt_researcher.exceptions import RetrievalFailureError
+from gpt_researcher.exceptions import BudgetExceededError, RetrievalFailureError
 from gpt_researcher.utils.enum import ReportType, ReportSource, Tone
 from backend.report_type import DetailedReport
 from backend.utils import write_md_to_pdf, write_md_to_word
@@ -289,6 +289,11 @@ async def main(args):
         _abort_run(
             "[RETRIEVAL] Aborting after 3 consecutive empty retrieval steps. "
             f"Last queries: {', '.join(exc.failed_queries)}"
+        )
+    except BudgetExceededError as exc:
+        _abort_run(
+            "[BUDGET] Aborting because the cumulative research cost exceeded "
+            f"MAX_COST_USD (${exc.max_cost_usd:.6f}). Current total: ${exc.total_cost_usd:.6f}."
         )
 
     # Write the report to markdown file

--- a/cli.py
+++ b/cli.py
@@ -25,6 +25,12 @@ from gpt_researcher.utils.enum import ReportType, ReportSource, Tone
 from backend.report_type import DetailedReport
 from backend.utils import write_md_to_pdf, write_md_to_word
 
+# Safeguard patterns:
+# - print the resolved config and credential presence before starting a run
+# - probe the first configured retriever before any LLM work starts
+# - fail fast on terminal runtime conditions instead of writing partial artifacts
+# - attach run metadata to outputs for postmortem debugging
+
 # =============================================================================
 # CLI
 # =============================================================================
@@ -138,7 +144,6 @@ cli.add_argument(
 # =============================================================================
 # Main
 # =============================================================================
-
 def _env_status(name: str) -> str:
     return "present" if os.getenv(name) else "missing"
 
@@ -146,8 +151,6 @@ def _env_status(name: str) -> str:
 def _abort_run(message: str) -> None:
     print(message, file=sys.stderr)
     sys.exit(1)
-
-
 def _log_resolved_config(cfg: Config) -> None:
     print(
         f"[CONFIG] retriever={cfg.retriever}, fast_llm={cfg.fast_llm}, "

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -17,6 +17,7 @@ from .actions import (
     get_search_results,
     table_of_contents,
 )
+from .exceptions import BudgetExceededError
 from .config import Config
 from .llm_provider import GenericLLMProvider
 from .memory import Memory
@@ -79,6 +80,7 @@ class GPTResearcher:
         mcp_configs: list[dict] | None = None,
         mcp_max_iterations: int | None = None,
         mcp_strategy: str | None = None,
+        budget_state: dict[str, float | None] | None = None,
         **kwargs
     ):
         """
@@ -165,6 +167,10 @@ class GPTResearcher:
         self.step_costs: dict[str, float] = {}
         self.total_sub_queries = 0
         self.successful_scrapes = 0
+        self.budget_state = budget_state or {
+            "max_cost_usd": self._parse_max_cost_usd(os.getenv("MAX_COST_USD")),
+            "total_cost_usd": 0.0,
+        }
         self._current_step: str = "general"
         self.log_handler = log_handler
         self.prompt_family = get_prompt_family(prompt_family or self.cfg.prompt_family, self.cfg)
@@ -214,6 +220,16 @@ class GPTResearcher:
             unique_str = f"{self.query}_{time.time()}"
             self._research_id = f"research_{hashlib.md5(unique_str.encode()).hexdigest()[:12]}"
         return self._research_id
+
+    @staticmethod
+    def _parse_max_cost_usd(raw_value: str | None) -> float | None:
+        if raw_value in (None, ""):
+            return None
+
+        max_cost_usd = float(raw_value)
+        if max_cost_usd < 0:
+            raise ValueError("MAX_COST_USD must be non-negative")
+        return max_cost_usd
 
     def _resolve_mcp_strategy(self, mcp_strategy: str | None, mcp_max_iterations: int | None) -> str:
         """
@@ -739,8 +755,15 @@ class GPTResearcher:
         if not isinstance(cost, (float, int)):
             raise ValueError("Cost must be an integer or float")
         self.research_costs += cost
+        self.budget_state["total_cost_usd"] = (
+            float(self.budget_state.get("total_cost_usd") or 0.0) + float(cost)
+        )
         step = self._current_step
         self.step_costs[step] = self.step_costs.get(step, 0.0) + cost
+        max_cost_usd = self.budget_state.get("max_cost_usd")
+        total_cost_usd = float(self.budget_state["total_cost_usd"])
+        if max_cost_usd is not None and total_cost_usd > float(max_cost_usd):
+            raise BudgetExceededError(float(max_cost_usd), total_cost_usd)
         if self.log_handler:
             self._log_event("research", step="cost_update", details={
                 "cost": cost,

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -163,6 +163,8 @@ class GPTResearcher:
         self.headers = headers or {}
         self.research_costs = 0.0
         self.step_costs: dict[str, float] = {}
+        self.total_sub_queries = 0
+        self.successful_scrapes = 0
         self._current_step: str = "general"
         self.log_handler = log_handler
         self.prompt_family = get_prompt_family(prompt_family or self.cfg.prompt_family, self.cfg)
@@ -706,6 +708,14 @@ class GPTResearcher:
             Dictionary mapping step names to their costs in USD.
         """
         return dict(self.step_costs)
+
+    def get_total_sub_queries(self) -> int:
+        """Get the number of sub-queries attempted during the run."""
+        return self.total_sub_queries
+
+    def get_successful_scrapes(self) -> int:
+        """Get the number of successfully retrieved content entries."""
+        return self.successful_scrapes
 
     def set_verbose(self, verbose: bool) -> None:
         """Set the verbose output mode.

--- a/gpt_researcher/exceptions.py
+++ b/gpt_researcher/exceptions.py
@@ -10,3 +10,14 @@ class RetrievalFailureError(Exception):
         super().__init__(
             f"Retrieval failed for consecutive sub-queries: {query_list}"
         )
+
+
+class BudgetExceededError(BaseException):
+    """Raised when the shared research budget exceeds MAX_COST_USD."""
+
+    def __init__(self, max_cost_usd: float, total_cost_usd: float):
+        self.max_cost_usd = max_cost_usd
+        self.total_cost_usd = total_cost_usd
+        super().__init__(
+            f"Research budget exceeded: ${total_cost_usd:.6f} > ${max_cost_usd:.6f}"
+        )

--- a/gpt_researcher/exceptions.py
+++ b/gpt_researcher/exceptions.py
@@ -1,0 +1,12 @@
+"""Terminal exceptions for fail-fast research safeguards."""
+
+
+class RetrievalFailureError(Exception):
+    """Raised when repeated sub-queries fail to produce retrievable sources."""
+
+    def __init__(self, failed_queries: list[str]):
+        self.failed_queries = failed_queries
+        query_list = ", ".join(failed_queries)
+        super().__init__(
+            f"Retrieval failed for consecutive sub-queries: {query_list}"
+        )

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -75,7 +75,8 @@ class DeepResearchSkill:
             llm_provider=self.researcher.cfg.strategic_llm_provider,
             model=self.researcher.cfg.strategic_llm_model,
             reasoning_effort=self.researcher.cfg.reasoning_effort,
-            temperature=0.4
+            temperature=0.4,
+            cost_callback=self.researcher.add_costs,
         )
 
         lines = response.split('\n')
@@ -136,7 +137,8 @@ Format each question on a new line starting with 'Question: '"""}
             llm_provider=self.researcher.cfg.strategic_llm_provider,
             model=self.researcher.cfg.strategic_llm_model,
             reasoning_effort=ReasoningEfforts.High.value,
-            temperature=0.4
+            temperature=0.4,
+            cost_callback=self.researcher.add_costs,
         )
 
         questions = [q.replace('Question:', '').strip()
@@ -158,7 +160,8 @@ Format each question on a new line starting with 'Question: '"""}
             model=self.researcher.cfg.strategic_llm_model,
             temperature=0.4,
             reasoning_effort=ReasoningEfforts.High.value,
-            max_tokens=1000
+            max_tokens=1000,
+            cost_callback=self.researcher.add_costs,
         )
 
         lines = response.split('\n')
@@ -254,11 +257,13 @@ Format each question on a new line starting with 'Question: '"""}
                         visited_urls=self.visited_urls,
                         # Propagate MCP configuration to nested researchers
                         mcp_configs=self.researcher.mcp_configs,
-                        mcp_strategy=self.researcher.mcp_strategy
+                        mcp_strategy=self.researcher.mcp_strategy,
+                        budget_state=self.researcher.budget_state,
                     )
 
                     # Conduct research
                     context = await researcher.conduct_research()
+                    self.researcher.research_costs += researcher.get_costs()
 
                     # Get results and visited URLs
                     visited = researcher.visited_urls

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -245,6 +245,8 @@ class ResearchConductor:
         if self.researcher.report_type != "subtopic_report":
             sub_queries.append(query)
 
+        self.researcher.total_sub_queries += len(sub_queries)
+
         if self.researcher.verbose:
             await stream_output(
                 "logs",
@@ -866,6 +868,7 @@ class ResearchConductor:
 
         # Merge pre-fetched content from retrievers that already provide full text
         scraped_content.extend(prefetched_content)
+        self.researcher.successful_scrapes += len(scraped_content)
 
         if self.researcher.vector_store:
             self.researcher.vector_store.load(scraped_content)

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -14,6 +14,7 @@ from ..actions.agent_creator import choose_agent
 from ..actions.query_processing import get_search_results, plan_research_outline
 from ..actions.utils import stream_output
 from ..document import DocumentLoader, LangChainDocumentLoader, OnlineDocumentLoader
+from ..exceptions import RetrievalFailureError
 from ..utils.enum import ReportSource, ReportType
 from ..utils.logging_config import get_json_handler
 
@@ -344,22 +345,39 @@ class ResearchConductor:
                 sub_queries,
             )
 
-        # Using asyncio.gather to process the sub_queries asynchronously
         try:
-            context = await asyncio.gather(
-                *[
-                    self._process_sub_query(sub_query, scraped_data, query_domains)
-                    for sub_query in sub_queries
-                ]
-            )
+            context = []
+            empty_retrieval_streak = 0
+            failed_queries: list[str] = []
+
+            for sub_query in sub_queries:
+                sub_query_result = await self._process_sub_query(
+                    sub_query,
+                    scraped_data,
+                    query_domains,
+                )
+
+                if sub_query_result["context"]:
+                    context.append(sub_query_result["context"])
+
+                if sub_query_result["retrieved_source_count"] == 0:
+                    empty_retrieval_streak += 1
+                    failed_queries.append(sub_query)
+                    failed_queries = failed_queries[-3:]
+                    if empty_retrieval_streak >= 3:
+                        raise RetrievalFailureError(failed_queries)
+                else:
+                    empty_retrieval_streak = 0
+                    failed_queries.clear()
+
             self.logger.info(f"Gathered context from {len(context)} sub-queries")
-            # Filter out empty results and join the context
-            context = [c for c in context if c]
             if context:
                 combined_context = " ".join(context)
                 self.logger.info(f"Combined context size: {len(combined_context)}")
                 return combined_context
             return []
+        except RetrievalFailureError:
+            raise
         except Exception as e:
             self.logger.error(f"Error during web search: {e}", exc_info=True)
             return []
@@ -446,8 +464,18 @@ class ResearchConductor:
         
         return all_mcp_context
 
-    async def _process_sub_query(self, sub_query: str, scraped_data: list = [], query_domains: list = []):
+    async def _process_sub_query(
+        self,
+        sub_query: str,
+        scraped_data: list | None = None,
+        query_domains: list | None = None,
+    ):
         """Takes in a sub query and scrapes urls based on it and gathers context."""
+        if scraped_data is None:
+            scraped_data = []
+        if query_domains is None:
+            query_domains = []
+
         if self.json_handler:
             self.json_handler.log_event("sub_query", {
                 "query": sub_query,
@@ -470,7 +498,8 @@ class ResearchConductor:
             # Initialize context components
             mcp_context = []
             web_context = ""
-            
+            retrieved_source_count = len(scraped_data)
+             
             # Get MCP strategy configuration
             mcp_strategy = self._get_mcp_strategy()
             
@@ -519,7 +548,10 @@ class ResearchConductor:
             
             # Get web search context using non-MCP retrievers (if no scraped data provided)
             if not scraped_data:
-                scraped_data = await self._scrape_data_by_urls(sub_query, query_domains)
+                scraped_data, retrieved_source_count = await self._scrape_data_by_urls(
+                    sub_query,
+                    query_domains,
+                )
                 self.logger.info(f"Scraped data size: {len(scraped_data)}")
 
             # Get similar content based on scraped data
@@ -563,9 +595,14 @@ class ResearchConductor:
                     "mcp_sources": len(mcp_context),
                     "web_content": bool(web_context)
                 })
-                
-            return combined_context
-            
+                 
+            return {
+                "context": combined_context,
+                "retrieved_source_count": retrieved_source_count,
+            }
+             
+        except RetrievalFailureError:
+            raise
         except Exception as e:
             self.logger.error(f"Error processing sub-query {sub_query}: {e}", exc_info=True)
             if self.researcher.verbose:
@@ -575,7 +612,10 @@ class ResearchConductor:
                     f"❌ Error processing '{sub_query}': {str(e)}",
                     self.researcher.websocket,
                 )
-            return ""
+            return {
+                "context": "",
+                "retrieved_source_count": 0,
+            }
 
     async def _execute_mcp_research(self, retriever, query):
         """
@@ -805,7 +845,7 @@ class ResearchConductor:
             sub_query (str): The sub-query to search for.
 
         Returns:
-            list: A list of scraped content results.
+            tuple[list, int]: Scraped content plus the number of retrievable sources found.
         """
         if query_domains is None:
             query_domains = []
@@ -830,7 +870,7 @@ class ResearchConductor:
         if self.researcher.vector_store:
             self.researcher.vector_store.load(scraped_content)
 
-        return scraped_content
+        return scraped_content, len(scraped_content)
 
     async def _search(self, retriever, query):
         """

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -337,6 +337,8 @@ class ResearchConductor:
         if self.researcher.report_type != "subtopic_report":
             sub_queries.append(query)
 
+        self.researcher.total_sub_queries += len(sub_queries)
+
         if self.researcher.verbose:
             await stream_output(
                 "logs",

--- a/tests/test_budget_cap_binding.py
+++ b/tests/test_budget_cap_binding.py
@@ -1,0 +1,66 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gpt_researcher.exceptions import BudgetExceededError
+from gpt_researcher.skills.deep_research import DeepResearchSkill
+from gpt_researcher.utils.enum import Tone
+from gpt_researcher.agent import GPTResearcher
+
+
+class _BudgetedNestedResearcher:
+    add_costs = GPTResearcher.add_costs
+    get_costs = GPTResearcher.get_costs
+
+    def __init__(self, *args, budget_state=None, **kwargs):
+        if budget_state is None:
+            raise AssertionError("Nested researcher must share the parent budget_state")
+        self.budget_state = budget_state
+        self.research_costs = 0.0
+        self.step_costs = {}
+        self._current_step = "research"
+        self.log_handler = None
+        self.visited_urls = set()
+        self.research_sources = []
+
+    async def conduct_research(self):
+        self.add_costs(0.03)
+        self.add_costs(0.03)
+        return "context"
+
+
+class TestBudgetCapBinding(unittest.TestCase):
+    def test_deep_research_nested_researchers_share_budget_state(self):
+        parent_researcher = SimpleNamespace(
+            cfg=SimpleNamespace(
+                deep_research_breadth=1,
+                deep_research_depth=1,
+                deep_research_concurrency=1,
+                config_path=None,
+                strategic_llm_provider="anthropic",
+                strategic_llm_model="claude-sonnet-4-6",
+                reasoning_effort="medium",
+            ),
+            websocket=None,
+            tone=Tone.Objective,
+            headers={},
+            visited_urls=set(),
+            mcp_configs=None,
+            mcp_strategy=None,
+            budget_state={"max_cost_usd": 0.05, "total_cost_usd": 0.0},
+            research_costs=0.0,
+            add_costs=AsyncMock(),
+        )
+        skill = DeepResearchSkill(parent_researcher)
+        skill.generate_search_queries = AsyncMock(
+            return_value=[{"query": "sub-query", "researchGoal": "goal"}]
+        )
+
+        with patch("gpt_researcher.GPTResearcher", _BudgetedNestedResearcher):
+            with self.assertRaises(BudgetExceededError):
+                asyncio.run(skill.deep_research("root query", breadth=1, depth=1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -1,0 +1,83 @@
+import io
+import unittest
+from types import SimpleNamespace
+from contextlib import redirect_stdout
+from unittest.mock import AsyncMock, patch
+
+import cli
+
+
+class SuccessfulProbeRetriever:
+    queries = []
+
+    def __init__(self, query, query_domains=None):
+        self.query = query
+        self.query_domains = query_domains or []
+        self.last_rate_limit_remaining = "42"
+        self.last_rate_limit_reset = "3600"
+        SuccessfulProbeRetriever.queries.append(query)
+
+    def search(self, max_results=3):
+        return [{"href": "https://example.com", "body": "result"}]
+
+
+class SecondProbeFailsRetriever:
+    queries = []
+
+    def __init__(self, query, query_domains=None):
+        self.query = query
+        self.query_domains = query_domains or []
+        self.last_rate_limit_remaining = None
+        self.last_rate_limit_reset = None
+        SecondProbeFailsRetriever.queries.append(query)
+
+    def search(self, max_results=3):
+        if self.query == "rust programming language":
+            return []
+        return [{"href": "https://example.com", "body": "result"}]
+
+
+class CliPreflightTests(unittest.IsolatedAsyncioTestCase):
+    async def test_preflight_runs_three_probe_queries_and_logs_rate_limits(self):
+        SuccessfulProbeRetriever.queries = []
+        cfg = SimpleNamespace(retrievers=["brave"])
+        sleep_mock = AsyncMock()
+        stdout = io.StringIO()
+
+        with patch.object(cli, "get_retriever", return_value=SuccessfulProbeRetriever):
+            with patch.object(cli.asyncio, "sleep", sleep_mock):
+                with redirect_stdout(stdout):
+                    await cli._run_retriever_preflight(cfg)
+
+        self.assertEqual(
+            SuccessfulProbeRetriever.queries,
+            [
+                "test connectivity",
+                "rust programming language",
+                "python decorators tutorial",
+            ],
+        )
+        self.assertEqual(sleep_mock.await_args_list[0].args[0], 1.5)
+        self.assertEqual(sleep_mock.await_args_list[1].args[0], 1.5)
+        self.assertIn("rate_limit_remaining=42", stdout.getvalue())
+
+    async def test_preflight_aborts_when_any_probe_returns_zero_results(self):
+        SecondProbeFailsRetriever.queries = []
+        cfg = SimpleNamespace(retrievers=["brave"])
+        sleep_mock = AsyncMock()
+
+        with patch.object(cli, "get_retriever", return_value=SecondProbeFailsRetriever):
+            with patch.object(cli.asyncio, "sleep", sleep_mock):
+                with patch.object(cli, "_abort_run", side_effect=RuntimeError("abort")):
+                    with self.assertRaisesRegex(RuntimeError, "abort"):
+                        await cli._run_retriever_preflight(cfg)
+
+        self.assertEqual(
+            SecondProbeFailsRetriever.queries,
+            ["test connectivity", "rust programming language"],
+        )
+        self.assertEqual(sleep_mock.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# One-line summary

Add fail-fast retrieval and budget safeguards, richer run metadata, and a stronger multi-probe retriever preflight.

## Problem

The CLI could start expensive research runs without proving that retrieval was healthy, and it would continue through repeated empty web-retrieval steps. Budget enforcement also missed deep-research child work because nested researchers did not share the same budget accumulator. Run artifacts also lacked enough metadata to diagnose failures after the fact.

Companion PR: `pr/fix-deep-research-abort-propagation` depends on this one.

## Solution

- introduce `RetrievalFailureError` and abort after repeated empty retrieval steps
- make `_scrape_data_by_urls()` report actual usable scraped entries so the safeguard counts real content, not just discovered URLs
- add CLI retriever preflight checks before LLM work starts
- persist run metadata in markdown frontmatter and sidecar `.meta.json` outputs
- add `MAX_COST_USD` enforcement and make deep-research child researchers share the parent budget state
- refine preflight to use three probe queries with delays and optional rate-limit logging when a retriever exposes that metadata
- add safeguard-focused tests for preflight and deep-research budget propagation

## Testing

Verified locally with:

- `uv run python -c "import gpt_researcher; print('ok')"`
- `uv run python -m unittest tests.test_cli_preflight tests.test_budget_cap_binding`

## Breaking changes

None.

## Related issues

None identified.
