### PR TITLE
fix(scraper): detect PDF links with query strings and uppercase extensions

### DIFF
--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -9,6 +9,7 @@ import importlib
 import logging
 import subprocess
 import sys
+from urllib.parse import urlparse
 
 import requests
 from colorama import Fore, init
@@ -198,7 +199,11 @@ class Scraper:
 
         scraper_key = None
 
-        if link.endswith(".pdf"):
+        # Inspect only the path component so query strings / fragments don't
+        # hide the extension (e.g. signed CDN/S3 links like "…/doc.pdf?sig=…").
+        # Match case-insensitively because ".PDF" is a perfectly valid suffix.
+        path = urlparse(link).path
+        if path.lower().endswith(".pdf"):
             scraper_key = "pdf"
         elif "arxiv.org" in link:
             scraper_key = "arxiv"

--- a/tests/test_scraper_get_scraper.py
+++ b/tests/test_scraper_get_scraper.py
@@ -1,0 +1,58 @@
+"""Regression tests for PDF detection in Scraper.get_scraper.
+
+PDF links were detected with ``link.endswith(".pdf")``, which:
+  * missed query strings / fragments (signed CDN/S3 links such as
+    ``https://host/doc.pdf?sig=...`` are extremely common), and
+  * was case-sensitive, so ``.PDF`` was not recognized.
+
+In both cases a real PDF was routed to the configured HTML scraper
+(e.g. BeautifulSoup) instead of PyMuPDFScraper, producing garbage or
+empty content. These tests pin correct routing.
+"""
+
+import unittest
+
+from gpt_researcher.scraper.scraper import Scraper
+from gpt_researcher.scraper import PyMuPDFScraper, BeautifulSoupScraper
+
+
+def _scraper():
+    # worker_pool is unused by get_scraper; default scraper is "bs".
+    return Scraper(urls=["https://example.com"], user_agent="ua", scraper="bs", worker_pool=None)
+
+
+class GetScraperPdfDetectionTests(unittest.TestCase):
+    def test_plain_pdf_url_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/doc.pdf"), PyMuPDFScraper)
+
+    def test_pdf_with_query_string_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(
+            s.get_scraper("https://example.com/doc.pdf?sig=abc123&exp=999"),
+            PyMuPDFScraper,
+        )
+
+    def test_pdf_with_fragment_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/doc.pdf#page=2"), PyMuPDFScraper)
+
+    def test_uppercase_pdf_extension_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/REPORT.PDF"), PyMuPDFScraper)
+
+    def test_non_pdf_url_uses_default_scraper(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/article"), BeautifulSoupScraper)
+
+    def test_pdf_substring_in_query_is_not_treated_as_pdf(self):
+        # "pdf" only in the query, not the path extension -> NOT a pdf.
+        s = _scraper()
+        self.assertIs(
+            s.get_scraper("https://example.com/article?format=pdf"),
+            BeautifulSoupScraper,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `Scraper.get_scraper()` decided whether a URL is a PDF with `link.endswith(".pdf")`.
- That misses two very common real-world cases: PDF links with a query string/fragment (signed CDN/S3 URLs like `…/report.pdf?sig=…`) and uppercase `.PDF`. Those PDFs were silently routed to the configured **HTML** scraper (BeautifulSoup) instead of `PyMuPDFScraper`, producing empty/garbage content.

## Root Cause

**Symptom** — PDFs served from signed/object-storage URLs (which append `?token=…`/`?sig=…`) or with an uppercase `.PDF` extension scrape as empty or garbage; the user never learns the right scraper wasn't used.

**Root cause** — In `gpt_researcher/scraper/scraper.py::get_scraper`, the check is `if link.endswith(".pdf")`. A query string or fragment makes the URL end in something other than `.pdf`, so the branch is skipped and `scraper_key` falls through to the default HTML scraper. It's also case-sensitive, so `.PDF` never matches.

**Evidence** — Before the fix, on this branch's code:
```
https://example.com/doc.pdf          -> PyMuPDFScraper
https://example.com/doc.pdf?sig=abc  -> BeautifulSoupScraper   # wrong
https://example.com/REPORT.PDF       -> BeautifulSoupScraper   # wrong
```

**Fix + why this level** — Parse the URL with `urllib.parse.urlparse` and test `path.lower().endswith(".pdf")`. Checking the parsed **path** (not the whole link) is the correct layer: it ignores query/fragment by construction and won't be fooled by `pdf` appearing only in a query value (e.g. `?format=pdf` stays HTML). Lower-casing handles `.PDF`.

**Scope / risk** — Touches only `get_scraper`. Non-PDF URLs and the `arxiv.org` branch are unchanged; a bare `.pdf` link behaves exactly as before. The only behavioral change is that previously-misrouted PDFs now reach PyMuPDFScraper.

## Verification

- `python -m pytest tests/test_scraper_get_scraper.py -q` — 6 passed.

## Real behavior proof

- **Real environment:** Python 3.14 venv, repo at current `upstream/main` (409b8b60).
- **Captured output AFTER fix:**
  ```
  https://example.com/doc.pdf          -> PyMuPDFScraper
  https://example.com/doc.pdf?sig=abc  -> PyMuPDFScraper
  https://example.com/REPORT.PDF       -> PyMuPDFScraper
  ```
- **Regression test:** `tests/test_scraper_get_scraper.py` asserts correct routing and FAILS without the fix:
  ```
  WITHOUT fix: 3 failed (query-string, fragment, uppercase), 3 passed
  WITH fix:    6 passed
  ```
- **What was NOT tested:** live network scraping (requires fetching real PDFs); the fix is isolated to scraper-class selection.
