### PR TITLE
fix(retriever): handle errors and missing keys in BoChaSearch

### DIFF
--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -40,19 +40,32 @@ class BoChaSearch():
             "count": max_results
         }
 
-        response = requests.post(url, headers=headers, json=data)
+        try:
+            response = requests.post(url, headers=headers, json=data, timeout=10)
+            response.raise_for_status()
+            json_response = response.json()
+        except (requests.RequestException, ValueError) as e:
+            logging.getLogger(__name__).warning(
+                f"Error: {e}. Failed fetching sources. Resulting in empty response."
+            )
+            return []
 
-        json_response = response.json()
-        results = json_response["data"]["webPages"]["value"]
+        # The BoCha response shape is data.webPages.value; any of these may be
+        # missing on an error/empty payload, so walk it defensively rather than
+        # KeyError-ing the whole research run.
+        results = (
+            ((json_response or {}).get("data") or {}).get("webPages") or {}
+        ).get("value") or []
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
-            search_result = {
-                "title": result["name"],
-                "href": result["url"],
-                "body": result["snippet"],
-            }
-            search_results.append(search_result)
+            search_results.append(
+                {
+                    "title": result.get("name", ""),
+                    "href": result.get("url", ""),
+                    "body": result.get("snippet", ""),
+                }
+            )
 
         return search_results

--- a/tests/test_bocha_error_handling.py
+++ b/tests/test_bocha_error_handling.py
@@ -1,0 +1,69 @@
+"""Regression tests for BoChaSearch robustness.
+
+Unlike every sibling retriever (which returns ``[]`` and uses ``.get()`` on a
+bad/empty payload), BoChaSearch indexed ``json_response["data"]["webPages"]
+["value"]`` directly and had no error handling. A non-200 response, a body
+that doesn't decode as JSON, or a payload missing those keys crashed the whole
+research run with an unhandled ``KeyError`` / ``JSONDecodeError``.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_search():
+    with patch.dict(os.environ, {"BOCHA_API_KEY": "test-key"}):
+        from gpt_researcher.retrievers.bocha.bocha import BoChaSearch
+
+        return BoChaSearch("test query")
+
+
+def test_missing_keys_returns_empty_list():
+    search = _make_search()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"unexpected": "shape"}  # no data.webPages.value
+
+    with patch(
+        "gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp
+    ):
+        assert search.search() == []
+
+
+def test_request_exception_returns_empty_list():
+    import requests
+
+    search = _make_search()
+    with patch(
+        "gpt_researcher.retrievers.bocha.bocha.requests.post",
+        side_effect=requests.RequestException("boom"),
+    ):
+        assert search.search() == []
+
+
+def test_valid_payload_is_normalized():
+    search = _make_search()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "data": {
+            "webPages": {
+                "value": [
+                    {"name": "T", "url": "https://e.com", "snippet": "B"},
+                    {"name": "T2", "url": "https://e2.com"},  # missing snippet
+                ]
+            }
+        }
+    }
+
+    with patch(
+        "gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp
+    ):
+        results = search.search()
+
+    assert results == [
+        {"title": "T", "href": "https://e.com", "body": "B"},
+        {"title": "T2", "href": "https://e2.com", "body": ""},
+    ]


### PR DESCRIPTION
## Summary

- `BoChaSearch.search` indexed `json_response["data"]["webPages"]["value"]` directly and had **no** error handling around the HTTP call or the response shape.
- User-facing impact: a non-200 response (rate limit / bad key / server error), a body that doesn't decode as JSON, or a payload missing those keys raises an unhandled `KeyError` / `JSONDecodeError` that propagates out of `search()` and crashes the whole research run. Every other retriever in the repo (serper, searchapi, semantic_scholar, etc.) degrades to `[]` on failure.

## Motivation

Make BoCha consistent with its sibling retrievers: add `timeout` + `raise_for_status()`, catch `requests.RequestException` / `ValueError` (JSON decode) and return `[]`, walk `data.webPages.value` defensively, and use `result.get(...)` so an item missing a field doesn't crash the loop.

> Note: a prior community PR (#1722) raised the same issue but was closed without a maintainer review and shipped no test. This version adds full regression coverage.

## Verification

- `python -m pytest tests/test_bocha_error_handling.py -q` — 3 passed.

## Real behavior proof

**Regression tests** `tests/test_bocha_error_handling.py` cover (1) a payload missing the expected keys, (2) a `requests.RequestException`, and (3) a valid payload (including a result missing `snippet`). All three FAIL without the fix:
```
FAILED tests/test_bocha_error_handling.py::test_missing_keys_returns_empty_list
FAILED tests/test_bocha_error_handling.py::test_request_exception_returns_empty_list
FAILED tests/test_bocha_error_handling.py::test_valid_payload_is_normalized
3 failed
```
and pass with it:
```
3 passed
```

## Scope / risk

- Touches only `gpt_researcher/retrievers/bocha/bocha.py` + a new test.
- The happy-path output shape (`{title, href, body}`) is unchanged for well-formed responses; only error/edge behavior is hardened.