### PR TITLE
feat(agent): add all_retrievers option to quick_search

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -4,6 +4,7 @@ This module provides the main GPTResearcher class that orchestrates
 autonomous research and report generation using LLMs and web search.
 """
 
+import asyncio
 import json
 import os
 from typing import Any, Optional
@@ -516,18 +517,32 @@ class GPTResearcher:
         await self._log_event("research", step="introduction_completed")
         return intro
 
-    async def quick_search(self, query: str, query_domains: list[str] = None, aggregated_summary: bool = False) -> list[Any] | str:
+    async def quick_search(
+        self,
+        query: str,
+        query_domains: list[str] = None,
+        aggregated_summary: bool = False,
+        all_retrievers: bool = False,
+    ) -> list[Any] | str:
         """Perform a quick search without full research workflow.
 
         Args:
             query: The search query.
             query_domains: Optional list of domains to restrict search to.
             aggregated_summary: Whether to return an aggregated summary of the search results.
+            all_retrievers: If True, query every configured retriever concurrently and
+                merge the results (de-duplicated by URL). Defaults to False, which uses
+                only the primary retriever for backward compatibility.
 
         Returns:
             List of search results or a synthesized summary string.
         """
-        search_results = await get_search_results(query, self.retrievers[0], query_domains=query_domains)
+        if all_retrievers and len(self.retrievers) > 1:
+            search_results = await self._search_all_retrievers(query, query_domains)
+        else:
+            search_results = await get_search_results(
+                query, self.retrievers[0], query_domains=query_domains, researcher=self
+            )
 
         if not aggregated_summary:
             return search_results
@@ -549,6 +564,42 @@ class GPTResearcher:
         )
 
         return summary
+
+    async def _search_all_retrievers(
+        self, query: str, query_domains: list[str] = None
+    ) -> list[dict[str, Any]]:
+        """Query every configured retriever concurrently and merge the results.
+
+        Results are de-duplicated by URL (checking both ``url`` and ``href`` keys,
+        which different retrievers use). Retrievers that raise are skipped so a
+        single failing provider does not abort the whole search.
+
+        Args:
+            query: The search query.
+            query_domains: Optional list of domains to restrict search to.
+
+        Returns:
+            A merged, de-duplicated list of search results.
+        """
+        tasks = [
+            get_search_results(query, retriever, query_domains=query_domains, researcher=self)
+            for retriever in self.retrievers
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        merged: list[dict[str, Any]] = []
+        seen_urls: set[str] = set()
+        for result in results:
+            if isinstance(result, Exception) or not result:
+                continue
+            for item in result:
+                url = item.get("url") or item.get("href") or ""
+                if url and url in seen_urls:
+                    continue
+                if url:
+                    seen_urls.add(url)
+                merged.append(item)
+        return merged
 
     async def get_subtopics(self):
         """Generate subtopics for the research query.

--- a/tests/test_quick_search.py
+++ b/tests/test_quick_search.py
@@ -42,5 +42,69 @@ class TestQuickSearch(unittest.TestCase):
         self.assertEqual(summary, "This is a summary.")
         mock_create_chat.assert_called_once()
 
+    @patch('gpt_researcher.agent.get_search_results', new_callable=AsyncMock)
+    @patch('langchain_openai.OpenAIEmbeddings')
+    def test_quick_search_all_retrievers_merges_and_dedups(self, mock_embeddings, mock_search):
+        # Two retrievers return overlapping results; the shared URL should appear once.
+        mock_search.side_effect = [
+            [
+                {'title': 'A', 'body': 'a', 'href': 'http://dup.com'},
+                {'title': 'B', 'body': 'b', 'href': 'http://b.com'},
+            ],
+            [
+                {'title': 'A dup', 'body': 'a2', 'href': 'http://dup.com'},
+                {'title': 'C', 'body': 'c', 'href': 'http://c.com'},
+            ],
+        ]
+
+        researcher = GPTResearcher(query="test query")
+        # Force two retrievers regardless of env configuration.
+        researcher.retrievers = [MagicMock(__name__='R1'), MagicMock(__name__='R2')]
+
+        results = asyncio.run(
+            researcher.quick_search("test query", all_retrievers=True)
+        )
+
+        self.assertEqual(mock_search.await_count, 2)
+        hrefs = [r.get('href') for r in results]
+        self.assertEqual(hrefs.count('http://dup.com'), 1)
+        self.assertEqual(len(results), 3)
+
+    @patch('gpt_researcher.agent.get_search_results', new_callable=AsyncMock)
+    @patch('langchain_openai.OpenAIEmbeddings')
+    def test_quick_search_all_retrievers_skips_failing_retriever(self, mock_embeddings, mock_search):
+        # One retriever raises; results from the healthy one are still returned.
+        mock_search.side_effect = [
+            RuntimeError("provider down"),
+            [{'title': 'B', 'body': 'b', 'href': 'http://b.com'}],
+        ]
+
+        researcher = GPTResearcher(query="test query")
+        researcher.retrievers = [MagicMock(__name__='R1'), MagicMock(__name__='R2')]
+
+        results = asyncio.run(
+            researcher.quick_search("test query", all_retrievers=True)
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['href'], 'http://b.com')
+
+    @patch('gpt_researcher.agent.get_search_results', new_callable=AsyncMock)
+    @patch('langchain_openai.OpenAIEmbeddings')
+    def test_quick_search_single_retriever_ignores_all_flag(self, mock_embeddings, mock_search):
+        # With only one retriever, all_retrievers=True falls back to the primary path.
+        mock_search.return_value = [{'title': 'Test', 'body': 'x', 'href': 'http://test.com'}]
+
+        researcher = GPTResearcher(query="test query")
+        researcher.retrievers = [MagicMock(__name__='R1')]
+
+        results = asyncio.run(
+            researcher.quick_search("test query", all_retrievers=True)
+        )
+
+        self.assertEqual(mock_search.await_count, 1)
+        self.assertEqual(len(results), 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

`GPTResearcher.quick_search()` is documented as a lightweight web search, but it only ever queries **the first configured retriever** (`self.retrievers[0]`). When a user configures multiple retrievers — e.g. `RETRIEVER="tavily,duckduckgo"` — `quick_search` silently ignores all but the first. Full research (`conduct_research`) fans out across retrievers, so this is an inconsistent and surprising gap for anyone using `quick_search` as a fast multi-source lookup or chat tool.

## Solution

Add an opt-in `all_retrievers` flag to `quick_search`:

- When `all_retrievers=True` (and more than one retriever is configured), it queries **every** configured retriever concurrently via `asyncio.gather` and merges the results.
- Results are **de-duplicated by URL**, handling both `url` and `href` keys (different retrievers use different shapes — Tavily returns `href`, others `url`).
- A retriever that raises is **skipped** (`return_exceptions=True`), so one failing provider doesn't abort the whole search.
- Default behaviour is **unchanged** (`all_retrievers=False` → primary retriever only), so this is fully backward compatible.

Also threads the `researcher=self` argument through the primary-path `get_search_results` call so MCP retrievers work in single-retriever quick searches too.

## Files changed

- `gpt_researcher/agent.py` — new `all_retrievers` param + `_search_all_retrievers` helper.
- `tests/test_quick_search.py` — 3 new tests (merge+dedup, failing-retriever skip, single-retriever fallback).

## Tests

```
$ python -m pytest tests/test_quick_search.py -v
...
5 passed, 3 warnings in 0.66s
```

All existing quick_search tests still pass; new tests cover the merge/dedup, fault-tolerance, and backward-compat paths.

## Breaking changes

None. The new parameter defaults to `False`.
