### PR TITLE
docs(proposal): Firefox-based stealth scraper backend

### DIFF
--- a/gpt_researcher/scraper/__init__.py
+++ b/gpt_researcher/scraper/__init__.py
@@ -6,6 +6,7 @@ from .browser.browser import BrowserScraper
 from .browser.nodriver_scraper import NoDriverScraper
 from .tavily_extract.tavily_extract import TavilyExtract
 from .firecrawl.firecrawl import FireCrawl
+from .invisible_firefox.invisible_firefox_scraper import InvisibleFirefoxScraper
 from .scraper import Scraper
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "TavilyExtract",
     "Scraper",
     "FireCrawl",
+    "InvisibleFirefoxScraper",
 ]

--- a/gpt_researcher/scraper/__init__.py
+++ b/gpt_researcher/scraper/__init__.py
@@ -6,7 +6,7 @@ from .browser.browser import BrowserScraper
 from .browser.nodriver_scraper import NoDriverScraper
 from .tavily_extract.tavily_extract import TavilyExtract
 from .firecrawl.firecrawl import FireCrawl
-from .invisible_firefox.invisible_firefox_scraper import InvisibleFirefoxScraper
+from .invisible_playwright.invisible_playwright_scraper import InvisiblePlaywrightScraper
 from .scraper import Scraper
 
 __all__ = [
@@ -19,5 +19,5 @@ __all__ = [
     "TavilyExtract",
     "Scraper",
     "FireCrawl",
-    "InvisibleFirefoxScraper",
+    "InvisiblePlaywrightScraper",
 ]

--- a/gpt_researcher/scraper/invisible_firefox/invisible_firefox_scraper.py
+++ b/gpt_researcher/scraper/invisible_firefox/invisible_firefox_scraper.py
@@ -1,0 +1,58 @@
+import os
+
+from bs4 import BeautifulSoup
+
+from ..utils import get_relevant_images, extract_title, get_text_from_soup, clean_soup
+
+
+class InvisibleFirefoxScraper:
+    """Opt-in scraper that renders a page with a patched, fingerprint-real Firefox
+    (``invisible_playwright``) before parsing it, for sources that block or fingerprint
+    stock automation. Once the HTML is rendered it is parsed with the same BeautifulSoup
+    utilities the other scrapers use, so the output format is unchanged.
+
+    Select it with ``SCRAPER=invisible_firefox``; when it is not selected nothing changes,
+    so defaults are untouched. ``invisible_playwright`` is imported lazily and is therefore
+    NOT a required dependency: install it only if you use this scraper::
+
+        pip install "git+https://github.com/feder-cr/invisible_playwright.git"
+        python -m invisible_playwright fetch   # download the patched browser once
+
+    Optional env: ``INVISIBLE_FIREFOX_SEED`` pins the fingerprint (stable identity across runs).
+    """
+
+    def __init__(self, link, session=None):
+        self.link = link
+        self.session = session
+
+    async def scrape_async(self):
+        try:
+            try:
+                from invisible_playwright.async_api import InvisiblePlaywright
+            except ImportError as e:
+                raise ImportError(
+                    "InvisibleFirefoxScraper requires invisible_playwright. Install it with "
+                    '`pip install "git+https://github.com/feder-cr/invisible_playwright.git"` '
+                    "and run `python -m invisible_playwright fetch` to download the browser."
+                ) from e
+
+            raw_seed = os.environ.get("INVISIBLE_FIREFOX_SEED")
+            kwargs = {"headless": True}
+            if raw_seed:
+                kwargs["seed"] = int(raw_seed, 0)
+
+            async with InvisiblePlaywright(**kwargs) as browser:
+                ctx = await browser.new_context()
+                page = await ctx.new_page()
+                await page.goto(self.link, wait_until="domcontentloaded", timeout=30000)
+                html = await page.content()
+
+            soup = clean_soup(BeautifulSoup(html, "lxml"))
+            content = get_text_from_soup(soup)
+            image_urls = get_relevant_images(soup, self.link)
+            title = extract_title(soup)
+            return content, image_urls, title
+
+        except Exception as e:
+            print("Error! : " + str(e))
+            return "", [], ""

--- a/gpt_researcher/scraper/invisible_playwright/invisible_playwright_scraper.py
+++ b/gpt_researcher/scraper/invisible_playwright/invisible_playwright_scraper.py
@@ -5,13 +5,13 @@ from bs4 import BeautifulSoup
 from ..utils import get_relevant_images, extract_title, get_text_from_soup, clean_soup
 
 
-class InvisibleFirefoxScraper:
+class InvisiblePlaywrightScraper:
     """Opt-in scraper that renders a page with a patched, fingerprint-real Firefox
     (``invisible_playwright``) before parsing it, for sources that block or fingerprint
     stock automation. Once the HTML is rendered it is parsed with the same BeautifulSoup
     utilities the other scrapers use, so the output format is unchanged.
 
-    Select it with ``SCRAPER=invisible_firefox``; when it is not selected nothing changes,
+    Select it with ``SCRAPER=invisible_playwright``; when it is not selected nothing changes,
     so defaults are untouched. ``invisible_playwright`` is imported lazily and is therefore
     NOT a required dependency: install it only if you use this scraper::
 
@@ -31,7 +31,7 @@ class InvisibleFirefoxScraper:
                 from invisible_playwright.async_api import InvisiblePlaywright
             except ImportError as e:
                 raise ImportError(
-                    "InvisibleFirefoxScraper requires invisible_playwright. Install it with "
+                    "InvisiblePlaywrightScraper requires invisible_playwright. Install it with "
                     '`pip install "git+https://github.com/feder-cr/invisible_playwright.git"` '
                     "and run `python -m invisible_playwright fetch` to download the browser."
                 ) from e

--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -20,6 +20,7 @@ from . import (
     BeautifulSoupScraper,
     BrowserScraper,
     FireCrawl,
+    InvisibleFirefoxScraper,
     NoDriverScraper,
     PyMuPDFScraper,
     TavilyExtract,
@@ -194,6 +195,7 @@ class Scraper:
             "nodriver": NoDriverScraper,
             "tavily_extract": TavilyExtract,
             "firecrawl": FireCrawl,
+            "invisible_firefox": InvisibleFirefoxScraper,
         }
 
         scraper_key = None

--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -20,7 +20,7 @@ from . import (
     BeautifulSoupScraper,
     BrowserScraper,
     FireCrawl,
-    InvisibleFirefoxScraper,
+    InvisiblePlaywrightScraper,
     NoDriverScraper,
     PyMuPDFScraper,
     TavilyExtract,
@@ -195,7 +195,7 @@ class Scraper:
             "nodriver": NoDriverScraper,
             "tavily_extract": TavilyExtract,
             "firecrawl": FireCrawl,
-            "invisible_firefox": InvisibleFirefoxScraper,
+            "invisible_playwright": InvisiblePlaywrightScraper,
         }
 
         scraper_key = None


### PR DESCRIPTION
opening as draft to check interest before building this out further.

would an optional `invisible_firefox` scraper backend fit in scope, parallel to firecrawl / browser / web_base_loader / tavily_extract under `gpt_researcher/scraper/`?

motivation: research-relevant pages behind Cloudflare/Akamai/Datadome/hCaptcha currently return empty content or 403. relevant open issues: #1685, #1081, #1602, #1404.

the backend wraps invisible_playwright (github.com/feder-cr/invisible_playwright, also on PyPI as invisible-playwright), which drives a patched Firefox through the normal Playwright context/page API. the C++ level patches live in a separate repo, firefox_antidetect_patch. selected via `SCRAPER=invisible_firefox`, optional dependency, no change to defaults.

two corrections to the original post. first, this diff already includes the actual scraper class, not just a docs stub - I described it wrong the first time. second, the module/class name and the install line in the docstring still reference invisible_firefox, a separate profile-manager project of mine that's since been retired; the code here never depended on it, it only imports invisible_playwright, so before this leaves draft I'll rename the module/class and switch the install line to `pip install invisible-playwright`.

if the answer is "not in scope" I'll close it without noise.