### PR TITLE
docs: upgrade MiniMax default model to M3

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -381,24 +381,23 @@ EMBEDDING="aimlapi:text-embedding-3-small"
 
 ## MiniMax
 
-[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. The latest MiniMax-M2.7 features improved reasoning and competitive pricing.
+[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. The latest MiniMax-M3 features a 512K context window, up to 128K output, and image input support.
 
 Sign up at [minimaxi.com](https://www.minimaxi.com) to get an API key, then set the following environment variables:
 
 ```env
 MINIMAX_API_KEY=[Your Key]
-FAST_LLM=minimax:MiniMax-M2.7-highspeed
-SMART_LLM=minimax:MiniMax-M2.7
-STRATEGIC_LLM=minimax:MiniMax-M2.7
+FAST_LLM=minimax:MiniMax-M3
+SMART_LLM=minimax:MiniMax-M3
+STRATEGIC_LLM=minimax:MiniMax-M3
 
 EMBEDDING=minimax:embo-01
 ```
 
 Available models:
-- `MiniMax-M2.7` — latest flagship model with improved reasoning
-- `MiniMax-M2.7-highspeed` — optimized for speed
-- `MiniMax-M2.5` — 204K context, general-purpose model
-- `MiniMax-M2.5-highspeed` — 204K context, optimized for speed
+- `MiniMax-M3` — flagship model with 512K context, 128K max output, image input support (default)
+- `MiniMax-M2.7` — previous-generation model
+- `MiniMax-M2.7-highspeed` — previous-generation low-latency variant
 
 ## Avian
 


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration in the docs to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the documented model list and set as default in env-var examples (`FAST_LLM` / `SMART_LLM` / `STRATEGIC_LLM`)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`MiniMax-M2.5` / `MiniMax-M2.5-highspeed`)
- Update the MiniMax section description to reflect M3's capabilities

## Why
MiniMax-M3 is the latest model, with a 512K context window, up to 128K output, and image input support. It is a drop-in replacement for the existing OpenAI-compatible client wiring already in place in `gpt_researcher/llm_provider/generic/base.py` and `gpt_researcher/memory/embeddings.py` — no code changes are needed since model IDs are passed via env vars.

## Testing
- Doc-only change; existing OpenAI-compatible client code path is unchanged
- Verified no Python source references the legacy `MiniMax-M2.5` / `MiniMax-M2.7` model IDs