### PR TITLE
fix(agent): use real retriever keys (href/body) in quick_search summary

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -532,10 +532,15 @@ class GPTResearcher:
         if not aggregated_summary:
             return search_results
 
-        # Format results for summary
+        # Format results for summary. Search retrievers return records keyed
+        # by "href" (URL) and "body" (content); fall back to the alternate
+        # keys so callers that pass pre-normalized records still work.
         context = ""
         for i, result in enumerate(search_results, 1):
-            context += f"[{i}] {result.get('title', '')}: {result.get('content', '')} ({result.get('url', '')})\n\n"
+            title = result.get("title", "")
+            body = result.get("body") or result.get("content", "")
+            url = result.get("href") or result.get("url", "")
+            context += f"[{i}] {title}: {body} ({url})\n\n"
 
         prompt = self.prompt_family.generate_quick_summary_prompt(query, context)
 

--- a/tests/test_quick_search_summary_context.py
+++ b/tests/test_quick_search_summary_context.py
@@ -1,0 +1,59 @@
+"""Regression test: quick_search aggregated summary must include real result data.
+
+All GPT-Researcher search retrievers return records keyed by ``href`` (URL)
+and ``body`` (content) — never ``title``/``content``/``url``. The aggregated
+summary path in ``quick_search`` built its context with
+``result.get('content')`` / ``result.get('url')``, so for real retriever
+output every field was empty and the LLM was summarizing
+``[1] :  ()`` with no source data. The existing test masked this by feeding
+fake ``title``/``content``/``url`` records that no retriever produces.
+
+This test feeds the REAL retriever contract and asserts the body/URL reach
+the summarization prompt.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from gpt_researcher.agent import GPTResearcher
+
+
+class QuickSearchSummaryContextTests(unittest.TestCase):
+    @patch("gpt_researcher.agent.get_search_results", new_callable=AsyncMock)
+    @patch("gpt_researcher.agent.create_chat_completion", new_callable=AsyncMock)
+    @patch("langchain_openai.OpenAIEmbeddings")
+    def test_summary_prompt_contains_real_retriever_fields(
+        self, _mock_embeddings, mock_create_chat, mock_search
+    ):
+        # Real retriever output shape: href + body.
+        mock_search.return_value = [
+            {"href": "https://example.com/a", "body": "Alpha finding about rust."},
+            {"href": "https://example.com/b", "body": "Beta finding about async."},
+        ]
+        mock_create_chat.return_value = "summary"
+
+        researcher = GPTResearcher(query="rust async")
+        captured = {}
+
+        def fake_quick_prompt(query, context):
+            captured["context"] = context
+            return f"PROMPT for {query}\n{context}"
+
+        researcher.prompt_family.generate_quick_summary_prompt = fake_quick_prompt
+
+        result = asyncio.run(
+            researcher.quick_search("rust async", aggregated_summary=True)
+        )
+
+        self.assertEqual(result, "summary")
+        ctx = captured["context"]
+        # The bug produced an empty context ("[1] :  ()"); these must appear now.
+        self.assertIn("Alpha finding about rust.", ctx)
+        self.assertIn("Beta finding about async.", ctx)
+        self.assertIn("https://example.com/a", ctx)
+        self.assertIn("https://example.com/b", ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `quick_search(aggregated_summary=True)` built the context it hands to the summarization LLM from `result.get('content')` and `result.get('url')`.
- But every GPT-Researcher search retriever returns records keyed by **`href`** (URL) and **`body`** (content) — never `content`/`url`. So for real retriever output the context was always empty (`[1] :  ()`) and the "aggregated summary" was generated with no source data.

## Root Cause

**Symptom** — `quick_search(query, aggregated_summary=True)` returns a summary that ignores the actual search results (it summarizes empty placeholders), because the source text never makes it into the prompt.

**Root cause** — In `gpt_researcher/agent.py::quick_search`, the loop is:
```python
context += f"[{i}] {result.get('title', '')}: {result.get('content', '')} ({result.get('url', '')})\n\n"
```
`get_search_results()` returns whatever the retriever's `search()` produces, and every retriever (tavily, serper, google, bing, brave, exa, arxiv, crw, groundroute, mcp, …) emits `{"href": ..., "body": ...}`. `result.get('content')` and `result.get('url')` therefore always return `''`.

**Evidence** — grep of `gpt_researcher/retrievers/*/*.py` shows the uniform `"href"`/`"body"` contract (e.g. `tavily_search.py`: `{"href": obj["url"], "body": obj["content"]}`; `serper.py`, `google.py`, `bing.py`, `exa.py`, `arxiv.py` all identical in shape). Built context before vs after the fix on a real record:
```
OLD: '[1] :  ()'
NEW: '[1] : Alpha finding. (https://example.com/a)'
```

**Fix + why this level** — Read `result.get("body")` and `result.get("href")` (the real contract), falling back to `content`/`url` so any caller that passes pre-normalized records still works. Fixing at the consumer (where the retriever contract is known) is correct; changing every retriever to also emit `content`/`url` would be a far larger, riskier change for no benefit.

**Scope / risk** — One loop in `quick_search`. The non-summary path (`aggregated_summary=False`) is untouched. The fallback keeps backward compatibility for any record shaped with `content`/`url`.

## Verification

- `python -m pytest tests/test_quick_search_summary_context.py tests/test_quick_search.py -q` — 3 passed.

> Note: the pre-existing `tests/test_quick_search.py` fed fake `title`/`content`/`url` records that no retriever actually produces, which is exactly what hid this bug. The new test uses the real `href`/`body` contract.

## Real behavior proof

- **Real environment:** Python 3.14 venv, repo at current `upstream/main` (409b8b60).
- **Captured context built from a real retriever record (`{"href": "...", "body": "Alpha finding."}`):**
  ```
  OLD (buggy): [1] :  ()
  NEW (fixed): [1] : Alpha finding. (https://example.com/a)
  ```
- **Regression test:** `tests/test_quick_search_summary_context.py` feeds `href`/`body` records and asserts the body + URL reach the summarization prompt; it FAILS without the fix:
  ```
  WITHOUT fix: FAILED (context missing body/url)
  WITH fix:    passed
  ```
- **What was NOT tested:** a live LLM summary call (mocked); the fix is isolated to context assembly.
