### PR TITLE
fix(mcp): forward connection_headers for HTTP/websocket transports

### DIFF
--- a/gpt_researcher/mcp/client.py
+++ b/gpt_researcher/mcp/client.py
@@ -73,7 +73,7 @@ class MCPClientManager:
                 connection_type = config.get("connection_type", "stdio")
                 server_config["transport"] = connection_type
             
-            if server_config.get("connection_type") in ["streamable_http", "http"]:
+            if server_config.get("transport") in ["streamable_http", "http", "websocket"]:
                 connection_headers = config.get("connection_headers")
                 if connection_headers and isinstance(connection_headers, dict):
                     server_config["headers"] = connection_headers

--- a/tests/test_mcp_client_config.py
+++ b/tests/test_mcp_client_config.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Unit tests for MCPClientManager.convert_configs_to_langchain_format.
+
+Regression coverage for the dead-branch bug where connection_headers were
+silently dropped for HTTP/websocket transports because the guard checked
+server_config["connection_type"] (never set) instead of the transport.
+"""
+
+import unittest
+
+from gpt_researcher.mcp.client import MCPClientManager
+
+
+class TestConvertConfigsHeaders(unittest.TestCase):
+    def test_headers_forwarded_for_streamable_http(self):
+        configs = [{
+            "name": "my_server",
+            "connection_url": "https://mcp.example.com",
+            "connection_type": "streamable_http",
+            "connection_headers": {"Authorization": "Bearer TOKEN"},
+        }]
+        result = MCPClientManager(configs).convert_configs_to_langchain_format()
+        server = result["my_server"]
+        self.assertEqual(server["transport"], "streamable_http")
+        self.assertEqual(server["headers"], {"Authorization": "Bearer TOKEN"})
+
+    def test_headers_forwarded_for_websocket(self):
+        configs = [{
+            "name": "ws_server",
+            "connection_url": "wss://mcp.example.com",
+            "connection_headers": {"Authorization": "Bearer WS"},
+        }]
+        result = MCPClientManager(configs).convert_configs_to_langchain_format()
+        server = result["ws_server"]
+        self.assertEqual(server["transport"], "websocket")
+        self.assertEqual(server["headers"], {"Authorization": "Bearer WS"})
+
+    def test_no_headers_when_not_provided(self):
+        configs = [{
+            "name": "plain",
+            "connection_url": "https://mcp.example.com",
+        }]
+        result = MCPClientManager(configs).convert_configs_to_langchain_format()
+        self.assertNotIn("headers", result["plain"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Forward user-supplied `connection_headers` to `MultiServerMCPClient` for HTTP/websocket MCP transports.
- Auth-protected HTTP MCP servers now receive their `Authorization` header instead of being silently rejected.

## Motivation

Closes #1854.

The guard in `convert_configs_to_langchain_format` checked `server_config.get("connection_type")`, but `server_config` only ever has `transport` set (lines 60/63/68/74) — `connection_type` lives on the input `config` dict. The branch was therefore unreachable and `connection_headers` were always dropped. Fixed by checking `transport` (and including `websocket`, which also supports headers).

## Verification

```
$ python -m pytest tests/test_mcp_client_config.py -q
3 passed
```

Fails-without-fix proof (guard reverted):
```
FAILED test_headers_forwarded_for_streamable_http
FAILED test_headers_forwarded_for_websocket
2 failed, 1 passed
```
