### PR TITLE
Add Keenable web search retriever

### DIFF
--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -99,7 +99,7 @@ so you only need to set the retriever:
 RETRIEVER=keenable
 ```
 
-To lift rate limits and enable `realtime` mode, set an API key (create one at
+To lift rate limits, set an API key (create one at
 [keenable.ai/console](https://keenable.ai/console)):
 
 ```bash
@@ -110,7 +110,6 @@ KEENABLE_API_KEY=your_api_key_here   # optional
 **Optional Configuration:**
 
 ```bash
-KEENABLE_SEARCH_MODE=pro             # "pro" (default, deeper) or "realtime" (low latency, requires a key)
 KEENABLE_API_URL=https://api.keenable.ai   # override the API base URL (HTTPS); e.g. for staging
 ```
 

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -24,6 +24,7 @@ RETRIEVER=tavily, arxiv
 Thanks to our community, we have integrated the following web search engines:
 
 - [Tavily](https://app.tavily.com) - Default
+- [Keenable](https://keenable.ai) - Env: `RETRIEVER=keenable` - keyless by default - [Setup Guide](#keenable)
 - [Bing](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api) - Env: `RETRIEVER=bing`
 - [Brave Search](https://brave.com/search/api/) - Env: `RETRIEVER=brave` and `BRAVE_API_KEY`
 - [Google](https://developers.google.com/custom-search/v1/overview) - Env: `RETRIEVER=google`
@@ -86,6 +87,31 @@ To use [Brave Search](https://brave.com/search/api/) as your search engine:
 ```bash
 RETRIEVER=brave
 BRAVE_API_KEY=your_api_key_here
+```
+
+### Keenable
+
+[Keenable](https://keenable.ai) is a web search API built for AI agents. It
+works **without an API key** — by default it uses the keyless public endpoint,
+so you only need to set the retriever:
+
+```bash
+RETRIEVER=keenable
+```
+
+To lift rate limits and enable `realtime` mode, set an API key (create one at
+[keenable.ai/console](https://keenable.ai/console)):
+
+```bash
+RETRIEVER=keenable
+KEENABLE_API_KEY=your_api_key_here   # optional
+```
+
+**Optional Configuration:**
+
+```bash
+KEENABLE_SEARCH_MODE=pro             # "pro" (default, deeper) or "realtime" (low latency, requires a key)
+KEENABLE_API_URL=https://api.keenable.ai   # override the API base URL (HTTPS); e.g. for staging
 ```
 
 ### Serper

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -111,7 +111,7 @@ so you only need to set the retriever:
 RETRIEVER=keenable
 ```
 
-To lift rate limits and enable `realtime` mode, set an API key (create one at
+To lift rate limits, set an API key (create one at
 [keenable.ai/console](https://keenable.ai/console)):
 
 ```bash
@@ -122,7 +122,6 @@ KEENABLE_API_KEY=your_api_key_here   # optional
 **Optional Configuration:**
 
 ```bash
-KEENABLE_SEARCH_MODE=pro             # "pro" (default, deeper) or "realtime" (low latency, requires a key)
 KEENABLE_API_URL=https://api.keenable.ai   # override the API base URL (HTTPS); e.g. for staging
 ```
 

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -30,6 +30,7 @@ RETRIEVER=tavily,openalex,semantic_scholar
 Thanks to our community, we have integrated the following web search engines and research retrievers:
 
 - [Tavily](https://app.tavily.com) - Default
+- [Keenable](https://keenable.ai) - Env: `RETRIEVER=keenable` - keyless by default - [Setup Guide](#keenable)
 - [Bing](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api) - Env: `RETRIEVER=bing`
 - [Brave Search](https://brave.com/search/api/) - Env: `RETRIEVER=brave` and `BRAVE_API_KEY`
 - [GroundRoute](https://groundroute.ai/) - Env: `RETRIEVER=groundroute` and `GROUNDROUTE_API_KEY`
@@ -98,6 +99,31 @@ To use [Brave Search](https://brave.com/search/api/) as your search engine:
 ```bash
 RETRIEVER=brave
 BRAVE_API_KEY=your_api_key_here
+```
+
+### Keenable
+
+[Keenable](https://keenable.ai) is a web search API built for AI agents. It
+works **without an API key** — by default it uses the keyless public endpoint,
+so you only need to set the retriever:
+
+```bash
+RETRIEVER=keenable
+```
+
+To lift rate limits and enable `realtime` mode, set an API key (create one at
+[keenable.ai/console](https://keenable.ai/console)):
+
+```bash
+RETRIEVER=keenable
+KEENABLE_API_KEY=your_api_key_here   # optional
+```
+
+**Optional Configuration:**
+
+```bash
+KEENABLE_SEARCH_MODE=pro             # "pro" (default, deeper) or "realtime" (low latency, requires a key)
+KEENABLE_API_URL=https://api.keenable.ai   # override the API base URL (HTTPS); e.g. for staging
 ```
 
 ### Serper

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -25,6 +25,7 @@ def get_retriever(retriever: str):
         - brave: Brave Search API
         - arxiv: arXiv academic search
         - tavily: Tavily search API
+        - keenable: Keenable web search API (keyless by default)
         - exa: Exa search
         - crw: fastCRW search (Firecrawl-compatible web scraper)
         - semantic_scholar: Semantic Scholar academic search
@@ -83,6 +84,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import GroundRouteSearch
 
             return GroundRouteSearch
+        case "keenable":
+            from gpt_researcher.retrievers import KeenableSearch
+
+            return KeenableSearch
         case "exa":
             from gpt_researcher.retrievers import ExaSearch
 

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -25,6 +25,7 @@ def get_retriever(retriever: str):
         - brave: Brave Search API
         - arxiv: arXiv academic search
         - tavily: Tavily search API
+        - keenable: Keenable web search API (keyless by default)
         - exa: Exa search
         - crw: fastCRW search (Firecrawl-compatible web scraper)
         - semantic_scholar: Semantic Scholar academic search
@@ -84,6 +85,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import GroundRouteSearch
 
             return GroundRouteSearch
+        case "keenable":
+            from gpt_researcher.retrievers import KeenableSearch
+
+            return KeenableSearch
         case "exa":
             from gpt_researcher.retrievers import ExaSearch
 

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -12,6 +12,7 @@ from .serpapi.serpapi import SerpApiSearch
 from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
 from .groundroute.groundroute import GroundRouteSearch
+from .keenable.keenable import KeenableSearch
 from .exa.exa import ExaSearch
 from .crw.crw import CRWRetriever
 from .mcp import MCPRetriever
@@ -22,6 +23,7 @@ from .openalex.openalex import OpenAlexSearch
 __all__ = [
     "TavilySearch",
     "GroundRouteSearch",
+    "KeenableSearch",
     "CustomRetriever",
     "Duckduckgo",
     "SearchApiSearch",

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -12,6 +12,7 @@ from .serpapi.serpapi import SerpApiSearch
 from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
 from .groundroute.groundroute import GroundRouteSearch
+from .keenable.keenable import KeenableSearch
 from .exa.exa import ExaSearch
 from .crw.crw import CRWRetriever
 from .getxapi.getxapi import GetXAPISearch
@@ -23,6 +24,7 @@ from .openalex.openalex import OpenAlexSearch
 __all__ = [
     "TavilySearch",
     "GroundRouteSearch",
+    "KeenableSearch",
     "CustomRetriever",
     "Duckduckgo",
     "SearchApiSearch",

--- a/gpt_researcher/retrievers/keenable/keenable.py
+++ b/gpt_researcher/retrievers/keenable/keenable.py
@@ -1,0 +1,120 @@
+# Keenable Retriever
+# https://keenable.ai
+
+import os
+from urllib.parse import urlsplit
+
+import requests
+
+
+class KeenableSearch:
+    """
+    Keenable API Retriever — a web search API built for AI agents.
+
+    Keyless by default: with no ``KEENABLE_API_KEY`` set, the free public
+    endpoint is used, so this retriever works out of the box. Set
+    ``KEENABLE_API_KEY`` (create one at https://keenable.ai/console) to use the
+    authenticated endpoint, lift rate limits, and enable ``realtime`` mode.
+    """
+
+    def __init__(self, query, query_domains=None, **kwargs):
+        """
+        Initializes the KeenableSearch object.
+
+        Args:
+            query (str): The search query string.
+            query_domains (list, optional): Domains to restrict the search to.
+                Keenable filters by a single site, so the first domain is used.
+                Defaults to None.
+        """
+        self.query = query
+        self.query_domains = query_domains or None
+        # "pro" (default, deeper retrieval) or "realtime" (low latency; requires
+        # a key — not available on the keyless public endpoint).
+        self.mode = os.getenv("KEENABLE_SEARCH_MODE", "pro")
+        self.api_key = self.get_api_key()
+        self.base_url = self.get_base_url()
+
+    def get_api_key(self):
+        """
+        Gets the Keenable API key if one is configured.
+
+        Returns:
+            str: The API key, or "" to use the keyless free tier.
+        """
+        # A key is optional here, unlike most retrievers — Keenable defaults to
+        # the keyless public endpoint, so we never raise when it is missing.
+        return (os.environ.get("KEENABLE_API_KEY") or "").strip()
+
+    def get_base_url(self):
+        """
+        Resolves the API base URL from ``KEENABLE_API_URL`` (HTTPS enforced).
+
+        Returns:
+            str: The base URL, defaulting to https://api.keenable.ai.
+        """
+        base = (os.environ.get("KEENABLE_API_URL") or "https://api.keenable.ai").rstrip("/")
+        parsed = urlsplit(base)
+        if parsed.hostname:
+            if parsed.scheme == "https":
+                return base
+            # Permit plain http only against a loopback host (local dev).
+            if parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1", "::1"}:
+                return base
+        raise ValueError(
+            f"KEENABLE_API_URL must be an https:// URL with a host, got {base!r}"
+        )
+
+    def search(self, max_results=10):
+        """
+        Searches the query via the Keenable API.
+
+        Returns:
+            list: List of search results with title, href, and body.
+        """
+        # Keyless public endpoint by default; the keyed endpoint + X-API-Key
+        # header when KEENABLE_API_KEY is set.
+        if self.api_key:
+            path = "/v1/search"
+            headers = {"X-API-Key": self.api_key}
+        else:
+            path = "/v1/search/public"
+            headers = {}
+
+        headers.update({
+            "Content-Type": "application/json",
+            "User-Agent": "keenable-gpt-researcher",
+            # Attribution header the Keenable backend segments traffic by.
+            "X-Keenable-Title": "GPT-Researcher",
+        })
+
+        payload = {"query": self.query, "mode": self.mode}
+        # Keenable filters by a single site; use the first domain when provided.
+        if self.query_domains:
+            payload["site"] = list(self.query_domains)[0]
+
+        try:
+            response = requests.post(
+                f"{self.base_url}{path}",
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+            response.raise_for_status()
+            results = response.json().get("results", [])
+            if not results:
+                raise Exception("No results found with Keenable API search.")
+            search_response = [
+                {
+                    "title": obj.get("title"),
+                    "href": obj.get("url"),
+                    "body": obj.get("description"),
+                }
+                for obj in results
+                if obj.get("url")
+            ]
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
+            search_response = []
+        # Keenable returns a fixed-size result set; honor the caller's cap.
+        return search_response[:max_results]

--- a/gpt_researcher/retrievers/keenable/keenable.py
+++ b/gpt_researcher/retrievers/keenable/keenable.py
@@ -14,7 +14,7 @@ class KeenableSearch:
     Keyless by default: with no ``KEENABLE_API_KEY`` set, the free public
     endpoint is used, so this retriever works out of the box. Set
     ``KEENABLE_API_KEY`` (create one at https://keenable.ai/console) to use the
-    authenticated endpoint, lift rate limits, and enable ``realtime`` mode.
+    authenticated endpoint and lift rate limits.
     """
 
     def __init__(self, query, query_domains=None, **kwargs):
@@ -29,8 +29,7 @@ class KeenableSearch:
         """
         self.query = query
         self.query_domains = query_domains or None
-        # "pro" (default, deeper retrieval) or "realtime" (low latency; requires
-        # a key — not available on the keyless public endpoint).
+        # "pro" (default): deeper retrieval. Keyless public endpoint supported.
         self.mode = os.getenv("KEENABLE_SEARCH_MODE", "pro")
         self.api_key = self.get_api_key()
         self.base_url = self.get_base_url()

--- a/gpt_researcher/retrievers/keenable/keenable.py
+++ b/gpt_researcher/retrievers/keenable/keenable.py
@@ -23,6 +23,10 @@ class KeenableSearch:
     authenticated endpoint and lift rate limits.
     """
 
+    # Results are links plus a capped `body` preview -- the page still has to
+    # be scraped for its real content.
+    requires_scraping = True
+
     def __init__(self, query, query_domains=None, **kwargs):
         """
         Initializes the KeenableSearch object.

--- a/gpt_researcher/retrievers/keenable/keenable.py
+++ b/gpt_researcher/retrievers/keenable/keenable.py
@@ -6,6 +6,12 @@ from urllib.parse import urlsplit
 
 import requests
 
+# `body` is snippet-sized for web retrievers here — GPT-Researcher scrapes each
+# `href` for the full page anyway (only `raw_content` marks a result as already
+# fetched). Keenable returns whole-page text, so cap it to keep the shape the
+# other retrievers have.
+MAX_BODY_CHARS = 500
+
 
 class KeenableSearch:
     """
@@ -64,6 +70,25 @@ class KeenableSearch:
             f"KEENABLE_API_URL must be an https:// URL with a host, got {base!r}"
         )
 
+    @staticmethod
+    def _result_body(obj):
+        """
+        Extracts a result's text.
+
+        Keenable returns both ``snippet`` and ``description``; ``snippet``
+        carries the page text and ``description`` is frequently empty, so
+        prefer whichever has content. Snippets arrive as raw page text with
+        newlines, so collapse whitespace and cap the length.
+
+        Args:
+            obj (dict): One result from the Keenable API.
+
+        Returns:
+            str: Snippet-sized text for the result, possibly empty.
+        """
+        text = " ".join(str(obj.get("snippet") or obj.get("description") or "").split())
+        return text[:MAX_BODY_CHARS]
+
     def search(self, max_results=10):
         """
         Searches the query via the Keenable API.
@@ -107,7 +132,7 @@ class KeenableSearch:
                 {
                     "title": obj.get("title"),
                     "href": obj.get("url"),
-                    "body": obj.get("description"),
+                    "body": self._result_body(obj),
                 }
                 for obj in results
                 if obj.get("url")

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -62,6 +62,7 @@ def check_pkg(pkg: str) -> None:
 VALID_RETRIEVERS = [
     "tavily",
     "groundroute",
+    "keenable",
     "custom",
     "duckduckgo",
     "searchapi",

--- a/tests/test_keenable_retriever.py
+++ b/tests/test_keenable_retriever.py
@@ -113,6 +113,10 @@ class TestKeenableSearch(unittest.TestCase):
 
         self.assertEqual([r["href"] for r in results], ["https://example.com/one"])
 
+    def test_declares_requires_scraping(self):
+        # `body` is a capped preview, so the page still has to be fetched.
+        self.assertIs(KeenableSearch.requires_scraping, True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_keenable_retriever.py
+++ b/tests/test_keenable_retriever.py
@@ -1,0 +1,118 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.keenable.keenable import MAX_BODY_CHARS, KeenableSearch
+
+
+class TestKeenableSearch(unittest.TestCase):
+    def test_missing_api_key_uses_the_keyless_endpoint(self):
+        # Unlike the other retrievers here, Keenable does not require a key.
+        with patch.dict(os.environ, {}, clear=True):
+            retriever = KeenableSearch("test query")
+        self.assertEqual(retriever.api_key, "")
+
+    @patch("gpt_researcher.retrievers.keenable.keenable.requests.post")
+    def test_search_normalizes_results(self, mock_post):
+        # The API returns both fields on every result: `description` is
+        # frequently empty and `snippet` carries the page text.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com/one",
+                    "title": "One",
+                    "description": "",
+                    "snippet": "First page text",
+                },
+                {
+                    "url": "https://example.com/two",
+                    "title": "Two",
+                    "description": "",
+                    "snippet": "Second page text",
+                },
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            results = KeenableSearch("test query").search(max_results=2)
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "href": "https://example.com/one",
+                    "title": "One",
+                    "body": "First page text",
+                },
+                {
+                    "href": "https://example.com/two",
+                    "title": "Two",
+                    "body": "Second page text",
+                },
+            ],
+        )
+
+    @patch("gpt_researcher.retrievers.keenable.keenable.requests.post")
+    def test_search_falls_back_to_description(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com/one",
+                    "title": "One",
+                    "description": "A description",
+                }
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            results = KeenableSearch("test query").search()
+
+        self.assertEqual(results[0]["body"], "A description")
+
+    @patch("gpt_researcher.retrievers.keenable.keenable.requests.post")
+    def test_search_collapses_whitespace_and_caps_the_body(self, mock_post):
+        # Snippets arrive as raw page text, newlines included, and run far
+        # longer than the snippet the other retrievers return.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com/one",
+                    "title": "One",
+                    "description": "",
+                    "snippet": "line one\n\nline two" + " padding" * 500,
+                }
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            body = KeenableSearch("test query").search()[0]["body"]
+
+        self.assertEqual(len(body), MAX_BODY_CHARS)
+        self.assertNotIn("\n", body)
+        self.assertTrue(body.startswith("line one line two"))
+
+    @patch("gpt_researcher.retrievers.keenable.keenable.requests.post")
+    def test_search_drops_results_without_a_url(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"title": "No URL", "snippet": "text"},
+                {"url": "https://example.com/one", "title": "One", "snippet": "text"},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            results = KeenableSearch("test query").search()
+
+        self.assertEqual([r["href"] for r in results], ["https://example.com/one"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Keenable as a search retriever, selectable with `RETRIEVER=keenable`.

The main difference from the existing retrievers is that it doesn't require
an API key. By default it hits Keenable's keyless public endpoint, so it works
out of the box. Setting `KEENABLE_API_KEY` switches to the authenticated
endpoint and lifts the rate limits.

### Usage

```bash
RETRIEVER=keenable
```

Optional:

```bash
KEENABLE_API_KEY=...                 # lifts rate limits, enables realtime mode
KEENABLE_SEARCH_MODE=pro             # pro (default) or realtime
KEENABLE_API_URL=https://api.keenable.ai   # override base URL (HTTPS)
```

### Changes

- `gpt_researcher/retrievers/keenable/` — `KeenableSearch`, follows the Tavily
  retriever (`query` + `query_domains`, `.search()` returns `{title, href, body}`).
- Registered in `retrievers/__init__.py`, `actions/retriever.py`, and
  `VALID_RETRIEVERS`.
- Docs: added the retriever to the search engines page with a short setup section.

`query_domains` maps to Keenable's single-domain `site` filter (first domain
used). The base URL is read from the environment with HTTPS enforced; there's no
URL fetch path here, so nothing user/agent-controlled reaches the network beyond
the query.

Tested against the public endpoint and with a mocked transport (keyed/keyless
selection, headers, site filter, response mapping, error handling).
