### PR TITLE
fix(deep-research): don't split learning text on the URL scheme colon

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -173,7 +173,10 @@ Format each question on a new line starting with 'Question: '"""}
                 url_match = re.search(r'\[(.*?)\]:', line)
                 if url_match:
                     url = url_match.group(1)
-                    learning = line.split(':', 1)[1].strip()
+                    # Take everything AFTER the matched ``[url]:`` marker. Using
+                    # ``line.split(':', 1)`` would split on the colon inside the
+                    # URL scheme (``https:``) and mangle the learning text.
+                    learning = line[url_match.end():].strip()
                     learnings.append(learning)
                     citations[learning] = url
                 else:

--- a/tests/test_deep_research_learning_parsing.py
+++ b/tests/test_deep_research_learning_parsing.py
@@ -1,0 +1,64 @@
+"""Regression test for learning/citation parsing in DeepResearchSkill.
+
+``process_research_results`` parses LLM output lines shaped like
+``Learning [https://example.com/page]: <insight>``. The old implementation
+used ``line.split(':', 1)[1]`` to grab the insight, which split on the colon
+inside the URL scheme (``https:``) and produced a mangled learning such as
+``//example.com/page]: <insight>``. The citation URL was captured correctly,
+but the learning text (and therefore the citation key) was corrupted.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_skill():
+    from gpt_researcher.skills.deep_research import DeepResearchSkill
+
+    cfg = types.SimpleNamespace(
+        deep_research_breadth=4,
+        deep_research_depth=2,
+        deep_research_concurrency=2,
+        config_path=None,
+        strategic_llm_provider="openai",
+        strategic_llm_model="gpt-4o",
+        reasoning_effort="medium",
+    )
+    researcher = types.SimpleNamespace(
+        cfg=cfg,
+        websocket=None,
+        tone=None,
+        headers={},
+        visited_urls=set(),
+    )
+    return DeepResearchSkill(researcher)
+
+
+@pytest.mark.asyncio
+async def test_learning_with_url_is_not_mangled_by_scheme_colon():
+    skill = _make_skill()
+    response = (
+        "Learning [https://example.com/page]: The sky appears blue due to "
+        "Rayleigh scattering\n"
+        "Question: What causes red sunsets?"
+    )
+
+    with patch(
+        "gpt_researcher.skills.deep_research.create_chat_completion",
+        return_value=response,
+    ):
+        result = await skill.process_research_results("why is the sky blue", "ctx")
+
+    expected_learning = (
+        "The sky appears blue due to Rayleigh scattering"
+    )
+    assert result["learnings"] == [expected_learning]
+    # The insight must NOT leak the URL remnant from the scheme colon split.
+    assert "//example.com" not in result["learnings"][0]
+    assert result["citations"] == {
+        expected_learning: "https://example.com/page"
+    }
+    assert result["followUpQuestions"] == ["What causes red sunsets?"]


### PR DESCRIPTION
## Summary

- `DeepResearchSkill.process_research_results` parses LLM output lines shaped like `Learning [https://example.com/page]: <insight>`. It grabbed the insight with `line.split(':', 1)[1]`, which splits on the **first** colon — the one inside the URL scheme (`https:`).
- User-facing impact: every learning that carries a citation URL is stored mangled (e.g. `//example.com/page]: <insight>` instead of `<insight>`), and because the mangled string is also used as the citations dict key, the citation mapping is corrupted too.

## Motivation

The regex `re.search(r'\[(.*?)\]:', line)` already captures the URL and locates the `[url]:` marker. The fix takes everything **after** the matched marker (`line[url_match.end():]`) instead of splitting on the first colon, so the URL's own `https:` colon no longer truncates the learning.

## Verification

- `python -m pytest tests/test_deep_research_learning_parsing.py -q` — 1 passed.

## Real behavior proof

**Repro of the bug (old code):**
```
line = 'Learning [https://example.com/page]: The sky is blue'
url    = 'https://example.com/page'        # captured correctly
learning = '//example.com/page]: The sky is blue'   # WRONG (split on https: colon)
```

**Regression test** `tests/test_deep_research_learning_parsing.py` mocks the LLM response and asserts the parsed learning is `The sky appears blue due to Rayleigh scattering` (no `//example.com` remnant) and the citation maps that clean learning to `https://example.com/page`. It FAILS without the fix:
```
FAILED tests/test_deep_research_learning_parsing.py::test_learning_with_url_is_not_mangled_by_scheme_colon
1 failed
```
and passes with it:
```
tests/test_deep_research_learning_parsing.py .                           [100%]
1 passed
```

## Scope / risk

- Touches only `gpt_researcher/skills/deep_research.py` (the `Learning [url]:` branch) + a new test.
- The no-bracket-URL fallback branches are unchanged.
- Lines without a `[url]:` marker are unaffected (different code path).