### PR TITLE
fix(retriever): preserve camelCase sort criterion for Semantic Scholar

### DIFF
--- a/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
+++ b/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
@@ -20,7 +20,11 @@ class SemanticScholarSearch:
         """
         self.query = query
         assert sort in self.VALID_SORT_CRITERIA, "Invalid sort criterion"
-        self.sort = sort.lower()
+        # Preserve the exact (camelCase) criterion. The Semantic Scholar API
+        # expects ``citationCount`` / ``publicationDate`` verbatim; lowercasing
+        # them produced ``citationcount`` / ``publicationdate``, which the API
+        # rejects or silently ignores.
+        self.sort = sort
 
     def search(self, max_results: int = 20) -> List[Dict[str, str]]:
         """

--- a/tests/test_semantic_scholar_sort.py
+++ b/tests/test_semantic_scholar_sort.py
@@ -1,0 +1,33 @@
+"""Regression test for Semantic Scholar sort-criterion casing.
+
+``VALID_SORT_CRITERIA`` holds the API's exact camelCase values
+(``citationCount``, ``publicationDate``), and ``__init__`` asserts the
+incoming value is one of them. It then stored ``sort.lower()``, corrupting
+``citationCount`` -> ``citationcount`` before it was sent as the ``sort``
+query parameter. The Semantic Scholar API expects the camelCase form.
+"""
+
+from gpt_researcher.retrievers.semantic_scholar.semantic_scholar import (
+    SemanticScholarSearch,
+)
+
+
+def test_camelcase_sort_preserved():
+    s = SemanticScholarSearch("anything", sort="citationCount")
+    assert s.sort == "citationCount"
+
+
+def test_publication_date_sort_preserved():
+    s = SemanticScholarSearch("anything", sort="publicationDate")
+    assert s.sort == "publicationDate"
+
+
+def test_relevance_default_preserved():
+    s = SemanticScholarSearch("anything")
+    assert s.sort == "relevance"
+
+
+def test_stored_sort_is_a_valid_api_value():
+    # Whatever is stored must round-trip as an accepted API criterion.
+    s = SemanticScholarSearch("anything", sort="citationCount")
+    assert s.sort in SemanticScholarSearch.VALID_SORT_CRITERIA


### PR DESCRIPTION
## Summary

- `SemanticScholarSearch.__init__` validated the `sort` argument against camelCase API values, then stored `sort.lower()` — corrupting `citationCount` → `citationcount` and `publicationDate` → `publicationdate`.
- The lowercased value was sent as the `sort` query parameter; the Semantic Scholar API expects the exact camelCase form, so non-default sorting was silently broken.

## Motivation

```python
VALID_SORT_CRITERIA = ["relevance", "citationCount", "publicationDate"]
...
assert sort in self.VALID_SORT_CRITERIA, "Invalid sort criterion"
self.sort = sort.lower()   # <- corrupts the just-validated value
```

The assert guarantees `sort` is already a valid API criterion; lowercasing it immediately afterward makes the stored value no longer a member of `VALID_SORT_CRITERIA`. `relevance` happened to survive (already lowercase), masking the bug for the default.

## Fix

Store the validated value verbatim (`self.sort = sort`).

## Real behavior proof

**Behavior addressed:** stored sort no longer matches the API's accepted set.

**Real environment:** Python 3.14, repo `master`, local venv.

**Exact commands run:**
```
python -m pytest tests/test_semantic_scholar_sort.py -q
```

**Captured output AFTER fix:**
```
4 passed, 2 warnings in 0.30s
```

**Captured output BEFORE fix (test stashed back onto unpatched source):**
```
3 failed, 1 passed
FAILED tests/test_semantic_scholar_sort.py::test_camelcase_sort_preserved
FAILED tests/test_semantic_scholar_sort.py::test_publication_date_sort_preserved
FAILED tests/test_semantic_scholar_sort.py::test_stored_sort_is_a_valid_api_value
```

**Regression test:** `tests/test_semantic_scholar_sort.py` — asserts the stored `sort` stays camelCase and remains a member of `VALID_SORT_CRITERIA`. Fails without the fix.

## Scope / risk

One assignment changed. `relevance` (the default) is unaffected; only the two camelCase criteria are corrected.
