### PR TITLE
fix(retriever): handle missing keys in SearchApiSearch results

### DIFF
--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -1,6 +1,7 @@
 # SearchApi Retriever
 
 # libraries
+import logging
 import os
 import requests
 import urllib.parse
@@ -60,25 +61,33 @@ class SearchApiSearch():
         try:
             response = requests.get(encoded_url, headers=headers, timeout=20)
             if response.status_code == 200:
-                search_results = response.json()
-                if search_results:
-                    results = search_results["organic_results"]
-                    results_processed = 0
-                    for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
-                        if results_processed >= max_results:
-                            break
-                        search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
-                        }
-                        search_response.append(search_result)
-                        results_processed += 1
+                search_results = response.json() or {}
+                # ``organic_results`` may be absent (e.g. no matches, an error
+                # payload, or a non-google engine response). Default to [] so a
+                # missing key does not raise KeyError and silently drop every
+                # result via the broad ``except`` below.
+                results = search_results.get("organic_results") or []
+                results_processed = 0
+                for result in results:
+                    href = result.get("link") or ""
+                    # skip youtube results
+                    if "youtube.com" in href:
+                        continue
+                    if results_processed >= max_results:
+                        break
+                    search_result = {
+                        "title": result.get("title") or "",
+                        "href": href,
+                        "body": result.get("snippet") or "",
+                    }
+                    search_response.append(search_result)
+                    results_processed += 1
         except Exception as e:
-            print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
+            logging.getLogger(__name__).warning(
+                "SearchApiSearch: failed fetching sources (%s). "
+                "Returning empty response.",
+                e,
+            )
             search_response = []
 
         return search_response

--- a/tests/test_searchapi_missing_keys.py
+++ b/tests/test_searchapi_missing_keys.py
@@ -1,0 +1,67 @@
+"""Regression tests for SearchApiSearch missing-key handling.
+
+``SearchApiSearch.search`` used to index the JSON response directly:
+``search_results["organic_results"]`` and ``result["link"]`` /
+``result["title"]`` / ``result["snippet"]``. Any absent key raised
+``KeyError``, which the broad ``except Exception`` swallowed -- silently
+turning a partially-shaped response into an *empty* result list and
+dropping every source.
+
+These tests mock the HTTP layer and assert that:
+  * a response with no ``organic_results`` key yields [] without raising,
+  * results missing individual fields still produce entries (with empty
+    strings) instead of being dropped wholesale.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from gpt_researcher.retrievers.searchapi.searchapi import SearchApiSearch
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+class TestSearchApiMissingKeys(unittest.TestCase):
+    def setUp(self):
+        os.environ["SEARCHAPI_API_KEY"] = "test-key"
+
+    def _search(self, payload):
+        with patch("requests.get", return_value=_FakeResp(payload)):
+            return SearchApiSearch("q").search(max_results=5)
+
+    def test_missing_organic_results_returns_empty(self):
+        # Previously raised KeyError -> swallowed -> [] anyway, but via an
+        # error path; now it is a clean, intentional empty result.
+        self.assertEqual(self._search({"error": "quota exceeded"}), [])
+
+    def test_result_missing_fields_is_not_dropped(self):
+        results = self._search(
+            {"organic_results": [{"link": "https://example.com/a"}]}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["href"], "https://example.com/a")
+        self.assertEqual(results[0]["title"], "")
+        self.assertEqual(results[0]["body"], "")
+
+    def test_result_missing_link_still_processed(self):
+        results = self._search(
+            {"organic_results": [{"title": "t", "snippet": "s"}]}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["href"], "")
+        self.assertEqual(results[0]["title"], "t")
+
+    def test_null_payload_returns_empty(self):
+        self.assertEqual(self._search(None), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `SearchApiSearch.search` indexed the JSON response directly — `search_results["organic_results"]` and `result["title"]` / `result["link"]` / `result["snippet"]`.
- Any absent key raised `KeyError`, which the broad `except Exception` caught and turned into an empty result list — silently dropping every source.
- Switch to `.get()` with sensible defaults so a partially-shaped response still yields usable results, and log the failure instead of `print`.

## Motivation

Same defensive-parsing class as the existing BoCha fix (#1844) and XquikSearch fix (#1845). When SearchApi returns an error payload (quota/auth), a non-google engine shape, or results missing individual fields, the direct indexing raised `KeyError` and the broad `except` masked it — the caller just saw zero sources with no signal about why.

## Verification

- `python -m pytest tests/test_searchapi_missing_keys.py -v` — 4 passed.
- New regression test `test_result_missing_fields_is_not_dropped` **fails without the fix**:

```
tests/test_searchapi_missing_keys.py::TestSearchApiMissingKeys::test_result_missing_fields_is_not_dropped FAILED
```

  (a result with only `link` raised `KeyError: 'title'`, swallowed into an empty list). With the fix, the result is preserved with empty-string title/body.
- Did NOT change: the youtube-skip behavior, the `max_results` cap, or the return type (`list[dict]`).
