### PR TITLE
fix(scraper): detect PDF links with query strings/uppercase in BrowserScraper

### DIFF
--- a/gpt_researcher/scraper/browser/browser.py
+++ b/gpt_researcher/scraper/browser/browser.py
@@ -15,7 +15,20 @@ from typing import Iterable, cast
 from .processing.scrape_skills import (scrape_pdf_with_pymupdf,
                                        scrape_pdf_with_arxiv)
 
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
+
+
+def _is_pdf_url(url: str) -> bool:
+    """Return True when ``url`` points at a PDF.
+
+    Inspects only the path component so query strings / fragments don't hide
+    the extension (signed CDN/S3 links like ``https://host/doc.pdf?sig=...``
+    are extremely common), and matches case-insensitively because ``.PDF`` is
+    a perfectly valid suffix.
+    """
+    if not url:
+        return False
+    return urlparse(url).path.lower().endswith(".pdf")
 
 from ..utils import get_relevant_images, extract_title, get_text_from_soup, clean_soup
 
@@ -202,7 +215,7 @@ class BrowserScraper:
 
         self._scroll_to_bottom()
 
-        if self.url.endswith(".pdf"):
+        if _is_pdf_url(self.url):
             text = scrape_pdf_with_pymupdf(self.url)
             return text, [], ""
         elif "arxiv" in self.url:

--- a/tests/test_browser_pdf_detection.py
+++ b/tests/test_browser_pdf_detection.py
@@ -1,0 +1,41 @@
+"""Regression tests for PDF URL detection in the BrowserScraper.
+
+The scrape path used ``self.url.endswith(".pdf")``, which:
+  * missed query strings / fragments (signed CDN/S3 links such as
+    ``https://host/doc.pdf?sig=...`` are extremely common), and
+  * was case-sensitive, so ``.PDF`` was not recognized.
+
+These tests pin the corrected behavior via the ``_is_pdf_url`` helper.
+"""
+
+from gpt_researcher.scraper.browser.browser import _is_pdf_url
+
+
+def test_plain_pdf_url_detected():
+    assert _is_pdf_url("https://example.com/file.pdf") is True
+
+
+def test_pdf_with_query_string_detected():
+    # Signed CDN / S3 links carry the signature as a query string.
+    assert _is_pdf_url("https://cdn.example.com/doc.pdf?sig=abc123&exp=999") is True
+
+
+def test_pdf_with_fragment_detected():
+    assert _is_pdf_url("https://example.com/doc.pdf#page=2") is True
+
+
+def test_uppercase_extension_detected():
+    assert _is_pdf_url("https://example.com/REPORT.PDF") is True
+
+
+def test_non_pdf_url_not_detected():
+    assert _is_pdf_url("https://example.com/article.html") is False
+
+
+def test_pdf_substring_in_query_not_detected():
+    # A ".pdf" appearing only in a query param must NOT trigger PDF handling.
+    assert _is_pdf_url("https://example.com/view?file=report.pdf") is False
+
+
+def test_empty_url_not_detected():
+    assert _is_pdf_url("") is False


### PR DESCRIPTION
## Summary

- `BrowserScraper` (Selenium) routed pages to its PDF handler with `self.url.endswith(".pdf")`, which missed PDFs behind a query string/fragment and uppercase `.PDF`.
- Such links silently fell through to HTML scraping and returned non-PDF garbage.

## Motivation

Signed CDN/S3 PDF links almost always carry a signature query string (`https://host/report.pdf?sig=...&exp=...`), and uppercase `.PDF` is a valid suffix. The bare suffix check failed on both, so the browser scraper never invoked `scrape_pdf_with_pymupdf` for them.

This mirrors the same class of bug already fixed for `Scraper.get_scraper` in #1828 — but the `BrowserScraper` path is independent and was untouched.

## Fix

Extracted a small `_is_pdf_url(url)` helper that inspects only `urlparse(url).path`, lowercased, before checking the `.pdf` suffix. The scrape path now calls it instead of `endswith`.

## Real behavior proof

**Behavior addressed:** `endswith(".pdf")` returns `False` for `doc.pdf?sig=x` and `R.PDF`.

**Real environment:** Python 3.14, repo `master`, local venv.

**Exact commands run after the patch:**
```
python -m pytest tests/test_browser_pdf_detection.py -q
```

**Captured output AFTER fix:**
```
7 passed, 2 warnings in 0.34s
```

**Pre-fix demonstration (old logic):**
```
query: False   # https://cdn/doc.pdf?sig=x  -> should be a PDF
upper: False   # https://x/R.PDF            -> should be a PDF
```

**Regression test:** `tests/test_browser_pdf_detection.py` — asserts query-string, fragment, and uppercase PDFs are detected and that a `.pdf` appearing only in a query param is NOT. Fails without the fix.

## Scope / risk

Pure detection helper; only the browser scrape branch changed. Non-PDF and plain `.pdf` behavior unchanged.
