### PR TITLE
fix(retriever): strip whitespace in header-supplied retriever lists

### DIFF
--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -130,14 +130,17 @@ def get_retrievers(headers: dict[str, str], cfg):
             retrievers = cfg.retrievers.split(",")
         else:
             retrievers = cfg.retrievers
-        # Strip whitespace from each retriever name
-        retrievers = [r.strip() for r in retrievers]
     # If not found, check config for a single retriever
     elif cfg.retriever:
         retrievers = [cfg.retriever]
     # If still not set, use default retriever
     else:
         retrievers = [get_default_retriever().__name__]
+
+    # Strip whitespace from each retriever name so comma-separated lists with
+    # spaces (e.g. "tavily, exa" from a header or config) resolve correctly
+    # instead of silently falling back to the default retriever.
+    retrievers = [r.strip() for r in retrievers if r and r.strip()]
 
     # Convert retriever names to actual retriever classes
     # Use get_default_retriever() as a fallback for any invalid retriever names

--- a/tests/test_get_retrievers_whitespace.py
+++ b/tests/test_get_retrievers_whitespace.py
@@ -1,0 +1,61 @@
+"""Regression tests for whitespace handling in get_retrievers.
+
+Comma-separated retriever lists supplied via request headers
+(e.g. ``"tavily, exa"``) previously kept the surrounding whitespace,
+so every name after the first failed the exact ``match`` in
+``get_retriever`` and silently fell back to the default retriever.
+The config path already stripped whitespace; these tests pin the same
+behavior for the header path (and for a single-retriever value).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from gpt_researcher.actions.retriever import (
+    get_retrievers,
+    get_retriever,
+    get_default_retriever,
+)
+
+
+def _cfg(retrievers=None, retriever=None):
+    return SimpleNamespace(retrievers=retrievers, retriever=retriever)
+
+
+class GetRetrieversWhitespaceTests(unittest.TestCase):
+    def test_header_comma_list_with_spaces_resolves_each_retriever(self):
+        # "tavily, exa" -> the second name has a leading space.
+        headers = {"retrievers": "tavily, exa"}
+        result = get_retrievers(headers, _cfg())
+
+        expected = [get_retriever("tavily"), get_retriever("exa")]
+        self.assertEqual(result, expected)
+
+        # The buggy behavior silently substituted the default retriever for
+        # the un-stripped " exa"; assert that did NOT happen.
+        default = get_default_retriever()
+        self.assertEqual(result[1], get_retriever("exa"))
+        self.assertNotEqual(
+            result[1].__name__ if result[1] else None,
+            None,
+        )
+        # exa is not the default, so a correct parse must differ from default
+        self.assertNotEqual(get_retriever("exa"), default)
+
+    def test_single_header_retriever_with_spaces_is_stripped(self):
+        headers = {"retriever": "  tavily  "}
+        result = get_retrievers(headers, _cfg())
+        self.assertEqual(result, [get_retriever("tavily")])
+
+    def test_blank_entries_are_dropped(self):
+        headers = {"retrievers": "tavily, , exa,"}
+        result = get_retrievers(headers, _cfg())
+        self.assertEqual(result, [get_retriever("tavily"), get_retriever("exa")])
+
+    def test_config_string_path_still_strips(self):
+        result = get_retrievers({}, _cfg(retrievers="tavily, exa"))
+        self.assertEqual(result, [get_retriever("tavily"), get_retriever("exa")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `get_retrievers()` split a comma-separated retriever list from request headers on `,` but never stripped surrounding whitespace.
- Result: a perfectly normal header value like `"tavily, exa"` silently dropped every retriever after the first and fell back to the default (Tavily), so users thought they were querying multiple engines but weren't.

## Root Cause

**Symptom** — Supplying multiple retrievers via the `retrievers` header (e.g. `"tavily, exa"`) only ever uses the first one; the rest are silently replaced by the default retriever. No error, no log.

**Root cause** — In `gpt_researcher/actions/retriever.py::get_retrievers`, the header branch does `headers.get("retrievers").split(",")` and stops there. The names after the first keep a leading space (`" exa"`). `get_retriever(" exa")` does an exact `match` on the name, returns `None`, and the caller's `get_retriever(r) or get_default_retriever()` fallback substitutes Tavily. The **config** branch already had `retrievers = [r.strip() for r in retrievers]`, but that stripping lived inside the `elif cfg.retrievers` block, so it never applied to the header path or the single-retriever paths.

**Evidence** — Captured on this branch's code (before the fix), `" exa"` resolves to nothing and falls back:
```
get_retriever(" exa") => None
get_retriever("exa")  => ExaSearch
default               => TavilySearch
```
So `["tavily", " exa"]` becomes `[TavilySearch, TavilySearch]`.

**Fix + why this level** — Move the whitespace normalization out of the config-only branch and apply it to the final `retrievers` list for every source (headers, config-string, config-list, single values), also dropping empty entries from trailing/double commas. Fixing here (the single point where the name list is finalized) covers all input paths rather than patching one branch. This surfaces correct behavior — valid names now resolve — rather than masking bad input.

**Scope / risk** — Touches only `get_retrievers`. `.strip()` on already-clean names is a no-op, so the config-list and single-value paths are unchanged for well-formed input; the only behavioral change is that previously-broken whitespace lists now resolve correctly. Unknown names still fall back to the default exactly as before.

## Verification

- `python -m pytest tests/test_get_retrievers_whitespace.py -q` — 4 passed.

## Real behavior proof

- **Behavior addressed:** header value `"tavily, exa"` resolving to `[TavilySearch, TavilySearch]` instead of `[TavilySearch, ExaSearch]`.
- **Real environment:** Python 3.14 venv, repo at current `upstream/main` (409b8b60).
- **Regression test:** `tests/test_get_retrievers_whitespace.py` — asserts the new (correct) resolution and FAILS without the fix:
  ```
  WITHOUT fix:
  FAILED ::test_blank_entries_are_dropped
  FAILED ::test_header_comma_list_with_spaces_resolves_each_retriever
  2 failed, 2 passed

  WITH fix:
  4 passed
  ```
- **What was NOT tested:** end-to-end research run (requires live API keys / network); the fix is isolated to retriever-name resolution.
