### PR TITLE
fix(deep-research): keep oversized context from collapsing to empty

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -217,10 +217,14 @@ def trim_context_to_word_limit(context_list: List[str], max_words: int = MAX_CON
 
     # Process in reverse to keep most recent items
     for item in reversed(context_list):
+        text = " ".join(str(part) for part in item) if isinstance(item, list) else str(item)
         words = count_words(item)
         if total_words + words <= max_words:
             trimmed_context.insert(0, item)  # Insert at start to maintain original order
             total_words += words
+        elif not trimmed_context:
+            trimmed_context.insert(0, " ".join(text.split()[:max_words]))
+            break
         else:
             break
 

--- a/tests/test_deep_research_parsing.py
+++ b/tests/test_deep_research_parsing.py
@@ -5,9 +5,11 @@ import pytest
 import gpt_researcher.skills.deep_research as deep_research_module
 from gpt_researcher.skills.deep_research import (
     DeepResearchSkill,
+    MAX_CONTEXT_WORDS,
     parse_follow_up_questions_response,
     parse_research_results_response,
     parse_search_queries_response,
+    trim_context_to_word_limit,
 )
 
 
@@ -294,3 +296,21 @@ def test_parse_research_results_response_extracts_inline_legacy_url():
 
     assert result["learnings"] == ["stuff happened at"]
     assert result["citations"]["stuff happened at"] == "https://example.com/api/v1?key=value"
+
+
+def test_trim_context_to_word_limit_keeps_first_item_when_it_alone_exceeds_cap():
+    oversized_item = "word " * (MAX_CONTEXT_WORDS + 500)
+
+    result = trim_context_to_word_limit([oversized_item], max_words=MAX_CONTEXT_WORDS)
+
+    assert result, "trim_context_to_word_limit() should not return an empty context when the first item is oversized"
+    assert len(result[0].split()) == MAX_CONTEXT_WORDS
+
+
+def test_trim_context_to_word_limit_preserves_recent_context_and_keeps_one_oversized_tail_item():
+    earlier = "early context " * 50
+    oversized_latest = "latest " * (MAX_CONTEXT_WORDS + 250)
+
+    result = trim_context_to_word_limit([earlier, oversized_latest], max_words=MAX_CONTEXT_WORDS)
+
+    assert result == [" ".join(oversized_latest.split()[:MAX_CONTEXT_WORDS])]


### PR DESCRIPTION
Fixes #1770.

This PR prevents deep-research context trimming from collapsing to an empty string when the first retained context item alone exceeds `MAX_CONTEXT_WORDS`.

What changed:
- update `trim_context_to_word_limit()` in `gpt_researcher/skills/deep_research.py`
- when the first candidate item already exceeds the cap and nothing has been retained yet, keep a truncated version of that item instead of returning an empty context
- add focused regression tests in `tests/test_deep_research_parsing.py`

Why:
- deep research currently joins `final_context` into `self.researcher.context`
- if `trim_context_to_word_limit()` returns `[]`, the writer receives `""` for `{context}`
- this matches the failure mode described in #1770, where deep research completes but the writer rejects the report because no research material is present

Validation:
- `.\.venv\Scripts\python.exe -m pytest tests/test_deep_research_parsing.py -q`
- `25 passed`