### PR TITLE
Add SSRF and local-file-read protection for scraped URLs

### DIFF
--- a/gpt_researcher/document/online_document.py
+++ b/gpt_researcher/document/online_document.py
@@ -1,6 +1,8 @@
 import os
 import aiohttp
 import tempfile
+
+from gpt_researcher.utils.url_security import UnsafeURLError, validate_url
 from langchain_community.document_loaders import (
     PyMuPDFLoader,
     TextLoader,
@@ -35,6 +37,13 @@ class OnlineDocumentLoader:
 
     async def _download_and_process(self, url: str) -> list:
         try:
+            # Reject SSRF / local-file targets before issuing the request.
+            try:
+                validate_url(url)
+            except UnsafeURLError as e:
+                print(f"Skipping unsafe document URL {url}: {e}")
+                return []
+
             headers = {
                 "User-Agent": "Mozilla/5.0"
             }

--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -14,6 +14,7 @@ import requests
 from colorama import Fore, init
 
 from gpt_researcher.utils.workers import WorkerPool
+from gpt_researcher.utils.url_security import UnsafeURLError, validate_url
 
 from . import (
     ArxivScraper,
@@ -111,6 +112,19 @@ class Scraper:
         """
         async with self.worker_pool.throttle():
             try:
+                # Reject SSRF / local-file targets (internal hosts, cloud metadata
+                # endpoints, file:// paths, etc.) before any request is made.
+                try:
+                    validate_url(link)
+                except UnsafeURLError as e:
+                    self.logger.warning(f"Skipping unsafe URL {link}: {e}")
+                    return {
+                        "url": link,
+                        "raw_content": None,
+                        "image_urls": [],
+                        "title": "",
+                    }
+
                 Scraper = self.get_scraper(link)
                 scraper = Scraper(link, session)
 

--- a/gpt_researcher/utils/url_security.py
+++ b/gpt_researcher/utils/url_security.py
@@ -1,0 +1,125 @@
+"""URL security utilities for GPT Researcher.
+
+These helpers protect the scraping and document-loading pipelines against
+Server-Side Request Forgery (SSRF) and arbitrary local-file reads when the URLs
+originate from untrusted input (e.g. the ``source_urls`` / ``document_urls``
+parameters accepted by the API and WebSocket endpoints).
+
+By default only ``http`` / ``https`` URLs whose host resolves to a public IP
+address are allowed. This blocks:
+
+* Non-HTTP schemes such as ``file://``, ``ftp://`` and ``gopher://``.
+* Local filesystem paths (no scheme/host), which some document loaders would
+  otherwise read directly from disk (arbitrary local file read).
+* Requests to private, loopback, link-local, reserved or otherwise internal
+  addresses (e.g. ``127.0.0.1``, ``10.0.0.0/8`` and the ``169.254.169.254``
+  cloud metadata endpoint).
+
+Operators who intentionally scrape internal or self-hosted resources can opt out
+of the private-address check by setting the environment variable
+``ALLOW_PRIVATE_URLS=true`` (or by passing ``allow_private=True``).
+
+Note: resolving the host here and letting the HTTP client re-resolve it later
+leaves a small TOCTOU/DNS-rebinding window. Closing it fully requires pinning the
+validated IP into the connection; this guard is intended as defence-in-depth that
+removes the trivial, unauthenticated SSRF and local-file-read primitives.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+ALLOWED_SCHEMES = ("http", "https")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL is rejected by the SSRF / local-file protections."""
+
+
+def _private_urls_allowed() -> bool:
+    return os.getenv("ALLOW_PRIVATE_URLS", "").strip().lower() in _TRUTHY
+
+
+def _is_disallowed_ip(ip) -> bool:
+    """Return True if the address is not safe to contact (i.e. internal)."""
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def validate_url(url: str, *, allow_private: bool | None = None) -> str:
+    """Validate that ``url`` is safe to fetch and return it unchanged.
+
+    Args:
+        url: The URL to validate.
+        allow_private: When ``True``, skip the private/internal address check.
+            When ``None`` (default), fall back to the ``ALLOW_PRIVATE_URLS``
+            environment variable.
+
+    Returns:
+        The original ``url`` if it passes all checks.
+
+    Raises:
+        UnsafeURLError: If the URL uses a disallowed scheme, lacks a host, or
+            resolves to a non-public address.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UnsafeURLError("URL must be a non-empty string.")
+
+    parsed = urlparse(url.strip())
+
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise UnsafeURLError(
+            f"URL scheme {scheme or '(none)'!r} is not allowed; "
+            "only http and https URLs may be fetched."
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise UnsafeURLError("URL must include a valid host.")
+
+    if allow_private is None:
+        allow_private = _private_urls_allowed()
+    if allow_private:
+        return url
+
+    try:
+        addrinfo = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise UnsafeURLError(f"Could not resolve host {host!r}: {exc}") from exc
+
+    for info in addrinfo:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError as exc:
+            raise UnsafeURLError(
+                f"Host {host!r} resolved to an invalid address {ip_str!r}."
+            ) from exc
+        if _is_disallowed_ip(ip):
+            raise UnsafeURLError(
+                f"URL host {host!r} resolves to a non-public address ({ip_str}); "
+                "set ALLOW_PRIVATE_URLS=true to allow internal targets."
+            )
+
+    return url
+
+
+def is_safe_url(url: str, *, allow_private: bool | None = None) -> bool:
+    """Return ``True`` if ``url`` passes :func:`validate_url`, else ``False``."""
+    try:
+        validate_url(url, allow_private=allow_private)
+        return True
+    except UnsafeURLError:
+        return False

--- a/tests/test_url_security.py
+++ b/tests/test_url_security.py
@@ -1,0 +1,92 @@
+"""Tests for the SSRF / local-file-read URL protections.
+
+These cover the guard used by the scraping and document-loading pipelines to
+reject untrusted ``source_urls`` / ``document_urls`` that target internal
+services or the local filesystem (see GitHub issues #1794 and #1805).
+
+IP literals are used wherever possible so the checks run without DNS/network.
+"""
+
+import socket
+
+import pytest
+
+from gpt_researcher.utils.url_security import (
+    UnsafeURLError,
+    is_safe_url,
+    validate_url,
+)
+
+
+# --- Disallowed schemes / local-file paths (issue #1805) --------------------
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "file://C:/Windows/win.ini",
+        "ftp://example.com/resource",
+        "gopher://example.com:70/",
+        "/etc/passwd",  # bare local path, no scheme/host
+        "C:\\secret\\data.pdf",
+        "",
+        "   ",
+    ],
+)
+def test_rejects_non_http_and_local_paths(url):
+    with pytest.raises(UnsafeURLError):
+        validate_url(url)
+    assert is_safe_url(url) is False
+
+
+# --- SSRF: internal / reserved addresses (issue #1794) ----------------------
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",                                   # loopback
+        "http://localhost.localdomain/",                        # resolves to loopback
+        "http://169.254.169.254/latest/meta-data/",             # cloud metadata
+        "http://10.0.0.5/internal",                             # private /8
+        "http://192.168.1.1/admin",                             # private /16
+        "http://172.16.0.10/",                                  # private /12
+        "http://0.0.0.0/",                                      # unspecified
+        "http://[::1]/",                                         # IPv6 loopback
+        "http://[fd00::1]/",                                     # IPv6 unique-local
+    ],
+)
+def test_rejects_internal_addresses(url):
+    with pytest.raises(UnsafeURLError):
+        validate_url(url)
+
+
+def test_allows_public_ip():
+    # 8.8.8.8 is a public address; an IP literal avoids any DNS dependency.
+    assert validate_url("http://8.8.8.8/") == "http://8.8.8.8/"
+    assert is_safe_url("https://1.1.1.1/path?q=1") is True
+
+
+# --- DNS rebinding: a public-looking host that resolves internally ----------
+
+def test_blocks_host_resolving_to_private_ip(monkeypatch):
+    def fake_getaddrinfo(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.1.2.3", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(UnsafeURLError):
+        validate_url("http://totally-public-looking.example/")
+
+
+# --- Opt-in escape hatch for trusted / self-hosted deployments --------------
+
+def test_allow_private_argument_bypasses_check():
+    assert validate_url("http://127.0.0.1:8000/", allow_private=True) == (
+        "http://127.0.0.1:8000/"
+    )
+
+
+def test_allow_private_env_var_bypasses_check(monkeypatch):
+    monkeypatch.setenv("ALLOW_PRIVATE_URLS", "true")
+    assert is_safe_url("http://192.168.0.10/") is True
+    monkeypatch.setenv("ALLOW_PRIVATE_URLS", "false")
+    assert is_safe_url("http://192.168.0.10/") is False


### PR DESCRIPTION
## Summary

User-supplied `source_urls` and `document_urls` (accepted by the API and WebSocket endpoints) were fetched without any validation. This allowed two unauthenticated attacks:

- **SSRF (#1794):** an attacker could point the researcher at internal services, private-network hosts, or the cloud metadata endpoint (`http://169.254.169.254/...`) and have the response embedded in the generated report.
- **Arbitrary local file read (#1805):** a non-URL path (or `file://` URL) reaching `PyMuPDFLoader`/`PyMuPDFScraper`'s local-file branch caused the server to read files off its own disk.

Both stem from the same root cause: untrusted URLs flowing into the scraping / document-loading pipelines unchecked.

## Changes

- Add `gpt_researcher/utils/url_security.py` with `validate_url()` / `is_safe_url()`:
  - allow only `http` / `https` schemes (blocks `file://`, `ftp://`, `gopher://`, …);
  - require a host (blocks bare local filesystem paths);
  - resolve the host and reject **non-public** addresses — private, loopback, link-local, reserved, multicast and unspecified — which also covers the `169.254.169.254` metadata endpoint.
- Enforce it at the two chokepoints every untrusted URL passes through:
  - `Scraper.extract_data_from_url` (covers `source_urls` → all scraper backends, incl. the PyMuPDF local-file branch);
  - `OnlineDocumentLoader._download_and_process` (covers `document_urls`).
- Unsafe URLs are skipped with a warning rather than crashing the run.

## Opt-out for trusted / self-hosted deployments

Operators who intentionally scrape internal resources can set `ALLOW_PRIVATE_URLS=true` (or pass `allow_private=True`) to disable the private-address check. Scheme/host validation still applies.

## Tests

Adds `tests/test_url_security.py` (21 cases): disallowed schemes and local paths, internal/loopback/link-local/metadata IPv4 + IPv6 targets, allowed public IPs, a DNS-rebinding case (public-looking host resolving to a private IP), and the env-var / argument opt-out.

## Note on scope

Validation resolves the host and then lets the HTTP client re-resolve it, leaving a small TOCTOU / DNS-rebinding window. Fully closing it requires pinning the validated IP into the connection. This PR is intended as defence-in-depth that removes the trivial, unauthenticated SSRF and local-file-read primitives; pinning can be a follow-up.

Fixes #1794
Fixes #1805
