### PR TITLE
Add GetXAPI retriever for X/Twitter search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 OPENAI_API_KEY=
 TAVILY_API_KEY=
 XQUIK_API_KEY=
+GETXAPI_API_KEY=
 DOC_PATH=./my-docs
 
 # NEXT_PUBLIC_GPTR_API_URL=http://0.0.0.0:8000  # Defaults to localhost:8000 if not set

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -30,6 +30,7 @@ def get_retriever(retriever: str):
         - custom: Custom user-defined retriever
         - mcp: Model Context Protocol retriever
         - xquik: Xquik X/Twitter search
+        - getxapi: GetXAPI X/Twitter search
     """
     match retriever:
         case "google":
@@ -96,6 +97,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import XquikSearch
 
             return XquikSearch
+        case "getxapi":
+            from gpt_researcher.retrievers import GetXAPISearch
+
+            return GetXAPISearch
 
         case _:
             return None

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -11,6 +11,7 @@ from .serpapi.serpapi import SerpApiSearch
 from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
 from .exa.exa import ExaSearch
+from .getxapi.getxapi import GetXAPISearch
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
@@ -29,6 +30,7 @@ __all__ = [
     "SemanticScholarSearch",
     "PubMedCentralSearch",
     "ExaSearch",
+    "GetXAPISearch",
     "MCPRetriever",
     "BoChaSearch",
     "XquikSearch"

--- a/gpt_researcher/retrievers/getxapi/getxapi.py
+++ b/gpt_researcher/retrievers/getxapi/getxapi.py
@@ -1,0 +1,91 @@
+"""GetXAPI X/Twitter retriever for GPT Researcher."""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+
+class GetXAPISearch:
+    """
+    GetXAPI X/Twitter search retriever.
+
+    Searches tweets via the GetXAPI REST API and returns results in the
+    standard {title, href, body} format used by all GPT Researcher retrievers.
+
+    Set GETXAPI_API_KEY in your environment. Get one at https://getxapi.com
+    """
+
+    def __init__(self, query, query_domains=None, **kwargs):
+        self.query = query
+        self.query_domains = query_domains
+        self.api_key = self.get_api_key()
+
+    def get_api_key(self):
+        try:
+            api_key = os.environ["GETXAPI_API_KEY"]
+        except KeyError:
+            raise Exception(
+                "GetXAPI API key not found. Please set the GETXAPI_API_KEY "
+                "environment variable. Get a key at https://getxapi.com"
+            )
+        return api_key
+
+    def search(self, max_results=10):
+        """
+        Search X/Twitter via GetXAPI advanced search.
+
+        Returns:
+            list: Search results as [{title, href, body}, ...]
+        """
+        print(f"Searching X/Twitter with query: {self.query}...")
+
+        try:
+            results = self._search_tweets(max_results)
+            return results
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching X/Twitter sources. Resulting in empty response.")
+            return []
+
+    def _search_tweets(self, max_results):
+        params = urllib.parse.urlencode({"q": self.query})
+        url = f"https://api.getxapi.com/twitter/tweet/advanced_search?{params}"
+
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "User-Agent": "gpt-researcher/1.0",
+        })
+
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        tweets = data.get("tweets") or data.get("data") or []
+        search_results = []
+
+        for tweet in tweets[:max_results]:
+            author = tweet.get("author") or {}
+            username = (
+                author.get("userName")
+                or author.get("username")
+                or author.get("screen_name")
+                or tweet.get("username")
+                or "unknown"
+            )
+            text = tweet.get("text") or tweet.get("full_text") or ""
+            tweet_id = tweet.get("id") or tweet.get("id_str") or ""
+
+            likes = tweet.get("likeCount") or tweet.get("favorite_count") or 0
+            retweets = tweet.get("retweetCount") or tweet.get("retweet_count") or 0
+            replies = tweet.get("replyCount") or tweet.get("reply_count") or 0
+            views = tweet.get("viewCount") or tweet.get("view_count") or 0
+
+            truncated = text[:80] + ("..." if len(text) > 80 else "")
+
+            search_results.append({
+                "title": f"@{username}: {truncated}",
+                "href": f"https://x.com/{username}/status/{tweet_id}",
+                "body": f"{text}\n\n[likes:{likes} retweets:{retweets} replies:{replies} views:{views}]",
+            })
+
+        return search_results

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -73,6 +73,7 @@ VALID_RETRIEVERS = [
     "semantic_scholar",
     "pubmed_central",
     "exa",
+    "getxapi",
     "mcp",
     "xquik",
     "mock"


### PR DESCRIPTION
## Summary

Adds GetXAPI as a new retriever for X/Twitter search, following the same 6-file pattern used by the Xquik retriever (#1734) and OpenAlex (#1748).

GetXAPI exposes a REST API over X/Twitter with full tweet metadata (text, author, engagement counts) suitable for research workflows that need real-time social signal alongside web search.

## Why

GPT Researcher today routes through web crawlers + academic indexes. Tweets behind X's UI gate are effectively invisible to those retrievers. Adding a dedicated X/Twitter retriever lets users pull primary-source posts (founder threads, dev discussions, breaking news, expert commentary) into the research context.

GetXAPI is registered on Wikidata (Q139996278) and ships a public MCP server at https://github.com/getxapi/getxapi-mcp.

## Usage

```bash
export GETXAPI_API_KEY="<key>"
export RETRIEVER="getxapi"
```

Or combine with others:

```bash
export RETRIEVER="tavily,getxapi"
```

## Changes

| File | Change |
|---|---|
| `gpt_researcher/retrievers/getxapi/__init__.py` | new (package marker) |
| `gpt_researcher/retrievers/getxapi/getxapi.py` | new `GetXAPISearch` class, stdlib only |
| `gpt_researcher/retrievers/__init__.py` | export `GetXAPISearch` |
| `gpt_researcher/retrievers/utils.py` | add `"getxapi"` to `VALID_RETRIEVERS` |
| `gpt_researcher/actions/retriever.py` | add `case "getxapi"` and docstring entry |
| `.env.example` | add `GETXAPI_API_KEY=` |

Net diff: +100 lines, 0 deletions. No new runtime dependencies (uses `urllib`, `json`, `os` from stdlib). 15s timeout, graceful empty-list fallback on any HTTP/JSON error.

## Verification

Local sanity call:

```python
import os
os.environ["GETXAPI_API_KEY"] = "<key>"
from gpt_researcher.retrievers import GetXAPISearch
r = GetXAPISearch("gpt-researcher").search(max_results=3)
# -> [{"title": "@user: ...", "href": "https://x.com/user/status/...", "body": "...\n\n[likes:N retweets:N replies:N views:N]"}, ...]
```

Follows the established retriever contract: returns `[{title, href, body}, ...]` matching what `context_manager.get_similar_content_by_query` expects.