### PR TITLE
fix(scraper): debug-log instead of printing on non-numeric image dimensions

### DIFF
--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -63,7 +63,9 @@ def parse_dimension(value: str) -> int:
         # Convert to float first to handle decimal values like '409.12'
         return int(float(value))
     except (ValueError, TypeError) as e:
-        print(f"Error parsing dimension value {value}: {e}")
+        # Non-numeric dimensions (e.g. '100%', 'auto', '50em') are common and
+        # expected on real pages; log at debug level instead of spamming stdout.
+        logging.debug("Could not parse dimension value %r: %s", value, e)
         return None
 
 def extract_title(soup: BeautifulSoup) -> str:

--- a/tests/test_parse_dimension.py
+++ b/tests/test_parse_dimension.py
@@ -1,0 +1,48 @@
+"""Tests for image dimension parsing.
+
+`parse_dimension` is called for every `<img>` width/height attribute during
+scraping. Non-numeric values like '100%', 'auto', and '50em' are common and
+valid HTML, but used to print an error line to stdout for each one, polluting
+application output. It should parse numeric/px values and silently (debug-log)
+return None for the rest.
+"""
+
+import logging
+import unittest
+
+from gpt_researcher.scraper.utils import parse_dimension
+
+
+class TestParseDimension(unittest.TestCase):
+    def test_plain_integer(self):
+        self.assertEqual(parse_dimension("100"), 100)
+
+    def test_px_suffix(self):
+        self.assertEqual(parse_dimension("10px"), 10)
+
+    def test_decimal_value(self):
+        self.assertEqual(parse_dimension("409.12"), 409)
+
+    def test_non_numeric_returns_none(self):
+        for value in ("100%", "auto", "", "50em"):
+            self.assertIsNone(parse_dimension(value))
+
+    def test_non_numeric_does_not_write_to_stdout(self):
+        # Regression: these used to print(...) one line per malformed value.
+        import contextlib
+        import io
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            for value in ("100%", "auto", "50em"):
+                parse_dimension(value)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_non_numeric_logs_at_debug(self):
+        with self.assertLogs(level=logging.DEBUG) as captured:
+            parse_dimension("100%")
+        self.assertTrue(any("100%" in m for m in captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `parse_dimension` printed an error line to stdout for every non-numeric image dimension.
- Common, valid HTML values (`100%`, `auto`, `50em`) spammed application output during normal scraping. Now logged at debug level.

## Root Cause

**Symptom** — Running any research that scrapes real web pages floods stdout with lines like:

```
Error parsing dimension value 100%: could not convert string to float: '100%'
Error parsing dimension value auto: could not convert string to float: 'auto'
Error parsing dimension value 50em: could not convert string to float: '50em'
```

**Root cause** — `parse_dimension()` in `gpt_researcher/scraper/utils.py` is called for every `<img>` `width`/`height` attribute in `get_relevant_images`. On a parse failure it did `print(f"Error parsing dimension value {value}: {e}")`. But non-pixel dimensions are normal, valid HTML — percentages, `auto`, em units — so the "error" fires constantly on healthy pages and is treated as a `print`, not a log.

**Evidence** — Reproduced against the current code:

```
'100%'   -> None   (+ printed an error line)
'auto'   -> None   (+ printed an error line)
'50em'   -> None   (+ printed an error line)
'10px'   -> 10
'409.12' -> 409
'100'    -> 100
```

**Fix + why this level** — Replace the `print` with `logging.debug(...)` (the module already imports `logging`). These aren't errors; they're expected non-pixel units, so debug is the correct severity and keeps the message available when troubleshooting. Fixing the single helper covers every scraper backend that extracts images.

**Scope / risk** — One line changed plus a test. Return values are identical (numeric/px → int, everything else → None). Only the stdout noise is removed.

## Verification

```
python -m pytest tests/test_parse_dimension.py -q
6 passed
```

New `test_non_numeric_does_not_write_to_stdout` **fails without the fix** (captured stdout was non-empty) and passes with it. Added cases cover int/px/decimal parsing, `None` for non-numeric, and that a debug record is emitted.

## What was NOT changed

- Parsing behavior / return values are unchanged; this is purely a logging-severity fix.
