### PR TITLE
fix(report): emit references in deterministic (sorted) order

### DIFF
--- a/gpt_researcher/actions/markdown_processing.py
+++ b/gpt_researcher/actions/markdown_processing.py
@@ -104,7 +104,11 @@ def add_references(report_markdown: str, visited_urls: set) -> str:
     """
     try:
         url_markdown = "\n\n\n## References\n\n"
-        url_markdown += "".join(f"- [{url}]({url})\n" for url in visited_urls)
+        # Sort so the reference list is deterministic. ``visited_urls`` is a
+        # set, whose iteration order varies from run to run (and across
+        # processes), which made the final report's References section
+        # non-reproducible for the same inputs.
+        url_markdown += "".join(f"- [{url}]({url})\n" for url in sorted(visited_urls))
         updated_markdown_report = report_markdown + url_markdown
         return updated_markdown_report
     except Exception as e:

--- a/tests/test_add_references_order.py
+++ b/tests/test_add_references_order.py
@@ -1,0 +1,34 @@
+"""Regression tests for add_references deterministic ordering.
+
+``visited_urls`` is a set, so iterating it directly makes the report's
+References section order vary run-to-run. add_references must emit the URLs
+in a stable (sorted) order.
+"""
+
+from gpt_researcher.actions.markdown_processing import add_references
+
+
+def test_add_references_renders_in_sorted_order():
+    urls = {"https://c.example", "https://a.example", "https://b.example"}
+    out = add_references("# Report", urls)
+
+    expected_tail = (
+        "\n\n\n## References\n\n"
+        "- [https://a.example](https://a.example)\n"
+        "- [https://b.example](https://b.example)\n"
+        "- [https://c.example](https://c.example)\n"
+    )
+    assert out == "# Report" + expected_tail
+
+
+def test_add_references_stable_across_equivalent_sets():
+    # Two sets built in different insertion orders are equal but may iterate
+    # differently; the rendered references must be identical.
+    urls1 = set()
+    for u in ("https://z.example", "https://m.example", "https://a.example"):
+        urls1.add(u)
+    urls2 = set()
+    for u in ("https://a.example", "https://z.example", "https://m.example"):
+        urls2.add(u)
+
+    assert add_references("# R", urls1) == add_references("# R", urls2)


### PR DESCRIPTION
## Summary

- `add_references` now renders the report's References section in sorted order instead of raw set-iteration order.
- Makes the final report reproducible for identical inputs.

## Motivation

`add_references` (in `gpt_researcher/actions/markdown_processing.py`) built the References list by iterating `visited_urls` directly:

```python
url_markdown += "".join(f"- [{url}]({url})\n" for url in visited_urls)
```

`visited_urls` is a **set** (see `GPTResearcher.visited_urls` / `agent.py`), whose iteration order varies from run to run and across processes (it depends on `PYTHONHASHSEED`). So the same research query produced a different References ordering on every run — noisy diffs, non-reproducible reports, and flaky snapshot comparisons.

Sorting the URLs before rendering yields a stable, deterministic reference list.

## Verification

Real output on current `upstream/main` (fix reverted, test present) — the sorted-order test fails under **every** hash seed:

```
for s in 0 1 2 3 4; do PYTHONHASHSEED=$s python -m pytest tests/test_add_references_order.py::test_add_references_renders_in_sorted_order -q; done
1 failed  (x5)
```

With the fix applied:

```
python -m pytest tests/test_add_references_order.py -q
2 passed
```

- Two regression tests: one asserts exact sorted rendering, one asserts two equal-but-differently-built sets render identically.
