### PR TITLE
feat(retrievers): add Caesar web search retriever

### DIFF
--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -35,6 +35,7 @@ Thanks to our community, we have integrated the following web search engines:
 - [Arxiv](https://info.arxiv.org/help/api/index.html) - Env: `RETRIEVER=arxiv`
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
+- [Caesar](https://docs.trycaesar.com) - Env: `RETRIEVER=caesar` (free, no API key required)
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
 
 ## Custom Retrievers

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -35,7 +35,7 @@ Thanks to our community, we have integrated the following web search engines:
 - [Arxiv](https://info.arxiv.org/help/api/index.html) - Env: `RETRIEVER=arxiv`
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
-- [Caesar](https://docs.trycaesar.com) - Env: `RETRIEVER=caesar` (free, no API key required)
+- [Caesar](https://docs.trycaesar.com) - Env: `RETRIEVER=caesar`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
 
 ## Custom Retrievers

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -27,6 +27,7 @@ def get_retriever(retriever: str):
         - tavily: Tavily search API
         - exa: Exa search
         - crw: fastCRW search (Firecrawl-compatible web scraper)
+        - caesar: Caesar agentic web search (free, no API key required)
         - semantic_scholar: Semantic Scholar academic search
         - pubmed_central: PubMed Central medical literature
         - openalex: OpenAlex scholarly works catalog
@@ -91,6 +92,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import CRWRetriever
 
             return CRWRetriever
+        case "caesar":
+            from gpt_researcher.retrievers import CaesarSearch
+
+            return CaesarSearch
         case "semantic_scholar":
             from gpt_researcher.retrievers import SemanticScholarSearch
 

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -14,6 +14,7 @@ from .tavily.tavily_search import TavilySearch
 from .groundroute.groundroute import GroundRouteSearch
 from .exa.exa import ExaSearch
 from .crw.crw import CRWRetriever
+from .caesar.caesar import CaesarSearch
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
@@ -36,6 +37,7 @@ __all__ = [
     "PubMedCentralSearch",
     "ExaSearch",
     "CRWRetriever",
+    "CaesarSearch",
     "MCPRetriever",
     "BoChaSearch",
     "XquikSearch",

--- a/gpt_researcher/retrievers/caesar/caesar.py
+++ b/gpt_researcher/retrievers/caesar/caesar.py
@@ -86,6 +86,8 @@ class CaesarSearch:
             "query": query,
             "max_results": max_results,
         }
+        if self.query_domains:
+            data["source_policy"] = {"include_domains": self.query_domains}
 
         response = requests.post(
             f"{self.base_url}/v1/search",
@@ -96,6 +98,25 @@ class CaesarSearch:
         # Raises a HTTPError if the HTTP request returned an unsuccessful status code
         response.raise_for_status()
         return response.json()
+
+    @staticmethod
+    def _body(obj: dict) -> str:
+        """
+        Builds the result body.
+
+        Caesar's `snippet` is the page's meta description, so it is identical for
+        every query that surfaces the document. Its `passages` are the spans Caesar
+        selected for this query, so they carry the text that actually answers it.
+        Prefer those, and fall back to the flat fields when a result has none.
+        """
+        parts = []
+        for passage in obj.get("passages") or []:
+            text = passage.get("text") if isinstance(passage, dict) else passage
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        if parts:
+            return "\n\n".join(parts)
+        return obj.get("snippet") or obj.get("content") or obj.get("passage") or ""
 
     def search(self, max_results=10):
         """
@@ -115,13 +136,7 @@ class CaesarSearch:
                 href = obj.get("url") or obj.get("canonical_url") or obj.get("source_url")
                 if not href:
                     continue
-                body = (
-                    obj.get("snippet")
-                    or obj.get("content")
-                    or obj.get("passage")
-                    or ""
-                )
-                search_response.append({"href": href, "body": body})
+                search_response.append({"href": href, "body": self._body(obj)})
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/gpt_researcher/retrievers/caesar/caesar.py
+++ b/gpt_researcher/retrievers/caesar/caesar.py
@@ -1,0 +1,126 @@
+"""Caesar API search retriever for GPT Researcher.
+
+This module provides the CaesarSearch class for performing web searches
+using Caesar, a free agentic web-search API. Caesar works anonymously with
+no API key; an optional CAESAR_API_KEY raises rate limits for partners.
+
+Docs: https://docs.trycaesar.com
+"""
+
+import json
+import os
+
+import requests
+
+
+class CaesarSearch:
+    """
+    Caesar API Retriever
+    """
+
+    def __init__(self, query, headers=None, topic="general", query_domains=None):
+        """
+        Initializes the CaesarSearch object.
+
+        Args:
+            query (str): The search query string.
+            headers (dict, optional): Additional headers to include in the request. Defaults to None.
+            topic (str, optional): The topic for the search. Defaults to "general".
+            query_domains (list, optional): List of domains to include in the search. Defaults to None.
+        """
+        input_headers = headers or {}
+        self.query = query
+        self.topic = topic
+        self.base_url = self.get_base_url(input_headers)
+        self.api_key = self.get_api_key(input_headers)
+        self.headers = {
+            "Content-Type": "application/json",
+        }
+        # Caesar works fully anonymously; only attach a Bearer token when a
+        # partner key is explicitly provided.
+        if self.api_key:
+            self.headers["Authorization"] = f"Bearer {self.api_key}"
+        self.query_domains = query_domains or None
+
+    def get_api_key(self, headers):
+        """
+        Gets the optional Caesar API key.
+
+        Caesar works without any key. A key is only used to raise rate limits
+        for partners, so a missing key is not an error.
+        Args:
+            headers (dict): The headers passed to the retriever.
+        Returns:
+            The API key string, or "" when running anonymously.
+        """
+        api_key = headers.get("caesar_api_key")
+        if not api_key:
+            api_key = os.environ.get("CAESAR_API_KEY", "")
+        return api_key
+
+    def get_base_url(self, headers):
+        """
+        Gets the Caesar base URL, allowing overrides.
+
+        Defaults to the public API at https://alpha.api.trycaesar.com. Override
+        with the CAESAR_API_URL environment variable (or the caesar_api_url
+        header).
+        Args:
+            headers (dict): The headers passed to the retriever.
+        Returns:
+            The base URL (without a trailing slash).
+        """
+        base_url = headers.get("caesar_api_url") or os.environ.get(
+            "CAESAR_API_URL", "https://alpha.api.trycaesar.com"
+        )
+        return base_url.rstrip("/")
+
+    def _search(self, query: str, max_results: int = 10) -> dict:
+        """
+        Internal search method to send the request to the API.
+        """
+
+        data = {
+            "query": query,
+            "max_results": max_results,
+        }
+
+        response = requests.post(
+            f"{self.base_url}/v1/search",
+            data=json.dumps(data),
+            headers=self.headers,
+            timeout=100,
+        )
+        # Raises a HTTPError if the HTTP request returned an unsuccessful status code
+        response.raise_for_status()
+        return response.json()
+
+    def search(self, max_results=10):
+        """
+        Searches the query
+        Returns:
+
+        """
+        try:
+            # Search the query
+            results = self._search(self.query, max_results=max_results)
+            sources = results.get("results", [])
+            if not sources:
+                raise Exception("No results found with Caesar API search.")
+            # Normalize the results to GPT Researcher's {href, body} shape.
+            search_response = []
+            for obj in sources:
+                href = obj.get("url") or obj.get("canonical_url") or obj.get("source_url")
+                if not href:
+                    continue
+                body = (
+                    obj.get("snippet")
+                    or obj.get("content")
+                    or obj.get("passage")
+                    or ""
+                )
+                search_response.append({"href": href, "body": body})
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
+            search_response = []
+        return search_response

--- a/gpt_researcher/retrievers/caesar/caesar.py
+++ b/gpt_researcher/retrievers/caesar/caesar.py
@@ -1,8 +1,8 @@
 """Caesar API search retriever for GPT Researcher.
 
 This module provides the CaesarSearch class for performing web searches
-using Caesar, a free agentic web-search API. Caesar works anonymously with
-no API key; an optional CAESAR_API_KEY raises rate limits for partners.
+using Caesar, an agentic web-search API. Caesar requires an API key, read
+from the CAESAR_API_KEY environment variable.
 
 Docs: https://docs.trycaesar.com
 """
@@ -35,27 +35,29 @@ class CaesarSearch:
         self.api_key = self.get_api_key(input_headers)
         self.headers = {
             "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
         }
-        # Caesar works fully anonymously; only attach a Bearer token when a
-        # partner key is explicitly provided.
-        if self.api_key:
-            self.headers["Authorization"] = f"Bearer {self.api_key}"
         self.query_domains = query_domains or None
 
     def get_api_key(self, headers):
         """
-        Gets the optional Caesar API key.
+        Gets the Caesar API key.
 
-        Caesar works without any key. A key is only used to raise rate limits
-        for partners, so a missing key is not an error.
+        Caesar requires an API key on every request.
         Args:
             headers (dict): The headers passed to the retriever.
         Returns:
-            The API key string, or "" when running anonymously.
+            The API key string.
         """
         api_key = headers.get("caesar_api_key")
         if not api_key:
-            api_key = os.environ.get("CAESAR_API_KEY", "")
+            try:
+                api_key = os.environ["CAESAR_API_KEY"]
+            except KeyError:
+                raise Exception(
+                    "Caesar API key not found. Please set the CAESAR_API_KEY environment variable. "
+                    "You can obtain your key from https://app.trycaesar.com"
+                )
         return api_key
 
     def get_base_url(self, headers):

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -76,6 +76,7 @@ VALID_RETRIEVERS = [
     "pubmed_central",
     "exa",
     "crw",
+    "caesar",
     "mcp",
     "xquik",
     "openalex",

--- a/tests/test_caesar_retriever.py
+++ b/tests/test_caesar_retriever.py
@@ -1,0 +1,89 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.caesar.caesar import CaesarSearch
+
+
+class TestCaesarSearch(unittest.TestCase):
+    def test_works_without_api_key(self):
+        # Caesar is keyless: constructing with no env key must not raise and
+        # must not attach an Authorization header.
+        with patch.dict(os.environ, {}, clear=True):
+            retriever = CaesarSearch("test query")
+        self.assertEqual(retriever.api_key, "")
+        self.assertNotIn("Authorization", retriever.headers)
+
+    def test_api_key_adds_bearer_header(self):
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
+            retriever = CaesarSearch("test query")
+        self.assertEqual(retriever.headers.get("Authorization"), "Bearer sk_live_test")
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_search_normalizes_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com/one",
+                    "title": "One",
+                    "snippet": "First snippet",
+                    "score": 0.91,
+                },
+                {
+                    "url": "https://example.com/two",
+                    "title": "Two",
+                    "snippet": "Second snippet",
+                    "score": 0.84,
+                },
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            results = CaesarSearch("test query").search(max_results=2)
+
+        called_url = mock_post.call_args.args[0]
+        self.assertEqual(called_url, "https://alpha.api.trycaesar.com/v1/search")
+        self.assertEqual(
+            results,
+            [
+                {"href": "https://example.com/one", "body": "First snippet"},
+                {"href": "https://example.com/two", "body": "Second snippet"},
+            ],
+        )
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_search_falls_back_across_field_names(self, mock_post):
+        # url may arrive as canonical_url/source_url; snippet as content/passage.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"canonical_url": "https://example.com/c", "content": "body via content"},
+                {"source_url": "https://example.com/s", "passage": "body via passage"},
+                {"title": "no url, dropped"},
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            results = CaesarSearch("test query").search(max_results=5)
+
+        self.assertEqual(
+            results,
+            [
+                {"href": "https://example.com/c", "body": "body via content"},
+                {"href": "https://example.com/s", "body": "body via passage"},
+            ],
+        )
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_search_returns_empty_on_error(self, mock_post):
+        mock_post.side_effect = Exception("network down")
+        with patch.dict(os.environ, {}, clear=True):
+            results = CaesarSearch("test query").search()
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_caesar_retriever.py
+++ b/tests/test_caesar_retriever.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -74,6 +75,73 @@ class TestCaesarSearch(unittest.TestCase):
                 {"href": "https://example.com/s", "body": "body via passage"},
             ],
         )
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_search_prefers_query_selected_passages(self, mock_post):
+        # `snippet` is the page's meta description, identical for every query that
+        # surfaces the document. `passages` are selected for this query.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://tokio.rs/blog/2019-10-scheduler",
+                    "snippet": "A blog about the Tokio runtime.",
+                    "passages": [
+                        {"text": "Work stealing balances load across worker threads."},
+                        {"text": "The new scheduler avoids the atomic increment in wake_by_ref."},
+                    ],
+                }
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
+            results = CaesarSearch("work stealing").search(max_results=1)
+
+        self.assertEqual(
+            results[0]["body"],
+            "Work stealing balances load across worker threads.\n\n"
+            "The new scheduler avoids the atomic increment in wake_by_ref.",
+        )
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_search_ignores_blank_passages(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"url": "https://example.com/a", "snippet": "fallback", "passages": [{"text": "  "}]}
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
+            results = CaesarSearch("q").search(max_results=1)
+
+        self.assertEqual(results[0]["body"], "fallback")
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_query_domains_scope_the_search(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [{"url": "https://tokio.rs/x", "snippet": "s"}]}
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
+            CaesarSearch("q", query_domains=["tokio.rs"]).search(max_results=1)
+
+        body = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertEqual(body["source_policy"], {"include_domains": ["tokio.rs"]})
+
+    @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
+    def test_no_source_policy_without_query_domains(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [{"url": "https://example.com/a", "snippet": "s"}]}
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
+            CaesarSearch("q").search(max_results=1)
+
+        body = json.loads(mock_post.call_args.kwargs["data"])
+        self.assertNotIn("source_policy", body)
 
     @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
     def test_search_returns_empty_on_error(self, mock_post):

--- a/tests/test_caesar_retriever.py
+++ b/tests/test_caesar_retriever.py
@@ -6,13 +6,11 @@ from gpt_researcher.retrievers.caesar.caesar import CaesarSearch
 
 
 class TestCaesarSearch(unittest.TestCase):
-    def test_works_without_api_key(self):
-        # Caesar is keyless: constructing with no env key must not raise and
-        # must not attach an Authorization header.
+    def test_missing_api_key_raises(self):
+        # Caesar requires an API key: constructing with no env key must raise.
         with patch.dict(os.environ, {}, clear=True):
-            retriever = CaesarSearch("test query")
-        self.assertEqual(retriever.api_key, "")
-        self.assertNotIn("Authorization", retriever.headers)
+            with self.assertRaises(Exception):
+                CaesarSearch("test query")
 
     def test_api_key_adds_bearer_header(self):
         with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
@@ -40,7 +38,7 @@ class TestCaesarSearch(unittest.TestCase):
         }
         mock_post.return_value = mock_response
 
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
             results = CaesarSearch("test query").search(max_results=2)
 
         called_url = mock_post.call_args.args[0]
@@ -66,7 +64,7 @@ class TestCaesarSearch(unittest.TestCase):
         }
         mock_post.return_value = mock_response
 
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
             results = CaesarSearch("test query").search(max_results=5)
 
         self.assertEqual(
@@ -80,7 +78,7 @@ class TestCaesarSearch(unittest.TestCase):
     @patch("gpt_researcher.retrievers.caesar.caesar.requests.post")
     def test_search_returns_empty_on_error(self, mock_post):
         mock_post.side_effect = Exception("network down")
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_test"}, clear=True):
             results = CaesarSearch("test query").search()
         self.assertEqual(results, [])
 


### PR DESCRIPTION
## What

Adds **Caesar** as a new web-search retriever, selectable via `RETRIEVER=caesar`, alongside the existing providers (Tavily, Exa, Serper, Brave, fastCRW, and others).

[Caesar](https://docs.trycaesar.com) is an agentic web-search API. The retriever POSTs to its `/v1/search` endpoint and maps results into GPT Researcher's standard `{href, body}` shape.

**Disclosure:** I work on GTM for Caesar, so this is an affiliated contribution.

## Why

Caesar returns the passages it selected **for your query** inline with each search result, so the `body` of each `{href, body}` carries the text that addresses the query rather than the page's marketing blurb.

Its `snippet` field is the page's meta description, identical for every query that surfaces the document. Its `passages` are query-conditioned. Same document, two different queries, zero overlapping passages:

```
tokio.rs/blog/2019-10-scheduler

  q: "work stealing balancing load across worker threads"
     -> "That notified processor will steal half the tasks in the batch, and in turn notify..."

  q: "atomic reference counting overhead in the old scheduler"
     -> "There are many outstanding references to the task structure: the scheduler and each waker..."
```

So the retriever builds `body` from the passages and falls back to the flat fields when a result has none. For a research agent that reads `body` before deciding what to scrape, that is the difference between a meta description and roughly 1,200 characters of relevant text per source.

An honest note on history: when I opened this PR the rationale was that Caesar was **keyless**. Caesar removed the anonymous tier on 2026-07-07, so that rationale is gone and a `CAESAR_API_KEY` is required, created from an account at https://app.trycaesar.com. What replaced it is the argument above, which I think is the better one.

## Changes

- Add the `CaesarSearch` retriever under `gpt_researcher/retrievers/caesar/`.
- Register `caesar` in the retriever factory (`actions/retriever.py`) and in `VALID_RETRIEVERS` (`retrievers/utils.py`), and export it from `retrievers/__init__.py`.
- Document `RETRIEVER=caesar` in the search-engines guide.
- Add `tests/test_caesar_retriever.py`.

All changes are additive. No existing retriever is modified.

## Implementation notes

- The key requirement mirrors the **exa** retriever: `get_api_key` raises a clear error naming `CAESAR_API_KEY` and pointing at where to obtain it. The `Authorization: Bearer` header is always sent.
- `body` prefers `passages`, then falls back across `snippet`, `content`, and `passage`. `href` falls back across `url`, `canonical_url`, and `source_url`. Results with no URL are dropped, mirroring how `brave` normalizes.
- **`query_domains` is now honored.** It maps to Caesar's `source_policy.include_domains`. The earlier revision of this PR accepted `query_domains` and silently ignored it, so a domain-scoped report was quietly searching the whole web. `exa` and `tavily` both pass `include_domains`, and now so does this.
- `CAESAR_API_URL` (or a `caesar_api_url` header) can override the base URL, following the same override pattern `crw` uses.

One tradeoff, stated plainly: preferring passages makes each `body` roughly 4x larger than a meta description, which costs more tokens up front. For this project I think that is the right trade, since a better `body` is exactly what improves source selection before scraping. It is one method (`_body`) if you would rather keep bodies short.

## Testing

`tests/test_caesar_retriever.py` covers: a missing `CAESAR_API_KEY` raises, a present key produces the `Bearer` header, a header-supplied key is honored, passage preference over the meta description, blank-passage handling, the field-name fallbacks, `query_domains` producing a `source_policy`, its absence omitting one, and the empty-on-error path.

```
$ python -m unittest tests.test_caesar_retriever
Ran 9 tests in 0.004s

OK
```

Live, against a keyed account (the keyless transcript in the original description no longer reproduces):

```
$ python -c "...CaesarSearch('why did tokio avoid the atomic increment in wake_by_ref').search(max_results=3)"
 1208 chars  https://tokio.rs/blog/2019-10-scheduler
  965 chars  https://docs.rs/tokio/0.2.9/src/tokio/task/waker.rs.html
   33 chars  https://github.com/tokio-rs/tokio/issues/1388
body answers the question: True
```

And domain scoping, which now actually scopes:

```
query_domains=["tokio.rs"]  -> hosts: ['tokio.rs']
unscoped                    -> hosts: ['en.wikipedia.org', 'github.com', 'hackage.haskell.org', ...]
```

Happy to adjust naming or anything else to fit your conventions.
