### PR TITLE
fix(retriever): guard XquikSearch against null author/tweets/text fields

### DIFF
--- a/gpt_researcher/retrievers/xquik/xquik.py
+++ b/gpt_researcher/retrievers/xquik/xquik.py
@@ -68,14 +68,19 @@ class XquikSearch:
         with urllib.request.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read().decode("utf-8"))
 
-        tweets = data.get("tweets", [])
+        # Use `or` fallbacks so an explicit JSON null ("tweets": null,
+        # "author": null, "text": null) does not slip a None past `.get()`'s
+        # default and crash slicing / attribute access below — which the
+        # broad except in search() would swallow, silently dropping every
+        # result. Mirrors the sibling GetXAPI retriever.
+        tweets = data.get("tweets") or []
         search_results = []
 
         for tweet in tweets[:max_results]:
-            author = tweet.get("author", {})
-            username = author.get("username", "unknown")
-            text = tweet.get("text", "")
-            tweet_id = tweet.get("id", "")
+            author = tweet.get("author") or {}
+            username = author.get("username") or "unknown"
+            text = tweet.get("text") or ""
+            tweet_id = tweet.get("id") or ""
 
             likes = tweet.get("likeCount", 0)
             retweets = tweet.get("retweetCount", 0)

--- a/tests/test_xquik_null_fields.py
+++ b/tests/test_xquik_null_fields.py
@@ -1,0 +1,62 @@
+"""Regression tests for XquikSearch null-field handling.
+
+The Xquik API can return an explicit JSON ``null`` for ``tweets`` (no
+results) or for a tweet's ``author`` / ``text`` fields. ``dict.get(key,
+default)`` only substitutes the default when the key is *absent*, not when
+its value is ``None`` — so ``tweet.get("author", {})`` returns ``None`` for
+``{"author": null}``. The subsequent ``author.get("username")`` /
+``text[:120]`` then raise, and the broad ``except`` in ``search()`` swallows
+the error and silently drops *every* result.
+"""
+
+import io
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from gpt_researcher.retrievers.xquik.xquik import XquikSearch
+
+
+class TestXquikNullFields(unittest.TestCase):
+    def setUp(self):
+        os.environ["XQUIK_API_KEY"] = "test-key"
+
+    def _run_with_payload(self, payload):
+        raw = json.dumps(payload).encode("utf-8")
+
+        class FakeResp:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def read(self_inner):
+                return raw
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            return XquikSearch("test query").search(max_results=5)
+
+    def test_null_author_still_returns_result(self):
+        results = self._run_with_payload(
+            {"tweets": [{"author": None, "text": "hello world", "id": "1"}]}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIn("@unknown", results[0]["title"])
+        self.assertIn("hello world", results[0]["body"])
+
+    def test_null_text_and_id_do_not_crash(self):
+        results = self._run_with_payload(
+            {"tweets": [{"author": {"username": "bob"}, "text": None, "id": None}]}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIn("@bob", results[0]["title"])
+
+    def test_null_tweets_returns_empty_list(self):
+        results = self._run_with_payload({"tweets": None})
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Guard `XquikSearch._search_tweets` against explicit JSON `null` values for `tweets`, `author`, `text`, and `id`.
- User-facing impact: X/Twitter searches that previously returned **zero** results due to a swallowed crash now return the real tweets.

## Motivation
The Xquik API can send an explicit `null` for `tweets` (no results) or for a tweet's `author` / `text` fields. `dict.get(key, default)` only substitutes the default when the key is **absent**, not when its value is `None`. So `tweet.get("author", {})` returns `None` for `{"author": null}`, and the following `author.get("username")` (and `text[:120]`) raise `AttributeError` / `TypeError`. That exception is caught by the broad `except` in `search()`, which logs and returns `[]` — silently dropping **every** result for the whole query.

The sibling `GetXAPISearch` retriever already uses `or {}` / `or ""` fallbacks; this brings Xquik in line.

## Fix
Replace `.get(key, default)` with `.get(key) or default` for the null-prone fields, so an explicit `null` falls back correctly.

## Verification
- `python -m pytest tests/test_xquik_null_fields.py` — **3 passed**.
- Verified the new tests FAIL without the change:
  - `2 failed, 1 passed` before the fix (`test_null_author_still_returns_result`, `test_null_text_and_id_do_not_crash` crash on the `None`).
  - `3 passed` after the fix.
- No unrelated files touched (retriever + one new test).
