### PR TITLE
fix(retriever): guard SerpApiSearch against malformed/missing result fields

### DIFF
--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -60,18 +60,26 @@ class SerpApiSearch():
             if response.status_code == 200:
                 search_results = response.json()
                 if search_results:
-                    results = search_results["organic_results"]
+                    # A response with no organic results (e.g. an error payload
+                    # or a query that matched nothing) has no "organic_results"
+                    # key; default to [] instead of raising KeyError.
+                    results = search_results.get("organic_results") or []
                     results_processed = 0
                     for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
                         if results_processed >= max_results:
                             break
+                        link = result.get("link")
+                        # A result without a link is unusable; skip it rather
+                        # than emitting an entry with href=None.
+                        if not link:
+                            continue
+                        # skip youtube results
+                        if "youtube.com" in link:
+                            continue
                         search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
+                            "title": result.get("title", ""),
+                            "href": link,
+                            "body": result.get("snippet", ""),
                         }
                         search_response.append(search_result)
                         results_processed += 1

--- a/tests/test_serpapi_retriever_malformed.py
+++ b/tests/test_serpapi_retriever_malformed.py
@@ -1,0 +1,55 @@
+"""Regression tests for SerpApiSearch result normalization.
+
+Without the fix, a response missing ``organic_results`` raises a KeyError, and
+a single result missing ``title``/``link``/``snippet`` raises a KeyError that
+aborts the whole ``search()`` call.
+"""
+import importlib.util
+import os
+import pathlib
+from unittest.mock import patch
+
+# Import the module directly to avoid importing the heavy gpt_researcher package
+# (which pulls optional deps at import time).
+_SERPAPI_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher" / "retrievers" / "serpapi" / "serpapi.py"
+)
+_spec = importlib.util.spec_from_file_location("_serpapi_under_test", _SERPAPI_PATH)
+_serpapi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_serpapi)
+SerpApiSearch = _serpapi.SerpApiSearch
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+def test_serpapi_skips_results_missing_keys():
+    payload = {
+        "organic_results": [
+            {"title": "A", "link": "https://a.example", "snippet": "sa"},
+            {"title": "B", "link": "https://b.example"},  # missing snippet
+            {"link": "https://c.example"},  # missing title + snippet
+            {"title": "D", "snippet": "sd"},  # missing link -> skipped
+        ]
+    }
+    with patch.object(_serpapi.requests, "get", return_value=_FakeResp(payload)):
+        results = SerpApiSearch("q").search()
+
+    assert len(results) == 3
+    assert results[0] == {"title": "A", "href": "https://a.example", "body": "sa"}
+    assert results[1]["body"] == ""
+    assert results[2]["title"] == ""
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+def test_serpapi_no_organic_results_returns_empty():
+    with patch.object(_serpapi.requests, "get", return_value=_FakeResp({})):
+        assert SerpApiSearch("q").search() == []


### PR DESCRIPTION
## Summary

- `SerpApiSearch.search()` no longer crashes on SerpApi responses that omit `organic_results` or on individual results missing `title`/`link`/`snippet`.
- User-facing impact: a partially-malformed SerpApi response now yields the usable results instead of aborting the entire search with a `KeyError`.

## Motivation

`search()` indexed the response and each result directly:

```python
results = search_results["organic_results"]
...
if "youtube.com" in result["link"]: ...
search_result = {"title": result["title"], "href": result["link"], "body": result["snippet"]}
```

A SerpApi response with no `organic_results` (an error payload, or a query that
matched nothing) raised `KeyError: 'organic_results'`, and a single result
missing any of `title`/`link`/`snippet` raised a `KeyError` that aborted the
whole call. This is the same class of fragility already hardened in the Serper,
Bing, SearchApi, BoCha and XQuik retrievers.

Fix: use `.get()` with safe defaults, default `organic_results` to `[]`, and
skip results with no usable `link` rather than emitting an entry with
`href=None`.

## Verification

- `python3 -m pytest tests/test_serpapi_retriever_malformed.py` — 2 passed
- Fails-without-fix confirmed: with the source change stashed, `test_serpapi_skips_results_missing_keys` fails with `KeyError`; with the fix it passes.
- Did NOT change: the youtube-skip behavior or the shape of returned dicts (`title`/`href`/`body`).
