### PR TITLE
fix(retriever): return empty list instead of None from PubMedCentralSearch.search

### DIFF
--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -125,7 +125,7 @@ class PubMedCentralSearch:
         except requests.RequestException as e:
             return None
 
-    def search(self, max_results: int = 5) -> Optional[List[Dict[str, Any]]]:
+    def search(self, max_results: int = 5) -> List[Dict[str, Any]]:
         """
         Performs the search and retrieves full text content.
 
@@ -139,10 +139,13 @@ class PubMedCentralSearch:
               ...
             ]
         """
-        # Step 1: Search for article IDs
+        # Step 1: Search for article IDs. Always return a list (never None):
+        # callers such as actions.query_processing.get_search_results are typed
+        # -> List[Dict] and skills.researcher does len(search_results), which
+        # raises TypeError on None.
         article_ids = self._search_articles(max_results)
         if not article_ids:
-            return None
+            return []
         
         # Step 2: Fetch full text for each article
         results = []

--- a/tests/test_pubmed_central_returns_list.py
+++ b/tests/test_pubmed_central_returns_list.py
@@ -1,0 +1,31 @@
+"""Regression test: PubMedCentralSearch.search must return [] (never None).
+
+Callers (actions.query_processing.get_search_results -> List[Dict]) and
+skills.researcher (`len(search_results)`) crash on None.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+if "requests" not in sys.modules:
+    sys.modules["requests"] = types.ModuleType("requests")
+
+from gpt_researcher.retrievers.pubmed_central.pubmed_central import (  # noqa: E402
+    PubMedCentralSearch,
+)
+
+
+def test_search_returns_list_when_no_article_ids():
+    s = PubMedCentralSearch("cancer")
+    with patch.object(PubMedCentralSearch, "_search_articles", return_value=None):
+        out = s.search()
+    assert out == []
+    assert len(out) == 0  # would TypeError if None
+
+
+def test_search_returns_list_when_empty_article_ids():
+    s = PubMedCentralSearch("cancer")
+    with patch.object(PubMedCentralSearch, "_search_articles", return_value=[]):
+        out = s.search()
+    assert out == []


### PR DESCRIPTION
## Summary

- `PubMedCentralSearch.search` now returns `[]` (not `None`) when no articles are found.
- Prevents `TypeError: object of type 'NoneType' has no len()` on a zero-hit PubMed query.

## Motivation

`search` returned `None` whenever `_search_articles` produced nothing — a
genuine search miss, or a transient esearch failure:

```python
article_ids = self._search_articles(max_results)
if not article_ids:
    return None
```

But the result is consumed as a list. `actions.query_processing.get_search_results`
is annotated `-> List[Dict[str, Any]]`, and `skills/researcher.py` runs:

```python
search_results = await get_search_results(query, self.researcher.retrievers[0], ...)
self.logger.info(f"Initial search results obtained: {len(search_results)} results")
```

So a query that returns no PubMed articles crashed the research run with
`TypeError: object of type 'NoneType' has no len()`, instead of degrading to
an empty result set like every other retriever (serpapi/brave/bing/searx all
return `[]`).

## Verification

- `python -m pytest tests/test_pubmed_central_returns_list.py` — 2 passed.

## Real behavior proof

Regression test patches `_search_articles` to return `None` and `[]`.

**Without the fix:**
```
FAILED tests/test_pubmed_central_returns_list.py::test_search_returns_list_when_no_article_ids
FAILED tests/test_pubmed_central_returns_list.py::test_search_returns_list_when_empty_article_ids
2 failed
```
The `len(out) == 0` assertion raises `TypeError: object of type 'NoneType' has no len()` — the exact production failure.

**With the fix:** `2 passed`.

## Scope / risk

One return path changed (`return None` -> `return []`) plus a return-type
annotation tightened to `List[Dict[str, Any]]`. The success path (articles
found) is untouched.
