### PR TITLE
fix(compression): coerce SIMILARITY_THRESHOLD env var to float

### DIFF
--- a/gpt_researcher/context/compression.py
+++ b/gpt_researcher/context/compression.py
@@ -116,7 +116,7 @@ class ContextCompressor:
         self.documents = documents
         self.kwargs = kwargs
         self.embeddings = embeddings
-        self.similarity_threshold = os.environ.get("SIMILARITY_THRESHOLD", 0.35)
+        self.similarity_threshold = float(os.environ.get("SIMILARITY_THRESHOLD", 0.35))
         self.prompt_family = prompt_family
 
     def __get_contextual_retriever(self):

--- a/tests/test_compression_similarity_threshold.py
+++ b/tests/test_compression_similarity_threshold.py
@@ -1,0 +1,42 @@
+"""Regression test for SIMILARITY_THRESHOLD env-var type coercion.
+
+``ContextCompressor`` read the threshold as
+``os.environ.get("SIMILARITY_THRESHOLD", 0.35)``. When the env var is
+set, ``os.environ.get`` returns a **string**, which is later handed to
+LangChain's ``EmbeddingsFilter`` and compared against float similarity
+scores (``score >= threshold``) — raising
+``TypeError: '>=' not supported between instances of 'float' and 'str'``
+at query time. The default (a float) worked, so the bug only appeared
+once a user customized the threshold. The value must be coerced to float.
+"""
+
+import os
+import unittest
+from unittest import mock
+
+from gpt_researcher.context.compression import ContextCompressor
+
+
+class SimilarityThresholdTypeTests(unittest.TestCase):
+    def _make(self):
+        # documents/embeddings are not touched by __init__'s threshold read.
+        return ContextCompressor(documents=[], embeddings=object())
+
+    def test_env_override_is_coerced_to_float(self):
+        with mock.patch.dict(os.environ, {"SIMILARITY_THRESHOLD": "0.5"}):
+            cc = self._make()
+        self.assertIsInstance(cc.similarity_threshold, float)
+        self.assertEqual(cc.similarity_threshold, 0.5)
+        # The original bug: a float score could not be compared to the value.
+        self.assertTrue(0.6 >= cc.similarity_threshold)
+
+    def test_default_is_float(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SIMILARITY_THRESHOLD", None)
+            cc = self._make()
+        self.assertIsInstance(cc.similarity_threshold, float)
+        self.assertEqual(cc.similarity_threshold, 0.35)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `ContextCompressor` read its similarity threshold as `os.environ.get("SIMILARITY_THRESHOLD", 0.35)`.
- When a user sets that env var, the value is a **string**, which is later compared against float similarity scores by LangChain's `EmbeddingsFilter` (`score >= threshold`), raising `TypeError` at query time. Only the float default worked.

## Root Cause

**Symptom** — Setting `SIMILARITY_THRESHOLD` (a documented knob) breaks the standard context-compression path with `TypeError: '>=' not supported between instances of 'float' and 'str'`. Leaving it unset works, which masks the bug.

**Root cause** — In `gpt_researcher/context/compression.py`, `ContextCompressor.__init__` does `self.similarity_threshold = os.environ.get("SIMILARITY_THRESHOLD", 0.35)`. `os.environ.get` returns the raw string `"0.5"` when set; the float default only applies when unset. That value is passed straight into `EmbeddingsFilter(similarity_threshold=...)`, which compares it to float cosine scores.

**Evidence** — Reproduced directly:
```
>>> os.environ['SIMILARITY_THRESHOLD'] = '0.5'
>>> v = os.environ.get('SIMILARITY_THRESHOLD', 0.35); print(repr(v), type(v))
'0.5' <class 'str'>
>>> 0.6 >= v
TypeError: '>=' not supported between instances of 'float' and 'str'
```

**Fix + why this level** — Wrap the read in `float(...)`. Coercing at the point of ingestion (where the env var enters the object) is the correct layer — it normalizes the type once, so every downstream consumer (`EmbeddingsFilter`) gets a float, rather than patching the comparison site. `WrittenContentCompressor` already receives `similarity_threshold` as a typed float argument, so it was never affected.

**Scope / risk** — One line in `ContextCompressor.__init__`. Default behavior (unset env → 0.35) is unchanged since `float(0.35)` is `0.35`. An invalid non-numeric env value now fails fast with a clear `ValueError` at construction instead of a confusing `TypeError` mid-query.

## Verification

- `python -m pytest tests/test_compression_similarity_threshold.py -q` — 2 passed.

## Real behavior proof

- **Real environment:** Python 3.14 venv, repo at current `upstream/main` (409b8b60).
- **Regression test:** `tests/test_compression_similarity_threshold.py` sets the env var and asserts a float; it FAILS without the fix:
  ```
  WITHOUT fix: FAILED ::test_env_override_is_coerced_to_float (got str '0.5')
               1 failed, 1 passed
  WITH fix:    2 passed
  ```
- **What was NOT tested:** an end-to-end embedding query (needs an embeddings provider/API key); the fix is isolated to threshold type coercion.
