### PR TITLE
fix(llm): log the real exception in construct_subtopics error handler

### DIFF
--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -208,6 +208,7 @@ async def construct_subtopics(
         return output
 
     except Exception as e:
-        print("Exception in parsing subtopics : ", e)
-        logging.getLogger(__name__).error("Exception in parsing subtopics : \n {e}")
+        logging.getLogger(__name__).error(
+            "Exception in parsing subtopics: %s", e, exc_info=True
+        )
         return subtopics

--- a/tests/test_construct_subtopics_error_log.py
+++ b/tests/test_construct_subtopics_error_log.py
@@ -1,0 +1,50 @@
+"""Tests for construct_subtopics error handling.
+
+On failure, construct_subtopics returns the original `subtopics` fallback and
+logs the error. The log call previously used a non-f-string
+("...\\n {e}"), so it recorded the literal text "{e}" instead of the actual
+exception, and also printed to stdout. This test pins that the real exception
+text is logged.
+"""
+
+import logging
+import unittest
+
+import pytest
+
+from gpt_researcher.utils.llm import construct_subtopics
+
+
+class _BrokenConfig:
+    """A config stand-in that raises when its attributes are accessed.
+
+    construct_subtopics touches config.smart_llm_model early; raising there
+    drives execution into the except branch deterministically.
+    """
+
+    def __getattr__(self, name):
+        raise RuntimeError("boom-sentinel-12345")
+
+
+@pytest.mark.asyncio
+async def test_construct_subtopics_logs_real_exception(caplog):
+    fallback = ["existing-subtopic"]
+    with caplog.at_level(logging.ERROR):
+        result = await construct_subtopics(
+            task="t",
+            data="d",
+            config=_BrokenConfig(),
+            subtopics=fallback,
+        )
+
+    # Returns the fallback list rather than crashing.
+    assert result == fallback
+
+    # The ACTUAL exception text is logged, not the literal "{e}".
+    joined = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "boom-sentinel-12345" in joined
+    assert "{e}" not in joined
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- The `construct_subtopics` error handler logged the literal text `{e}` instead of the actual exception, hiding the real cause of subtopic-parsing failures.
- It now logs the real exception (with traceback) and drops a redundant `print`.

## Root Cause

**Symptom** — When subtopic generation fails, the function correctly falls back to the existing `subtopics` list, but the operator-facing log line reads:

```
Exception in parsing subtopics :
 {e}
```

i.e. the literal `{e}`, never the real error — so failures are effectively undiagnosable from logs.

**Root cause** — In `gpt_researcher/utils/llm.py`, the `except` branch of `construct_subtopics` was:

```python
except Exception as e:
    print("Exception in parsing subtopics : ", e)
    logging.getLogger(__name__).error("Exception in parsing subtopics : \n {e}")
    return subtopics
```

The `logging.error(...)` string has **no `f` prefix**, so `{e}` is logged verbatim instead of being interpolated. (The `print` did show `e`, but writing to stdout is not a substitute for a usable log record, and duplicates the output.)

**Evidence** — A regression test drives the function into the `except` branch with a config whose attribute access raises `RuntimeError("boom-sentinel-12345")`; on current code the captured ERROR log contains `{e}` and not `boom-sentinel-12345`.

**Fix + why this level** — Replace with lazy `%`-style logging and attach the traceback:

```python
logging.getLogger(__name__).error("Exception in parsing subtopics: %s", e, exc_info=True)
```

This is the standard logging idiom (deferred formatting, `exc_info` for the stack), fixes the actual defect at its source, and removes the redundant `print`.

**Scope / risk** — One `except` block plus a test. The fallback return value (`subtopics`) is unchanged; only the diagnostic output is corrected.

## Verification

```
python -m pytest tests/test_construct_subtopics_error_log.py -q
1 passed
```

The new test **fails without the fix** (logged message lacks the real exception text and contains `{e}`) and passes with it. Existing `tests/test_costs.py` still green.

## What was NOT changed

- The success path and the fallback return are untouched; this only fixes the error log.
