### PR TITLE
fix(document): normalise URL extension case in OnlineDocumentLoader

### DIFF
--- a/gpt_researcher/document/online_document.py
+++ b/gpt_researcher/document/online_document.py
@@ -88,4 +88,8 @@ class OnlineDocumentLoader:
 
     @staticmethod
     def _get_extension(url: str) -> str:
-        return os.path.splitext(url.split("?")[0])[1]
+        # Lower-case the extension so loader lookup (whose keys are lower-case,
+        # e.g. "pdf"/"docx") matches URLs that use upper-case extensions like
+        # "report.PDF" or "doc.DOCX". The leading "?" split drops query strings
+        # (signed CDN/S3 URLs) before extracting the suffix.
+        return os.path.splitext(url.split("?")[0])[1].lower()

--- a/tests/test_online_document_extension.py
+++ b/tests/test_online_document_extension.py
@@ -1,0 +1,24 @@
+"""Regression test for OnlineDocumentLoader._get_extension case handling."""
+
+from gpt_researcher.document.online_document import OnlineDocumentLoader
+
+
+def test_get_extension_lowercases_uppercase_suffix():
+    # Loader dict keys are lower-case ("pdf", "docx"); an upper-case URL
+    # extension must be normalised so the right loader is selected instead
+    # of silently falling through to the unsupported branch.
+    assert OnlineDocumentLoader._get_extension("https://x.com/report.PDF") == ".pdf"
+    assert OnlineDocumentLoader._get_extension("https://x.com/doc.DOCX") == ".docx"
+
+
+def test_get_extension_strips_query_string():
+    # Signed CDN/S3 URLs carry a query string after the real extension.
+    assert (
+        OnlineDocumentLoader._get_extension("https://x.com/report.PDF?sig=abc&t=1")
+        == ".pdf"
+    )
+    assert OnlineDocumentLoader._get_extension("https://x.com/a.pdf") == ".pdf"
+
+
+def test_get_extension_no_extension():
+    assert OnlineDocumentLoader._get_extension("https://x.com/page") == ""


### PR DESCRIPTION
## Summary

- `OnlineDocumentLoader._get_extension` now lower-cases the extracted file extension.
- Fixes online documents with upper-case URL extensions (`report.PDF`, `doc.DOCX`) being silently skipped instead of loaded.

## Motivation

`_load_document` selects a loader from `loader_dict`, whose keys are all
lower-case (`pdf`, `txt`, `docx`, `xlsx`, `md`, ...). But `_get_extension`
returned the raw suffix from the URL:

```python
return os.path.splitext(url.split("?")[0])[1]
```

So a URL ending in an upper-case extension — common for direct links and
signed CDN/S3 URLs (`https://host/report.PDF?sig=...`) — yielded the format
string `PDF`, which matches no `loader_dict` key. `loader_dict.get(...)`
returned `None` and the document was silently dropped with no error.

The fix lower-cases the extension so the loader lookup matches.

## Verification

- `python -m pytest tests/test_online_document_extension.py` — 3 passed.

## Real behavior proof

**Before fix** (raw suffix returned):
```
>>> OnlineDocumentLoader._get_extension("https://x.com/report.PDF?sig=abc")
'.PDF'      # -> _load_document gets "PDF" -> loader_dict.get("PDF") is None -> skipped
```

**After fix:**
```
>>> OnlineDocumentLoader._get_extension("https://x.com/report.PDF?sig=abc")
'.pdf'      # -> "pdf" -> PyMuPDFLoader selected
```

**Regression test** (`tests/test_online_document_extension.py`) asserts the
lower-cased result and FAILS without the fix:
```
FAILED tests/test_online_document_extension.py::test_get_extension_lowercases_uppercase_suffix
FAILED tests/test_online_document_extension.py::test_get_extension_strips_query_string
2 failed, 1 passed
```
With the fix: `3 passed`.

## Scope / risk

One-line change in a pure static helper. Lower-casing an already-lower-case
or empty extension is a no-op, so existing lower-case URLs are unaffected.
