### PR TITLE
fix(researcher): don't treat search snippets as prefetched full content

### DIFF
--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -790,7 +790,13 @@ class ResearchConductor:
                 # Separate results that already have content from those needing scraping
                 for result in search_results:
                     url = result.get("href") or result.get("url")
-                    raw_content = result.get("raw_content") or result.get("body")
+                    # Only the ``raw_content`` key carries genuine full-page text
+                    # (pubmed_central, tavily-with-raw-content, custom). The ``body``
+                    # key holds search-result *snippets* (e.g. searx maps SearXNG's
+                    # ``content`` field to ``body``); those are typically 150-400 chars,
+                    # so treating them as prefetched content would pass the length guard
+                    # below and skip scraping entirely (see issue #1846).
+                    raw_content = result.get("raw_content")
                     if url and raw_content and len(raw_content) > 100:
                         # Retriever already fetched full content (e.g. PubMed Central)
                         prefetched_content.append({

--- a/tests/test_snippet_scraping.py
+++ b/tests/test_snippet_scraping.py
@@ -1,0 +1,93 @@
+"""Regression tests for snippet-vs-prefetched-content classification.
+
+Snippet retrievers (e.g. searx) return short search-result snippets under
+the ``body`` key -- searx maps SearXNG's ``content`` field to ``body``.
+These snippets are typically 150-400 chars.
+
+``_search_relevant_source_urls`` used to treat any result with
+``raw_content`` OR ``body`` longer than 100 chars as *prefetched full
+content* and skip scraping entirely. Because snippets easily exceed 100
+chars, virtually every snippet-retriever result was mistaken for full page
+content, so the scraper was essentially never invoked and report quality
+collapsed (see issue #1846).
+
+The fix keys prefetched-content detection on ``raw_content`` only, so
+``body`` snippets flow through to real scraping while genuine full-text
+pass-through (pubmed_central, tavily-with-raw-content) is unchanged.
+"""
+
+import asyncio
+import unittest
+
+from gpt_researcher.skills.researcher import ResearchConductor
+
+
+class _FakeRetriever:
+    """Minimal retriever returning a fixed result set."""
+
+    _results = []
+
+    def __init__(self, query, query_domains=None):
+        self.query = query
+
+    def search(self, max_results=5):
+        return type(self)._results
+
+
+class _FakeResearcher:
+    """Minimal researcher stub for ResearchConductor."""
+
+    def __init__(self, retriever_cls):
+        self.retrievers = [retriever_cls]
+        self.visited_urls = set()
+        self.verbose = False
+        self.websocket = None
+        self.research_sources = []
+
+        class _Cfg:
+            max_search_results_per_query = 5
+
+        self.cfg = _Cfg()
+
+    def add_research_sources(self, sources):
+        self.research_sources.extend(sources)
+
+
+def _run(retriever_cls):
+    researcher = _FakeResearcher(retriever_cls)
+    conductor = ResearchConductor(researcher)
+    return researcher, asyncio.run(
+        conductor._search_relevant_source_urls("q")
+    )
+
+
+class TestSnippetScraping(unittest.TestCase):
+    def test_body_snippet_flows_to_scraping(self):
+        """A >100-char ``body`` snippet must NOT be treated as prefetched."""
+        snippet = "x" * 250  # realistic snippet length, passes the old >100 guard
+
+        class R(_FakeRetriever):
+            _results = [{"href": "https://example.com/a", "body": snippet}]
+
+        researcher, (new_urls, prefetched) = _run(R)
+        self.assertEqual(new_urls, ["https://example.com/a"])
+        self.assertEqual(prefetched, [])
+        self.assertEqual(researcher.research_sources, [])
+
+    def test_raw_content_still_prefetched(self):
+        """Genuine ``raw_content`` full text is still passed through."""
+        full = "y" * 2000
+
+        class R(_FakeRetriever):
+            _results = [{"url": "https://pmc.example.com/b", "raw_content": full}]
+
+        researcher, (new_urls, prefetched) = _run(R)
+        self.assertEqual(new_urls, [])
+        self.assertEqual(len(prefetched), 1)
+        self.assertEqual(prefetched[0]["url"], "https://pmc.example.com/b")
+        self.assertEqual(prefetched[0]["raw_content"], full)
+        self.assertEqual(researcher.research_sources, [{"url": "https://pmc.example.com/b"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Snippet retrievers (searx, and anything returning search-result snippets under the `body` key) had their snippets mistaken for full page content, so URLs were never scraped.
- Prefetched-content detection now keys on `raw_content` only; `body` snippets flow through to real scraping.

## Motivation

Closes #1846.

In `_search_relevant_source_urls` the prefetched-content heuristic was:

```python
raw_content = result.get("raw_content") or result.get("body")
if url and raw_content and len(raw_content) > 100:
    # treat as already-fetched full content, skip scraping
```

The intent (per the code comment) is to pass through retrievers that genuinely return full text — those use the `raw_content` key (`pubmed_central`, tavily-with-raw-content, `custom`). But the `or result.get("body")` fallback also captured **snippet** retrievers: searx maps SearXNG's `content` field to `body`, and those snippets are typically 150–400 chars. They easily pass the `> 100` guard, so nearly every result was treated as prefetched → the scraper was essentially never invoked and context was built from concatenated snippets.

The fix drops the `body` fallback. The `> 100` length guard still applies to genuine `raw_content`, so PubMed-style full-text pass-through is unchanged.

## Verification

- `python -m pytest tests/test_snippet_scraping.py -v` — 2 passed.
- New regression test `test_body_snippet_flows_to_scraping` **fails without the fix** (a 250-char `body` snippet is wrongly classified as prefetched, so the URL never reaches `new_search_urls`):

```
tests/test_snippet_scraping.py::TestSnippetScraping::test_body_snippet_flows_to_scraping FAILED
AssertionError: Lists differ: [] != ['https://example.com/a']
```

  With the fix applied, both the snippet-flows-to-scraping and the raw_content-still-prefetched cases pass.
- Did NOT change: the `> 100` length guard, or the genuine `raw_content` pass-through path.
