### PR TITLE
fix(context): guard SearchAPIRetriever against None raw_content

### DIFF
--- a/gpt_researcher/context/retriever.py
+++ b/gpt_researcher/context/retriever.py
@@ -23,7 +23,10 @@ class SearchAPIRetriever(BaseRetriever):
 
         docs = [
             Document(
-                page_content=page.get("raw_content", "")[:_MAX_CONTENT_CHARS],
+                # ``raw_content`` may be explicitly None (the scraper sets it to
+                # None for pages that failed to scrape), and slicing None raises
+                # TypeError. Coerce to a string before truncating.
+                page_content=(page.get("raw_content") or "")[:_MAX_CONTENT_CHARS],
                 metadata={
                     "title": page.get("title", ""),
                     "source": page.get("url", ""),

--- a/tests/test_searchapi_retriever_none.py
+++ b/tests/test_searchapi_retriever_none.py
@@ -1,0 +1,32 @@
+"""Regression: SearchAPIRetriever must tolerate raw_content=None.
+
+The scraper sets ``raw_content`` to ``None`` for pages that failed to scrape.
+Slicing ``None`` raises ``TypeError``, so the retriever must coerce a missing
+or None ``raw_content`` to an empty string.
+"""
+
+from gpt_researcher.context.retriever import SearchAPIRetriever
+
+
+def test_none_raw_content_yields_empty_page_content():
+    retriever = SearchAPIRetriever(
+        pages=[{"raw_content": None, "title": "t", "url": "https://u.example"}]
+    )
+    docs = retriever.invoke("q")
+    assert len(docs) == 1
+    assert docs[0].page_content == ""
+    assert docs[0].metadata["source"] == "https://u.example"
+
+
+def test_present_raw_content_is_preserved():
+    retriever = SearchAPIRetriever(
+        pages=[{"raw_content": "hello world", "title": "t", "url": "u"}]
+    )
+    docs = retriever.invoke("q")
+    assert docs[0].page_content == "hello world"
+
+
+def test_missing_raw_content_key_yields_empty():
+    retriever = SearchAPIRetriever(pages=[{"title": "t", "url": "u"}])
+    docs = retriever.invoke("q")
+    assert docs[0].page_content == ""


### PR DESCRIPTION
## Summary

- `SearchAPIRetriever._get_relevant_documents` now coerces a `None` `raw_content` to `""` before slicing.
- Fixes a `TypeError: 'NoneType' object is not subscriptable` that crashes context retrieval when a page failed to scrape.

## Motivation

`SearchAPIRetriever` (in `gpt_researcher/context/retriever.py`) built each document as:

```python
page_content=page.get("raw_content", "")[:_MAX_CONTENT_CHARS]
```

The `""` default only applies when the `raw_content` **key is missing**. But the scraper explicitly sets `raw_content` to `None` for pages that failed to scrape (see `Scraper.extract_data_from_url`, which returns `{"raw_content": None, ...}` on short/empty/error content). When such a page reaches the retriever, `None[:_MAX_CONTENT_CHARS]` raises `TypeError` and crashes the whole context-retrieval step.

`compression.py` already defends against non-string content with `str(doc.get('raw_content', ''))`; this brings the retriever in line by coercing missing/None to an empty string.

## Verification

Real output on current `upstream/main` (fix reverted, test present):

```
FAILED tests/test_searchapi_retriever_none.py::test_none_raw_content_yields_empty_page_content
  TypeError: 'NoneType' object is not subscriptable
1 failed, 2 passed
```

With the fix applied:

```
python -m pytest tests/test_searchapi_retriever_none.py -q
3 passed
```

- Three regression tests: `raw_content=None` → empty content, present content preserved, missing key → empty.
