### PR TITLE
feat(retrievers): add fastCRW search retriever

### DIFF
--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -33,6 +33,7 @@ Thanks to our community, we have integrated the following web search engines:
 - [Duckduckgo](https://pypi.org/project/duckduckgo-search/) - Env: `RETRIEVER=duckduckgo`
 - [Arxiv](https://info.arxiv.org/help/api/index.html) - Env: `RETRIEVER=arxiv`
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
+- [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
 
 ## Custom Retrievers

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -25,6 +25,7 @@ def get_retriever(retriever: str):
         - arxiv: arXiv academic search
         - tavily: Tavily search API
         - exa: Exa search
+        - crw: fastCRW search (Firecrawl-compatible web scraper)
         - semantic_scholar: Semantic Scholar academic search
         - pubmed_central: PubMed Central medical literature
         - openalex: OpenAlex scholarly works catalog
@@ -77,6 +78,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import ExaSearch
 
             return ExaSearch
+        case "crw":
+            from gpt_researcher.retrievers import CRWRetriever
+
+            return CRWRetriever
         case "semantic_scholar":
             from gpt_researcher.retrievers import SemanticScholarSearch
 

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -11,6 +11,7 @@ from .serpapi.serpapi import SerpApiSearch
 from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
 from .exa.exa import ExaSearch
+from .crw.crw import CRWRetriever
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
@@ -30,6 +31,7 @@ __all__ = [
     "SemanticScholarSearch",
     "PubMedCentralSearch",
     "ExaSearch",
+    "CRWRetriever",
     "MCPRetriever",
     "BoChaSearch",
     "XquikSearch",

--- a/gpt_researcher/retrievers/crw/crw.py
+++ b/gpt_researcher/retrievers/crw/crw.py
@@ -1,0 +1,124 @@
+"""fastCRW API search retriever for GPT Researcher.
+
+This module provides the CRWRetriever class for performing web searches
+using fastCRW, a Firecrawl-compatible web data engine (single binary;
+self-host or managed cloud).
+"""
+
+import json
+import os
+
+import requests
+
+
+class CRWRetriever:
+    """
+    fastCRW API Retriever
+    """
+
+    def __init__(self, query, headers=None, topic="general", query_domains=None):
+        """
+        Initializes the CRWRetriever object.
+
+        Args:
+            query (str): The search query string.
+            headers (dict, optional): Additional headers to include in the request. Defaults to None.
+            topic (str, optional): The topic for the search. Defaults to "general".
+            query_domains (list, optional): List of domains to include in the search. Defaults to None.
+        """
+        input_headers = headers or {}
+        self.query = query
+        self.topic = topic
+        self.base_url = self.get_base_url(input_headers)
+        self.api_key = self.get_api_key(input_headers)
+        self.headers = {
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            self.headers["Authorization"] = f"Bearer {self.api_key}"
+        self.query_domains = query_domains or None
+
+    def get_api_key(self, headers):
+        """
+        Gets the fastCRW API key
+        Args:
+            headers (dict): The headers passed to the retriever.
+        Returns:
+
+        """
+        api_key = headers.get("crw_api_key")
+        if not api_key:
+            try:
+                api_key = os.environ["CRW_API_KEY"]
+            except KeyError:
+                print(
+                    "CRW API key not found, set to blank. If you need a retriver, please set the CRW_API_KEY environment variable."
+                )
+                return ""
+        return api_key
+
+    def get_base_url(self, headers):
+        """
+        Gets the fastCRW base URL, allowing self-host overrides.
+
+        Defaults to the managed cloud at https://fastcrw.com/api. Override with
+        the CRW_API_URL environment variable (or the crw_api_url header) to point
+        at a self-hosted server.
+        Args:
+            headers (dict): The headers passed to the retriever.
+        Returns:
+            The base URL (without a trailing slash).
+        """
+        base_url = headers.get("crw_api_url") or os.environ.get(
+            "CRW_API_URL", "https://fastcrw.com/api"
+        )
+        return base_url.rstrip("/")
+
+    def _search(self, query: str, max_results: int = 10) -> dict:
+        """
+        Internal search method to send the request to the API.
+        """
+
+        data = {
+            "query": query,
+            "limit": max_results,
+        }
+
+        response = requests.post(
+            f"{self.base_url}/v1/search",
+            data=json.dumps(data),
+            headers=self.headers,
+            timeout=100,
+        )
+        # Raises a HTTPError if the HTTP request returned an unsuccessful status code
+        response.raise_for_status()
+        results = response.json()
+        # fastCRW wraps responses in a {success, error, data} envelope.
+        if results.get("success") is False:
+            raise Exception(results.get("error", "fastCRW API search failed."))
+        return results
+
+    def search(self, max_results=10):
+        """
+        Searches the query
+        Returns:
+
+        """
+        try:
+            # Search the query
+            results = self._search(self.query, max_results=max_results)
+            sources = results.get("data", [])
+            if not sources:
+                raise Exception("No results found with fastCRW API search.")
+            # Return the results
+            search_response = [
+                {
+                    "href": obj["url"],
+                    "body": obj.get("markdown") or obj.get("description", ""),
+                }
+                for obj in sources
+            ]
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
+            search_response = []
+        return search_response

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -73,6 +73,7 @@ VALID_RETRIEVERS = [
     "semantic_scholar",
     "pubmed_central",
     "exa",
+    "crw",
     "mcp",
     "xquik",
     "openalex",

--- a/tests/test_crw_retriever.py
+++ b/tests/test_crw_retriever.py
@@ -1,0 +1,108 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.crw.crw import CRWRetriever
+
+
+def make_response(json_data, status_code=200):
+    """Build a fake requests.Response-like object."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+class CRWRetrieverTests(unittest.TestCase):
+    @patch.dict("os.environ", {"CRW_API_KEY": "test-key"}, clear=False)
+    @patch("gpt_researcher.retrievers.crw.crw.requests.post")
+    def test_search_returns_href_body_shape(self, mock_post):
+        mock_post.return_value = make_response(
+            {
+                "success": True,
+                "data": [
+                    {
+                        "url": "https://example.com/one",
+                        "description": "desc one",
+                        "markdown": "markdown one",
+                    }
+                ],
+            }
+        )
+
+        retriever = CRWRetriever("rust async runtimes")
+        results = retriever.search()
+
+        self.assertEqual(
+            results,
+            [{"href": "https://example.com/one", "body": "markdown one"}],
+        )
+
+    @patch.dict("os.environ", {"CRW_API_KEY": "test-key"}, clear=False)
+    @patch("gpt_researcher.retrievers.crw.crw.requests.post")
+    def test_markdown_preferred_over_description(self, mock_post):
+        mock_post.return_value = make_response(
+            {
+                "success": True,
+                "data": [
+                    {
+                        "url": "https://example.com/md",
+                        "description": "fallback description",
+                        "markdown": "rich markdown",
+                    },
+                    {
+                        "url": "https://example.com/no-md",
+                        "description": "only description",
+                    },
+                ],
+            }
+        )
+
+        retriever = CRWRetriever("query")
+        results = retriever.search()
+
+        self.assertEqual(results[0]["body"], "rich markdown")
+        self.assertEqual(results[1]["body"], "only description")
+
+    @patch.dict("os.environ", {"CRW_API_KEY": "test-key"}, clear=False)
+    @patch("gpt_researcher.retrievers.crw.crw.requests.post")
+    def test_empty_data_returns_empty_list(self, mock_post):
+        mock_post.return_value = make_response({"success": True, "data": []})
+
+        retriever = CRWRetriever("query")
+        results = retriever.search()
+
+        self.assertEqual(results, [])
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_api_key_does_not_raise(self):
+        # Constructing without CRW_API_KEY must not raise; key falls back to blank.
+        retriever = CRWRetriever("query")
+        self.assertEqual(retriever.api_key, "")
+        # No Authorization header is added when the key is blank (self-host case).
+        self.assertNotIn("Authorization", retriever.headers)
+
+    @patch.dict(
+        "os.environ",
+        {"CRW_API_KEY": "test-key", "CRW_API_URL": "http://localhost:3000/"},
+        clear=False,
+    )
+    def test_base_url_override_strips_trailing_slash(self):
+        retriever = CRWRetriever("query")
+        self.assertEqual(retriever.base_url, "http://localhost:3000")
+
+    @patch.dict("os.environ", {"CRW_API_KEY": "test-key"}, clear=False)
+    @patch("gpt_researcher.retrievers.crw.crw.requests.post")
+    def test_envelope_failure_returns_empty_list(self, mock_post):
+        mock_post.return_value = make_response(
+            {"success": False, "error": "rate limited"}
+        )
+
+        retriever = CRWRetriever("query")
+        results = retriever.search()
+
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds **fastCRW** as a new web-search retriever, selectable via `RETRIEVER=crw`, alongside the existing providers (Tavily, Exa, Serper, etc.).

[fastCRW](https://fastcrw.com) is an open-source ([AGPL](https://github.com/us/crw)) web data engine distributed as a single ~8 MB Rust binary with zero runtime dependencies. It exposes a `/v1/search` endpoint (web + image search with optional scraped content), which this retriever uses.

## Why

### 1. Genuinely open — stealth, BYO-proxy, and JS rendering in the open core

fastCRW ships Cloudflare JS-challenge handling, UA rotation, SPA rendering, and BYO-proxy with automatic rotation in its AGPL open core — no cloud-only flags, no asterisks. Self-hosted Firecrawl OSS gates its anti-bot / stealth path (`fire-engine`) behind a cloud-only flag, so its self-hosted build falls back to plain fetch or Playwright and cannot reach Cloudflare-protected or JS-heavy sites. fastCRW's self-hosted build has no such limitation. It also runs as a single binary with no external services (no Redis, no worker processes, no Playwright daemon required).

**Practical upshot for gpt-researcher users:** self-hosting gpt-researcher + fastCRW is the only combination today that gives you a complete, cloud-free research stack that can actually reach protected and JS-heavy pages.

### 2. Faster and higher-quality on an independent benchmark

On Firecrawl's own public benchmark dataset:

| Metric | fastCRW | Firecrawl |
|---|---|---|
| Truth-recall | **63.74 %** | 56.04 % |
| Median latency (p50) | **~1.9 s** | ~2.3 s |

Single ~8 MB Rust binary, ~6 MB RAM idle.

### 3. Search is built on SearXNG — with a quality layer on top

fastCRW is not an alternative to SearXNG; it is built on top of it. SearXNG is the metasearch aggregator underneath; fastCRW adds a quality layer: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / Google Scholar, code queries to GitHub). The result is SearXNG's breadth plus a measurable accuracy layer — all open-source (AGPL) and self-hostable with configurable engines.

Free tier available; managed pricing is flat (1 credit = 1 page, no stealth surcharge, no charge on failure).

### Firecrawl-API compatibility

fastCRW's API is compatible with the Firecrawl `/v1/search` contract, which is why this integration is a small, additive diff that touches nothing existing.

## Changes (additive only — nothing existing is modified)

- `gpt_researcher/retrievers/crw/` — new `CRWRetriever`, mirrors the `TavilySearch` interface and return shape (`{"href", "body"}`).
- Registered in `retrievers/__init__.py`, `actions/retriever.py` (`get_retriever`), and `retrievers/utils.py` (`VALID_RETRIEVERS`).
- Docs entry in `search-engines.md`.
- `tests/test_crw_retriever.py` — unit tests with mocked HTTP (no network): result shape, markdown-preferred-over-description, empty results, missing key, base-URL override, error envelope.

## Config

```bash
export RETRIEVER=crw
export CRW_API_KEY=...            # from https://fastcrw.com/dashboard (free tier available)
export CRW_API_URL=http://...     # optional, for a self-hosted server (default: https://fastcrw.com/api)
```

Happy to adjust anything to match your conventions. I maintain the integration and am glad to set the team up with free credits to evaluate it.
