### PR TITLE
fix(deep-research): don't drop all context when newest item exceeds word limit

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -32,7 +32,12 @@ def trim_context_to_word_limit(context_list: List[str], max_words: int = MAX_CON
             trimmed_context.insert(0, item)  # Insert at start to maintain original order
             total_words += words
         else:
-            break
+            # Skip this item but keep scanning: a single oversized entry (often
+            # the most recent one) must not drop every smaller item that would
+            # still fit. Stop only once the budget is exhausted.
+            if total_words >= max_words:
+                break
+            continue
 
     return trimmed_context
 

--- a/tests/test_trim_context_word_limit.py
+++ b/tests/test_trim_context_word_limit.py
@@ -1,0 +1,33 @@
+"""Regression tests for trim_context_to_word_limit.
+
+The function keeps the most recent context items within a word budget. The old
+implementation ``break``ed on the first item that didn't fit. When the most
+recent item alone exceeded the budget, that ``break`` fired on the first
+iteration and discarded the ENTIRE context list -- including smaller, older
+items that would have fit comfortably. The fix skips an oversized item and
+keeps scanning, stopping only once the budget is actually exhausted.
+"""
+
+from gpt_researcher.skills.deep_research import trim_context_to_word_limit
+
+
+def test_oversized_recent_item_does_not_drop_smaller_older_items():
+    items = ["small one", "small two", "x " * 5000]  # newest is huge
+    out = trim_context_to_word_limit(items, max_words=100)
+    # The two small items must survive even though the newest is oversized.
+    assert "small one" in out
+    assert "small two" in out
+    assert ("x " * 5000) not in out
+
+
+def test_items_within_budget_all_kept_in_order():
+    items = ["a b", "c d", "e f"]
+    out = trim_context_to_word_limit(items, max_words=100)
+    assert out == ["a b", "c d", "e f"]
+
+
+def test_budget_stops_once_exhausted():
+    # Each item is 50 words; budget 100 -> only the two most recent fit.
+    items = ["w " * 50, "x " * 50, "y " * 50, "z " * 50]
+    out = trim_context_to_word_limit(items, max_words=100)
+    assert out == ["y " * 50, "z " * 50]


### PR DESCRIPTION
## Summary

- `trim_context_to_word_limit` keeps the most recent context items within a word budget. It iterated newest-first and `break`ed on the first item that didn't fit.
- User-facing impact: when the **most recent** context item alone exceeds `max_words` (a long scraped page / big learning), the `break` fires on the *first* iteration and discards the **entire** context list — including smaller, older items that would have fit comfortably. Deep research then proceeds with zero context for that step.

## Motivation

Replace the unconditional `break` with: skip an oversized item and keep scanning; `break` only once the budget is actually exhausted. Smaller items still get included even if a newer item was too big.

## Verification

- `python -m pytest tests/test_trim_context_word_limit.py -q` — 3 passed.

## Real behavior proof

**Repro (old code):**
```
items = ['small one', 'small two', 'x '*5000]   # newest is huge
trim_context_to_word_limit(items, max_words=100)  ->  []   # everything dropped
```

**Regression test** `tests/test_trim_context_word_limit.py` asserts the two small items survive when the newest item is oversized. It FAILS without the fix:
```
FAILED tests/test_trim_context_word_limit.py::test_oversized_recent_item_does_not_drop_smaller_older_items
1 failed, 2 passed
```
and passes with it:
```
3 passed
```
The other two tests confirm in-budget items are all kept in order and the budget still stops once exhausted.

## Scope / risk

- Touches only `trim_context_to_word_limit` in `gpt_researcher/skills/deep_research.py` + a new test.
- In-budget behavior and ordering are unchanged (covered by tests).