### PR TITLE
fix(retriever): skip fastCRW sources missing url instead of dropping all results

### DIFF
--- a/gpt_researcher/retrievers/crw/crw.py
+++ b/gpt_researcher/retrievers/crw/crw.py
@@ -107,16 +107,18 @@ class CRWRetriever:
         try:
             # Search the query
             results = self._search(self.query, max_results=max_results)
-            sources = results.get("data", [])
+            sources = results.get("data") or []
             if not sources:
                 raise Exception("No results found with fastCRW API search.")
-            # Return the results
+            # Return the results. A source missing "url" is unusable, so skip it
+            # rather than raising a KeyError that discards the whole result set.
             search_response = [
                 {
                     "href": obj["url"],
                     "body": obj.get("markdown") or obj.get("description", ""),
                 }
                 for obj in sources
+                if obj.get("url")
             ]
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")

--- a/tests/test_crw_retriever_malformed.py
+++ b/tests/test_crw_retriever_malformed.py
@@ -1,0 +1,50 @@
+"""Regression tests for CRWRetriever (fastCRW) result normalization.
+
+Without the fix, a source missing the ``url`` key raises a KeyError that is
+swallowed by the broad ``except`` in ``search()`` — discarding every other
+(valid) source in the same response and returning an empty list.
+"""
+import importlib.util
+import os
+import pathlib
+from unittest.mock import patch
+
+# Import the module directly to avoid importing the heavy gpt_researcher package.
+_CRW_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher" / "retrievers" / "crw" / "crw.py"
+)
+_spec = importlib.util.spec_from_file_location("_crw_under_test", _CRW_PATH)
+_crw = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_crw)
+CRWRetriever = _crw.CRWRetriever
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+@patch.dict(os.environ, {"CRW_API_KEY": "test-key"})
+def test_crw_skips_sources_missing_url():
+    payload = {
+        "success": True,
+        "data": [
+            {"url": "https://a.example", "markdown": "ma"},
+            {"url": "https://b.example", "description": "db"},  # no markdown
+            {"markdown": "orphan"},  # no url -> skipped, must not abort the rest
+        ],
+    }
+    with patch.object(_crw.requests, "post", return_value=_FakeResp(payload)):
+        results = CRWRetriever("q").search()
+
+    assert results == [
+        {"href": "https://a.example", "body": "ma"},
+        {"href": "https://b.example", "body": "db"},
+    ]


### PR DESCRIPTION
## Summary

- `CRWRetriever.search()` (fastCRW) no longer discards *all* results when a single source in the response is missing its `url`.
- User-facing impact: a partially-malformed fastCRW response now yields its usable sources instead of silently returning an empty list.

## Motivation

`search()` built each result with `obj["url"]`:

```python
sources = results.get("data", [])
...
search_response = [
    {"href": obj["url"], "body": obj.get("markdown") or obj.get("description", "")}
    for obj in sources
]
```

A source without a `url` raises `KeyError`, which is caught by the broad
`except Exception` in `search()` — so one malformed entry throws away every
other valid source and returns `[]`. This is the same fragility already
hardened in the Serper, Bing, SearchApi, BoCha, XQuik and SerpApi retrievers.

Fix: skip sources without a usable `url` in the comprehension, and default the
`data` envelope with `results.get("data") or []` so a `null` data field is
treated as no results.

## Verification

- `python3 -m pytest tests/test_crw_retriever_malformed.py` — 1 passed
- Fails-without-fix confirmed: with the source change stashed, the test fails (the url-less source aborts the whole search and returns `[]`); with the fix it passes.
- Did NOT change: the "No results found" raise on an empty `data`, or the shape of returned dicts (`href`/`body`).
