### PR TITLE
Fix Azure blob loader path handling

### DIFF
--- a/gpt_researcher/document/azure_document_loader.py
+++ b/gpt_researcher/document/azure_document_loader.py
@@ -1,6 +1,7 @@
 from azure.storage.blob import BlobServiceClient
-import os
 import tempfile
+from pathlib import Path, PurePosixPath
+
 
 class AzureDocumentLoader:
     def __init__(self, container_name, connection_string):
@@ -9,14 +10,28 @@ class AzureDocumentLoader:
 
     async def load(self):
         """Download all blobs to temp files and return their paths."""
-        temp_dir = tempfile.mkdtemp()
+        temp_dir = Path(tempfile.mkdtemp()).resolve()
         blobs = self.container.list_blobs()
         file_paths = []
         for blob in blobs:
             blob_client = self.container.get_blob_client(blob.name)
-            local_path = os.path.join(temp_dir, blob.name)
+            local_path = self._get_blob_path(temp_dir, blob.name)
+            local_path.parent.mkdir(parents=True, exist_ok=True)
             with open(local_path, "wb") as f:
                 blob_data = blob_client.download_blob()
                 f.write(blob_data.readall())
-            file_paths.append(local_path)
+            file_paths.append(str(local_path))
         return file_paths  # Pass to existing DocumentLoader
+
+    @staticmethod
+    def _get_blob_path(temp_dir: Path, blob_name: str) -> Path:
+        """Return a safe local path for an Azure blob name."""
+        blob_path = PurePosixPath(blob_name.replace("\\", "/"))
+        if blob_path.is_absolute() or ".." in blob_path.parts:
+            raise ValueError(f"Unsafe blob name: {blob_name}")
+
+        local_path = (temp_dir / Path(*blob_path.parts)).resolve()
+        if temp_dir != local_path and temp_dir not in local_path.parents:
+            raise ValueError(f"Unsafe blob name: {blob_name}")
+
+        return local_path

--- a/tests/test_azure_document_loader.py
+++ b/tests/test_azure_document_loader.py
@@ -1,0 +1,87 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class _FakeBlobServiceClient:
+    @classmethod
+    def from_connection_string(cls, connection_string):
+        return cls()
+
+    def get_container_client(self, container_name):
+        return None
+
+
+azure_module = types.ModuleType("azure")
+azure_storage_module = types.ModuleType("azure.storage")
+azure_blob_module = types.ModuleType("azure.storage.blob")
+azure_blob_module.BlobServiceClient = _FakeBlobServiceClient
+sys.modules.setdefault("azure", azure_module)
+sys.modules.setdefault("azure.storage", azure_storage_module)
+sys.modules.setdefault("azure.storage.blob", azure_blob_module)
+
+module_path = Path(__file__).resolve().parents[1] / "gpt_researcher" / "document" / "azure_document_loader.py"
+spec = importlib.util.spec_from_file_location("azure_document_loader", module_path)
+azure_document_loader = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(azure_document_loader)
+AzureDocumentLoader = azure_document_loader.AzureDocumentLoader
+
+
+class _Blob:
+    def __init__(self, name):
+        self.name = name
+
+
+class _BlobDownload:
+    def __init__(self, content):
+        self._content = content
+
+    def readall(self):
+        return self._content
+
+
+class _BlobClient:
+    def __init__(self, content):
+        self._content = content
+
+    def download_blob(self):
+        return _BlobDownload(self._content)
+
+
+class _Container:
+    def __init__(self, blobs):
+        self._blobs = blobs
+
+    def list_blobs(self):
+        return [_Blob(name) for name in self._blobs]
+
+    def get_blob_client(self, name):
+        return _BlobClient(self._blobs[name])
+
+
+class TestAzureDocumentLoader(unittest.IsolatedAsyncioTestCase):
+    async def test_load_creates_parent_directories_for_virtual_blob_paths(self):
+        loader = AzureDocumentLoader.__new__(AzureDocumentLoader)
+        loader.container = _Container({"reports/2026/summary.txt": b"hello"})
+
+        file_paths = await loader.load()
+
+        self.assertEqual(len(file_paths), 1)
+        downloaded_file = Path(file_paths[0])
+        self.assertEqual(downloaded_file.name, "summary.txt")
+        self.assertEqual(downloaded_file.read_bytes(), b"hello")
+        self.assertIn("reports", downloaded_file.parts)
+        self.assertIn("2026", downloaded_file.parts)
+
+    async def test_load_rejects_blob_names_that_escape_temp_dir(self):
+        loader = AzureDocumentLoader.__new__(AzureDocumentLoader)
+        loader.container = _Container({"../escape.txt": b"nope"})
+
+        with self.assertRaises(ValueError):
+            await loader.load()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create parent directories when Azure blob names contain virtual folder paths
- reject unsafe blob names that could escape the temporary download directory
- add unit coverage for nested blob paths and path traversal rejection

## Test
- python -m pytest tests/test_azure_document_loader.py -q
- python -m compileall gpt_researcher/document/azure_document_loader.py tests/test_azure_document_loader.py