### PR TITLE
fix(costs): fall back to default encoding for non-OpenAI embedding models

### DIFF
--- a/gpt_researcher/utils/costs.py
+++ b/gpt_researcher/utils/costs.py
@@ -191,7 +191,14 @@ def estimate_embedding_cost(model: str, docs: list) -> float:
     Returns:
         The estimated embedding cost in USD.
     """
-    encoding = tiktoken.encoding_for_model(model)
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        # tiktoken only knows OpenAI model names. Non-OpenAI embedding
+        # providers (Ollama, Cohere, Nomic, HuggingFace, ...) raise KeyError
+        # here, which would otherwise abort cost tracking mid-research. Fall
+        # back to the default OpenAI encoding for a best-effort token estimate.
+        encoding = tiktoken.get_encoding(ENCODING_MODEL)
     total_tokens = sum(len(encoding.encode(str(doc))) for doc in docs)
     return total_tokens * EMBEDDING_COST
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,6 +1,11 @@
 import unittest
 
-from gpt_researcher.utils.costs import calculate_llm_cost, estimate_llm_cost
+from gpt_researcher.utils.costs import (
+    EMBEDDING_COST,
+    calculate_llm_cost,
+    estimate_embedding_cost,
+    estimate_llm_cost,
+)
 
 
 class TestCosts(unittest.TestCase):
@@ -66,6 +71,31 @@ class TestCosts(unittest.TestCase):
         )
 
         self.assertEqual(fallback_cost, estimate_llm_cost("hello", "world"))
+
+
+class TestEmbeddingCost(unittest.TestCase):
+    def test_estimate_embedding_cost_openai_model(self):
+        cost = estimate_embedding_cost(
+            model="text-embedding-3-small",
+            docs=["hello world", "another document"],
+        )
+        self.assertGreater(cost, 0.0)
+
+    def test_estimate_embedding_cost_non_openai_model_does_not_raise(self):
+        # Non-OpenAI embedding models (Ollama, Cohere, Nomic, HuggingFace, ...)
+        # are not known to tiktoken and used to raise KeyError, aborting cost
+        # tracking mid-research. The estimator must degrade gracefully instead.
+        cost = estimate_embedding_cost(
+            model="nomic-embed-text",
+            docs=["hello world", "another document"],
+        )
+        self.assertGreater(cost, 0.0)
+
+    def test_estimate_embedding_cost_empty_docs(self):
+        self.assertEqual(
+            estimate_embedding_cost(model="nomic-embed-text", docs=[]),
+            0.0,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `estimate_embedding_cost` crashed with `KeyError` whenever a non-OpenAI embedding model was configured.
- Cost tracking now degrades gracefully to a best-effort token estimate instead of aborting research.

## Root Cause

**Symptom** — Users on non-OpenAI embedding providers (Ollama, Cohere, Nomic, HuggingFace, etc.) hit an uncaught `KeyError` during the context-compression cost callback, which surfaces as a hard failure in the middle of a research run.

**Root cause** — `estimate_embedding_cost()` in `gpt_researcher/utils/costs.py` called `tiktoken.encoding_for_model(model)`. `tiktoken` only maps **OpenAI** model names to tokenisers; any other name raises `KeyError: "Could not automatically map <model> to a tokeniser..."`. While the two current call sites in `context/compression.py` pass `OPENAI_EMBEDDING_MODEL`, the function is public, model-name-driven, and offers no safety net for the documented non-OpenAI providers the project supports.

**Evidence** — Reproduced directly against the pinned `tiktoken`:

```
OK   text-embedding-3-small
FAIL nomic-embed-text     KeyError 'Could not automatically map nomic-embed-text to a tokeniser'
FAIL embed-english-v3.0   KeyError 'Could not automatically map embed-english-v3.0 to a tokeniser'
FAIL mxbai-embed-large    KeyError 'Could not automatically map mxbai-embed-large to a tokeniser'
```

**Fix + why this level** — Wrap the lookup in `try/except KeyError` and fall back to the module's existing default encoding (`ENCODING_MODEL = "o200k_base"`), the same encoding `estimate_llm_cost` already uses. Fixing it inside the estimator (vs. at each call site) protects every present and future caller and keeps the public contract total.

**Scope / risk** — One function, plus tests. OpenAI model names take the exact same path as before (no behavior change). Non-OpenAI models now get a best-effort estimate rather than an exception. Token counts for non-OpenAI tokenisers are approximate by nature — this is a *cost estimate*, and a slightly-off estimate is strictly better than aborting the run.

## Verification

```
python -m pytest tests/test_costs.py -q
======================== 7 passed, 2 warnings ========================
```

New regression test `TestEmbeddingCost::test_estimate_embedding_cost_non_openai_model_does_not_raise` **fails without the fix**:

```
FAILED tests/test_costs.py::TestEmbeddingCost::test_estimate_embedding_cost_non_openai_model_does_not_raise
  KeyError: 'Could not automatically map nomic-embed-text to a tokeniser...'
```

and passes with it. Added tests also cover the OpenAI happy path and empty-docs (`0.0`) case.

## What was NOT changed

- Pricing constants and the OpenAI path are untouched.
- The call sites in `context/compression.py` still pass `OPENAI_EMBEDDING_MODEL`; this only hardens the estimator itself.
