### PR TITLE
fix(scraper): remove PyMuPDF temp file even when PDF loading fails

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -57,10 +57,16 @@ class PyMuPDFScraper:
                     for chunk in response.iter_content(chunk_size=8192):
                         temp_file.write(chunk)  # Write the downloaded content to the temporary file
 
-                loader = PyMuPDFLoader(temp_filename)
-                doc = loader.load()
-
-                os.remove(temp_filename)
+                # Always clean up the downloaded temp file, even if loading fails
+                # (PyMuPDFLoader.load() can raise on a malformed/partial PDF).
+                try:
+                    loader = PyMuPDFLoader(temp_filename)
+                    doc = loader.load()
+                finally:
+                    try:
+                        os.remove(temp_filename)
+                    except OSError:
+                        pass
             else:
                 loader = PyMuPDFLoader(self.link)
                 doc = loader.load()

--- a/tests/test_pymupdf_tempfile_cleanup.py
+++ b/tests/test_pymupdf_tempfile_cleanup.py
@@ -1,0 +1,50 @@
+"""Regression test: PyMuPDFScraper must not leak its downloaded temp file.
+
+When scraping a remote PDF, the scraper downloads it to a
+``NamedTemporaryFile(delete=False, suffix=".pdf")`` and then loads it with
+``PyMuPDFLoader``. The old code called ``os.remove(temp_filename)`` only on the
+success path, so a parse failure (malformed/partial PDF -> ``PyMuPDFLoader.load``
+raises) left the temp file behind on disk every time. The exception is then
+swallowed by the broad ``except``, so the leak was silent.
+"""
+
+import os
+import glob
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.scraper.pymupdf.pymupdf import PyMuPDFScraper
+
+
+class _FakeResponse:
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size=8192):
+        yield b"%PDF-1.4 not-a-real-pdf"
+
+
+def _temp_pdfs() -> set:
+    return set(glob.glob(os.path.join(tempfile.gettempdir(), "*.pdf")))
+
+
+def test_tempfile_removed_when_loader_raises():
+    scraper = PyMuPDFScraper("https://example.com/broken.pdf")
+
+    before = _temp_pdfs()
+
+    with patch(
+        "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
+        return_value=_FakeResponse(),
+    ), patch(
+        "gpt_researcher.scraper.pymupdf.pymupdf.PyMuPDFLoader"
+    ) as mock_loader:
+        mock_loader.return_value.load.side_effect = RuntimeError("corrupt PDF")
+
+        content, images, title = scraper.scrape()
+
+    # Broad except still yields the empty-result contract...
+    assert (content, images, title) == ("", [], "")
+    # ...but no new *.pdf temp file is left behind.
+    leaked = _temp_pdfs() - before
+    assert not leaked, f"PyMuPDFScraper leaked temp file(s): {leaked}"


### PR DESCRIPTION
## Summary

- `PyMuPDFScraper.scrape` downloads a remote PDF into a `NamedTemporaryFile(delete=False, suffix=".pdf")` and then loads it with `PyMuPDFLoader`. It called `os.remove(temp_filename)` **only on the success path**.
- User-facing impact: every time `PyMuPDFLoader.load()` raises (malformed / partial / truncated PDF, common with flaky downloads), the broad `except` swallows the error and the downloaded temp `.pdf` is left behind in the temp dir. Over a long run that's an unbounded disk leak.

## Motivation

The fix wraps the load in `try/finally` so the temp file is removed whether or not loading succeeds (the `os.remove` itself is guarded with `except OSError` so cleanup can't mask the real error). The empty-result contract `("", [], "")` on failure is unchanged.

## Verification

- `python -m pytest tests/test_pymupdf_tempfile_cleanup.py -q` — 1 passed.

## Real behavior proof

**Regression test** `tests/test_pymupdf_tempfile_cleanup.py` mocks `requests.get` to return PDF bytes and `PyMuPDFLoader.load` to raise `RuntimeError("corrupt PDF")`, then asserts no new `*.pdf` appears in the temp dir.

Without the fix:
```
FAILED tests/test_pymupdf_tempfile_cleanup.py::test_tempfile_removed_when_loader_raises
1 failed
```
(a leaked temp file remains)

With the fix:
```
tests/test_pymupdf_tempfile_cleanup.py .                                 [100%]
1 passed
```

## Scope / risk

- Touches only `gpt_researcher/scraper/pymupdf/pymupdf.py` (the URL download branch) + a new test.
- Local-file branch (no temp file) and the empty-result error contract are unchanged.