### PR TITLE
fix(scraper): return empty string from extract_title for empty title tags

### DIFF
--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -67,8 +67,17 @@ def parse_dimension(value: str) -> int:
         return None
 
 def extract_title(soup: BeautifulSoup) -> str:
-    """Extract the title from the BeautifulSoup object"""
-    return soup.title.string if soup.title else ""
+    """Extract the title text from the BeautifulSoup object.
+
+    Always returns a string. An empty ``<title></title>`` yields ``""`` (not
+    ``None``), and a title containing nested markup (e.g.
+    ``<title><span>x</span></title>``) yields its text content rather than the
+    raw inner HTML.
+    """
+    title_tag = soup.title
+    if not title_tag:
+        return ""
+    return title_tag.get_text(strip=True)
 
 def get_image_hash(image_url: str) -> str:
     """Calculate a simple hash based on the image filename and essential query parameters"""

--- a/tests/test_scraper_extract_title.py
+++ b/tests/test_scraper_extract_title.py
@@ -1,0 +1,41 @@
+"""Tests for scraper title extraction.
+
+`extract_title` is annotated `-> str` and its result flows into image alt-text
+and document metadata across every scraper backend. A `<title></title>` with no
+text node made `soup.title.string` return `None`, breaking the string contract
+and propagating `None` downstream.
+"""
+
+import unittest
+
+from bs4 import BeautifulSoup
+
+from gpt_researcher.scraper.utils import extract_title
+
+
+def _title(html: str) -> str:
+    return extract_title(BeautifulSoup(html, "html.parser"))
+
+
+class TestExtractTitle(unittest.TestCase):
+    def test_simple_title(self):
+        self.assertEqual(_title("<title>Hello</title>"), "Hello")
+
+    def test_empty_title_returns_empty_string_not_none(self):
+        result = _title("<title></title>")
+        self.assertIsNotNone(result)
+        self.assertEqual(result, "")
+
+    def test_no_title_tag(self):
+        self.assertEqual(_title("<html><body>x</body></html>"), "")
+
+    def test_title_is_whitespace_stripped(self):
+        self.assertEqual(_title("<title>   spaced   </title>"), "spaced")
+
+    def test_always_returns_str(self):
+        for html in ("<title>Hello</title>", "<title></title>", "<html></html>"):
+            self.assertIsInstance(_title(html), str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `extract_title` could return `None` for an empty `<title></title>`, violating its `-> str` contract.
- It now always returns a (whitespace-stripped) string.

## Root Cause

**Symptom** — Scraped pages whose HTML contains an empty title element (`<title></title>`) produce a `None` title, which then propagates into image alt-text and document metadata in every scraper backend (BeautifulSoup, web_base_loader, browser, nodriver, tavily_extract), where a string is expected.

**Root cause** — `extract_title()` in `gpt_researcher/scraper/utils.py` was:

```python
return soup.title.string if soup.title else ""
```

`Tag.string` is `None` when the element has no single text child. So `<title></title>` (present but empty) takes the truthy `soup.title` branch and returns `soup.title.string` → `None`, despite the `-> str` annotation.

**Evidence** — Reproduced directly against the pinned `bs4`:

```
'<title>Hello</title>'  -> 'Hello'
'<title></title>'       -> None     # <-- contract violation
'<html></html>'         -> ''
```

All five call sites (`beautiful_soup.py:36`, `web_base_loader.py:37`, `browser.py:222`, `nodriver_scraper.py:226`, `tavily_extract.py:56`) assign this directly to `title` and pass it downstream.

**Fix + why this level** — Use `soup.title.get_text(strip=True)`, which returns `""` for an empty element and never `None`, and also trims surrounding whitespace. Fixing it in the shared utility repairs all five backends at once and keeps the documented return type honest, rather than adding `or ""` guards at each call site.

**Scope / risk** — One function plus a test module. Non-empty titles are unchanged except for whitespace stripping (desirable for titles used as alt-text/metadata).

## Verification

```
python -m pytest tests/test_scraper_extract_title.py -q
5 passed
```

New `test_empty_title_returns_empty_string_not_none` **fails without the fix** (`None != ""`) and passes with it. Added cases cover the simple title, missing title tag, whitespace stripping, and an always-`str` assertion.

## What was NOT changed

- The nested-markup case (`<title><span>x</span></title>`) depends on the parser and is out of scope; this PR only guarantees a non-`None`, stripped string.
