### PR TITLE
fix(scraper): use session for PDF downloads to respect User-Agent

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -41,15 +41,16 @@ class PyMuPDFScraper:
         """
         try:
             if self.is_url():
+                http = self.session or requests
                 try:
-                    response = requests.get(self.link, timeout=(5, 30), stream=True)
+                    response = http.get(self.link, timeout=(5, 30), stream=True)
                     response.raise_for_status()
                 except requests.exceptions.SSLError:
                     import logging
                     logging.getLogger(__name__).warning(
                         f"SSL verification failed for {self.link}, retrying without verification"
                     )
-                    response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
+                    response = http.get(self.link, timeout=(5, 30), stream=True, verify=False)
                     response.raise_for_status()
 
                 with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:


### PR DESCRIPTION
## Summary

Fixes #1847 — `PyMuPDFScraper` ignores the configured `requests.Session` (and its User-Agent header) when downloading PDFs, causing 403 errors on sites that enforce UA identification (e.g. SEC EDGAR).

## Problem

`Scraper` builds a session with the configured User-Agent and passes it to `PyMuPDFScraper`, but the scraper uses bare `requests.get()` instead of `self.session.get()`. All PDF downloads go out with the default `python-requests/2.x` UA.

## Fix

Use `self.session` when available, fall back to bare `requests` when no session is passed:

```python
http = self.session or requests
response = http.get(self.link, timeout=(5, 30), stream=True)
```

Applied to both the normal request and the SSL-fallback retry path. No behavioral change when `session=None`.