### PR TITLE
docs: document scholarly retriever configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ BRAVE_API_KEY=
 XQUIK_API_KEY=
 DOC_PATH=./my-docs
 
+# Scholarly retrievers (optional)
+OPENALEX_EMAIL=
+OPENALEX_API_KEY=
+NCBI_API_KEY=
+# PUBMED_DB=pmc
+
 # NEXT_PUBLIC_GPTR_API_URL=http://0.0.0.0:8000  # Defaults to localhost:8000 if not set
 
 # Scraper Configuration

--- a/docs/docs/gpt-researcher/gptr/config.md
+++ b/docs/docs/gpt-researcher/gptr/config.md
@@ -50,7 +50,7 @@ python gpt_researcher/main.py --config_path my_config.json
 
 Below is a list of current supported options:
 
-- **`RETRIEVER`**: Web search engine used for retrieving sources. Defaults to `tavily`. Options: `duckduckgo`, `bing`, `brave`, `google`, `searchapi`, `serper`, `searx`. [Check here](https://github.com/assafelovic/gpt-researcher/tree/master/gpt_researcher/retrievers) for supported retrievers
+- **`RETRIEVER`**: Search engine or research retriever used for retrieving sources. Defaults to `tavily`. Options include `tavily`, `duckduckgo`, `bing`, `brave`, `google`, `searchapi`, `serper`, `serpapi`, `searx`, `arxiv`, `openalex`, `semantic_scholar`, `pubmed_central`, `exa`, `crw`, `groundroute`, `bocha`, `xquik`, `custom`, and `mcp`. You can also combine retrievers with commas, such as `tavily,openalex,semantic_scholar`. [Check here](https://github.com/assafelovic/gpt-researcher/tree/master/gpt_researcher/retrievers) for supported retrievers
 - **`EMBEDDING`**: Embedding model. Defaults to `openai:text-embedding-3-small`. Options: `ollama`, `huggingface`, `azure_openai`, `custom`.
 - **`SIMILARITY_THRESHOLD`**: Threshold value for similarity comparison when processing documents. Defaults to `0.42`.
 - **`FAST_LLM`**: Model name for fast LLM operations such summaries. Defaults to `openai:gpt-4o-mini`.
@@ -118,10 +118,17 @@ For academic or highly specialized research, consider increasing both breadth an
 To change the default configurations, you can simply add env variables to your `.env` file as named above or export manually in your local project directory.
 
 For example, to manually change the search engine and report format:
+
 ```bash
 export RETRIEVER=bing
 export REPORT_FORMAT=IEEE
 ```
+
+For academic literature reviews, you can combine web and scholarly retrievers:
+
+```bash
+export RETRIEVER=tavily,openalex,semantic_scholar
+```
+
 Please note that you might need to export additional env vars and obtain API keys for other supported search retrievers and LLM providers. Please follow your console logs for further assistance.
 To learn more about additional LLM support you can check out the docs [here](/docs/gpt-researcher/llms/llms).
-

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -18,14 +18,22 @@ You can also specify multiple retrievers by separating them with commas. The sys
 For example:
 
 ```bash
-RETRIEVER=tavily, arxiv
+RETRIEVER=tavily,arxiv
 ```
 
-Thanks to our community, we have integrated the following web search engines:
+For academic literature reviews, combine a broad web retriever with scholarly retrievers:
+
+```bash
+RETRIEVER=tavily,openalex,semantic_scholar
+```
+
+Thanks to our community, we have integrated the following web search engines and research retrievers:
 
 - [Tavily](https://app.tavily.com) - Default
 - [Bing](https://www.microsoft.com/en-us/bing/apis/bing-web-search-api) - Env: `RETRIEVER=bing`
 - [Brave Search](https://brave.com/search/api/) - Env: `RETRIEVER=brave` and `BRAVE_API_KEY`
+- [GroundRoute](https://groundroute.ai/) - Env: `RETRIEVER=groundroute` and `GROUNDROUTE_API_KEY`
+- [BoCha](https://bochaai.com/) - Env: `RETRIEVER=bocha` and `BOCHA_API_KEY`
 - [Google](https://developers.google.com/custom-search/v1/overview) - Env: `RETRIEVER=google`
 - [SearchApi](https://www.searchapi.io/) - Env: `RETRIEVER=searchapi`
 - [Serp API](https://serpapi.com/) - Env: `RETRIEVER=serpapi`
@@ -33,9 +41,13 @@ Thanks to our community, we have integrated the following web search engines:
 - [Searx](https://searx.github.io/searx/) - Env: `RETRIEVER=searx`
 - [Duckduckgo](https://pypi.org/project/duckduckgo-search/) - Env: `RETRIEVER=duckduckgo`
 - [Arxiv](https://info.arxiv.org/help/api/index.html) - Env: `RETRIEVER=arxiv`
+- [OpenAlex](https://docs.openalex.org/) - Env: `RETRIEVER=openalex`; optional `OPENALEX_EMAIL` and `OPENALEX_API_KEY`
+- [Semantic Scholar](https://www.semanticscholar.org/product/api) - Env: `RETRIEVER=semantic_scholar`
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
+- [Xquik](https://xquik.com/) - Env: `RETRIEVER=xquik` and `XQUIK_API_KEY`
+- [MCP](../retrievers/mcp-configs) - Env: `RETRIEVER=mcp`
 
 ## Custom Retrievers
 
@@ -107,6 +119,28 @@ SERPER_REGION=us                    # Country code (us, kr, jp, etc.)
 SERPER_LANGUAGE=en                  # Language code (en, ko, ja, etc.)
 SERPER_TIME_RANGE=qdr:w            # Time filter (qdr:h, qdr:d, qdr:w, qdr:m, qdr:y)
 SERPER_EXCLUDE_SITES=youtube.com   # Exclude sites (comma-separated)
+```
+
+### OpenAlex
+
+To use [OpenAlex](https://docs.openalex.org/) for scholarly works:
+
+```bash
+RETRIEVER=openalex
+OPENALEX_EMAIL=you@example.com      # Optional but recommended for polite API usage
+OPENALEX_API_KEY=your_api_key_here  # Optional; improves rate limits
+```
+
+OpenAlex works without an API key, but setting an email or free API key can make larger research runs more reliable.
+
+### PubMed Central
+
+To use PubMed Central full-text retrieval:
+
+```bash
+RETRIEVER=pubmed_central
+NCBI_API_KEY=your_api_key_here      # Optional; improves NCBI rate limits
+PUBMED_DB=pmc                       # Optional; defaults to pmc
 ```
 
 Missing a retriever? Feel free to contribute to this project by submitting issues or pull requests on our [GitHub](https://github.com/assafelovic/gpt-researcher) page.


### PR DESCRIPTION
## Summary
- Document the full set of retriever names currently supported by the retriever factory.
- Add scholarly-search examples for combining broad web retrieval with OpenAlex and Semantic Scholar.
- Document OpenAlex and PubMed Central environment variables in the search engines docs and `.env.example`.

## Why
`gpt_researcher.actions.retriever.get_retriever()` already supports scholarly retrievers such as `openalex`, `semantic_scholar`, and `pubmed_central`, but the user-facing config/search docs only listed a smaller subset. This makes the academic-research path easier to discover without changing runtime behavior.

## Validation
- Checked documented retriever names against `gpt_researcher/actions/retriever.py`.
- Reviewed no-index diff against the upstream `main` zipball; docs-only change.