### PR TITLE
fix(retriever): URL-encode Google Custom Search query parameters

### DIFF
--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -4,6 +4,7 @@
 import os
 import requests
 import json
+from urllib.parse import urlencode
 
 
 class GoogleSearch:
@@ -64,7 +65,18 @@ class GoogleSearch:
 
         print("Searching with query {0}...".format(search_query))
 
-        url = f"https://www.googleapis.com/customsearch/v1?key={self.api_key}&cx={self.cx_key}&q={search_query}&start=1"
+        # URL-encode every parameter. Interpolating the raw query broke any
+        # search containing reserved characters (e.g. "&" in "AT&T" added a
+        # spurious param, "#" truncated the rest of the query).
+        query_string = urlencode(
+            {
+                "key": self.api_key,
+                "cx": self.cx_key,
+                "q": search_query,
+                "start": 1,
+            }
+        )
+        url = f"https://www.googleapis.com/customsearch/v1?{query_string}"
         resp = requests.get(url)
 
         if resp.status_code < 200 or resp.status_code >= 300:

--- a/tests/test_google_search_url_encoding.py
+++ b/tests/test_google_search_url_encoding.py
@@ -1,0 +1,63 @@
+"""Regression test: GoogleSearch must URL-encode the query.
+
+The Custom Search request URL was built by f-string interpolating the raw
+query: ``...&q={search_query}&start=1``. Any reserved character in the
+query corrupted the request:
+  * ``&`` (e.g. "AT&T") injected a spurious query parameter,
+  * ``#`` truncated everything after it (fragment),
+  * spaces produced an invalid URL.
+
+These tests pin proper percent-encoding by inspecting the URL handed to
+``requests.get``.
+"""
+
+import os
+import unittest
+from unittest import mock
+from urllib.parse import urlparse, parse_qs
+
+from gpt_researcher.retrievers.google.google import GoogleSearch
+
+
+class _Resp:
+    status_code = 200
+    text = '{"items": []}'
+
+
+class GoogleSearchUrlEncodingTests(unittest.TestCase):
+    def _search(self, query):
+        env = {"GOOGLE_API_KEY": "k", "GOOGLE_CX_KEY": "c"}
+        with mock.patch.dict(os.environ, env):
+            gs = GoogleSearch(query)
+        with mock.patch(
+            "gpt_researcher.retrievers.google.google.requests.get",
+            return_value=_Resp(),
+        ) as m:
+            gs.search()
+        return m.call_args[0][0]  # the URL passed positionally
+
+    def test_ampersand_in_query_is_encoded_not_split(self):
+        url = self._search("AT&T market share")
+        parsed = parse_qs(urlparse(url).query)
+        # The whole query must survive as a single q param.
+        self.assertEqual(parsed["q"], ["AT&T market share"])
+        # No spurious top-level param leaked from the "&T".
+        self.assertNotIn("T", parsed)
+
+    def test_hash_in_query_is_not_treated_as_fragment(self):
+        url = self._search("python #1 framework")
+        self.assertEqual(urlparse(url).fragment, "")
+        parsed = parse_qs(urlparse(url).query)
+        self.assertEqual(parsed["q"], ["python #1 framework"])
+        # start must still be present (the bug dropped it after the #).
+        self.assertEqual(parsed["start"], ["1"])
+
+    def test_spaces_are_encoded(self):
+        url = self._search("hello world")
+        self.assertNotIn(" ", url)
+        parsed = parse_qs(urlparse(url).query)
+        self.assertEqual(parsed["q"], ["hello world"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `GoogleSearch.search()` built the Custom Search request URL by f-string interpolating the **raw** query.
- Any query containing reserved URL characters was silently corrupted: `&` (e.g. "AT&T") injected a spurious query parameter, `#` truncated the rest of the query as a fragment, and spaces produced a malformed URL. The user got wrong or empty results with no error.

## Root Cause

**Symptom** — Google searches for perfectly ordinary queries like `AT&T market share` or `python #1 framework` return wrong/empty results because the query sent to the Custom Search API isn't what the user typed.

**Root cause** — In `gpt_researcher/retrievers/google/google.py::search`:
```python
url = f"https://www.googleapis.com/customsearch/v1?key={self.api_key}&cx={self.cx_key}&q={search_query}&start=1"
resp = requests.get(url)
```
The query is concatenated unencoded. `&` ends the `q` value and starts a new param; `#` begins a URL fragment (dropping `q`'s tail *and* `start`); spaces are invalid in a URL.

**Evidence** — built URL before vs after the fix for `q="AT&T #1"`:
```
OLD: https://www.googleapis.com/customsearch/v1?key=k&cx=c&q=AT&T #1&start=1
NEW: https://www.googleapis.com/customsearch/v1?key=k&cx=c&q=AT%26T+%231&start=1
```
In the OLD URL the API sees `q=AT`, a junk param `T #1`, and the trailing `&start=1` mangled.

**Fix + why this level** — Build the query string with `urllib.parse.urlencode({...})`. Encoding at URL-construction time is the correct layer — it percent-encodes every parameter uniformly (query, key, cx, start) rather than special-casing individual characters. (Passing a `params=` dict to `requests.get` would also work; `urlencode` keeps the existing single-`url` shape with minimal diff.)

**Scope / risk** — Touches only the URL assembly in `GoogleSearch.search`. Domain-restriction logic, result parsing, and the `max_results` slice are unchanged. Well-formed queries with no reserved characters produce an equivalent (now properly-encoded) URL.

## Verification

- `python -m pytest tests/test_google_search_url_encoding.py -q` — 3 passed.

## Real behavior proof

- **Real environment:** Python 3.14 venv, repo at current `upstream/main` (409b8b60).
- **Captured URL built by the retriever (requests.get mocked, URL inspected):**
  ```
  OLD (buggy): .../v1?key=k&cx=c&q=AT&T #1&start=1   -> API sees q="AT", junk param, mangled start
  NEW (fixed): .../v1?key=k&cx=c&q=AT%26T+%231&start=1
  ```
- **Regression test:** `tests/test_google_search_url_encoding.py` inspects the URL passed to `requests.get` for `&`, `#`, and space queries; it FAILS without the fix:
  ```
  WITHOUT fix: 3 failed (ampersand split, hash fragment, unencoded space)
  WITH fix:    3 passed
  ```
- **What was NOT tested:** a live Custom Search API call (mocked); the fix is isolated to URL construction.
