### PR TITLE
[WIP] feat(retrievers): add nimble web search retriever

### DIFF
--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -34,6 +34,7 @@ Thanks to our community, we have integrated the following web search engines:
 - [Duckduckgo](https://pypi.org/project/duckduckgo-search/) - Env: `RETRIEVER=duckduckgo`
 - [Arxiv](https://info.arxiv.org/help/api/index.html) - Env: `RETRIEVER=arxiv`
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
+- [Nimble](https://docs.nimbleway.com/nimble-sdk/web-tools/search) - Env: `RETRIEVER=nimble` and `NIMBLE_API_KEY`
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
 

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -44,6 +44,7 @@ Thanks to our community, we have integrated the following web search engines and
 - [OpenAlex](https://docs.openalex.org/) - Env: `RETRIEVER=openalex`; optional `OPENALEX_EMAIL` and `OPENALEX_API_KEY`
 - [Semantic Scholar](https://www.semanticscholar.org/product/api) - Env: `RETRIEVER=semantic_scholar`
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
+- [Nimble](https://docs.nimbleway.com/nimble-sdk/web-tools/search) - Env: `RETRIEVER=nimble` and `NIMBLE_API_KEY`
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
 - [Xquik](https://xquik.com/) - Env: `RETRIEVER=xquik` and `XQUIK_API_KEY`

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -26,6 +26,7 @@ def get_retriever(retriever: str):
         - arxiv: arXiv academic search
         - tavily: Tavily search API
         - exa: Exa search
+        - nimble: Nimble Search API
         - crw: fastCRW search (Firecrawl-compatible web scraper)
         - semantic_scholar: Semantic Scholar academic search
         - pubmed_central: PubMed Central medical literature
@@ -87,6 +88,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import ExaSearch
 
             return ExaSearch
+        case "nimble":
+            from gpt_researcher.retrievers import NimbleSearch
+
+            return NimbleSearch
         case "crw":
             from gpt_researcher.retrievers import CRWRetriever
 

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -26,6 +26,7 @@ def get_retriever(retriever: str):
         - arxiv: arXiv academic search
         - tavily: Tavily search API
         - exa: Exa search
+        - nimble: Nimble Search API
         - crw: fastCRW search (Firecrawl-compatible web scraper)
         - semantic_scholar: Semantic Scholar academic search
         - pubmed_central: PubMed Central medical literature
@@ -88,6 +89,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import ExaSearch
 
             return ExaSearch
+        case "nimble":
+            from gpt_researcher.retrievers import NimbleSearch
+
+            return NimbleSearch
         case "crw":
             from gpt_researcher.retrievers import CRWRetriever
 

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -13,6 +13,7 @@ from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
 from .groundroute.groundroute import GroundRouteSearch
 from .exa.exa import ExaSearch
+from .nimble.nimble_search import NimbleSearch
 from .crw.crw import CRWRetriever
 from .getxapi.getxapi import GetXAPISearch
 from .mcp import MCPRetriever
@@ -36,6 +37,7 @@ __all__ = [
     "SemanticScholarSearch",
     "PubMedCentralSearch",
     "ExaSearch",
+    "NimbleSearch",
     "CRWRetriever",
     "GetXAPISearch",
     "MCPRetriever",

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -13,6 +13,7 @@ from .serper.serper import SerperSearch
 from .tavily.tavily_search import TavilySearch
 from .groundroute.groundroute import GroundRouteSearch
 from .exa.exa import ExaSearch
+from .nimble.nimble_search import NimbleSearch
 from .crw.crw import CRWRetriever
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
@@ -35,6 +36,7 @@ __all__ = [
     "SemanticScholarSearch",
     "PubMedCentralSearch",
     "ExaSearch",
+    "NimbleSearch",
     "CRWRetriever",
     "MCPRetriever",
     "BoChaSearch",

--- a/gpt_researcher/retrievers/nimble/nimble_search.py
+++ b/gpt_researcher/retrievers/nimble/nimble_search.py
@@ -1,0 +1,105 @@
+"""Nimble Search API retriever for GPT Researcher.
+
+This module provides the NimbleSearch class for performing web searches
+using the Nimble Search API (https://docs.nimbleway.com/nimble-sdk/web-tools/search).
+"""
+
+import os
+from typing import Optional, Sequence
+
+import requests
+
+
+class NimbleSearch:
+    """
+    Nimble Search API Retriever
+    """
+
+    def __init__(self, query, query_domains=None):
+        """
+        Initializes the NimbleSearch object.
+
+        Args:
+            query (str): The search query string.
+            query_domains (list, optional): List of domains to restrict the search to. Defaults to None.
+        """
+        self.query = query
+        self.query_domains = query_domains or None
+        self.base_url = "https://sdk.nimbleway.com/v1/search"
+        self.api_key = self.get_api_key()
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def get_api_key(self):
+        """
+        Gets the Nimble API key from the environment.
+
+        Returns:
+            str: The API key, or "" if unset.
+        """
+        try:
+            api_key = os.environ["NIMBLE_API_KEY"]
+        except KeyError:
+            print(
+                "Nimble API key not found, set to blank. If you need this retriever, "
+                "please set the NIMBLE_API_KEY environment variable."
+            )
+            return ""
+        return api_key
+
+    def _search(
+        self,
+        query: str,
+        max_results: int = 10,
+        include_domains: Optional[Sequence[str]] = None,
+    ) -> dict:
+        """
+        Internal search method that sends the request to the Nimble Search API.
+        """
+        payload = {
+            "query": query,
+            "max_results": max_results,
+        }
+        if include_domains:
+            payload["include_domains"] = list(include_domains)
+
+        response = requests.post(
+            self.base_url, json=payload, headers=self.headers, timeout=100
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def search(self, max_results=10):
+        """
+        Searches the query using the Nimble Search API.
+
+        Returns:
+            list[dict]: A list of {"href", "body", "title"} result dicts,
+            or an empty list on failure.
+        """
+        try:
+            results = self._search(
+                self.query,
+                max_results=max_results,
+                include_domains=self.query_domains,
+            )
+            sources = results.get("results", [])
+            if not sources:
+                raise Exception("No results found with Nimble Search API.")
+            # In the default (lite) search depth, `content` is absent and the
+            # snippet text is carried by `description`.
+            search_response = [
+                {
+                    "href": obj.get("url"),
+                    "body": obj.get("content") or obj.get("description") or "",
+                    "title": obj.get("title", ""),
+                }
+                for obj in sources
+                if obj.get("url")
+            ]
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
+            search_response = []
+        return search_response

--- a/gpt_researcher/retrievers/nimble/nimble_search.py
+++ b/gpt_researcher/retrievers/nimble/nimble_search.py
@@ -9,11 +9,17 @@ from typing import Optional, Sequence
 
 import requests
 
+from ..base import BaseRetriever
 
-class NimbleSearch:
+
+class NimbleSearch(BaseRetriever):
     """
     Nimble Search API Retriever
     """
+
+    # Nimble lite returns a URL plus a snippet (content/description); the
+    # real page text still has to be scraped. Matches Tavily/Searx/DuckDuckGo.
+    requires_scraping = True
 
     def __init__(self, query, query_domains=None):
         """

--- a/tests/test_nimble_retriever.py
+++ b/tests/test_nimble_retriever.py
@@ -1,0 +1,116 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.nimble.nimble_search import NimbleSearch
+
+
+class TestNimbleSearch(unittest.TestCase):
+    def test_missing_api_key_defaults_to_blank(self):
+        with patch.dict(os.environ, {}, clear=True):
+            retriever = NimbleSearch("test query")
+        self.assertEqual(retriever.api_key, "")
+
+    @patch("gpt_researcher.retrievers.nimble.nimble_search.requests.post")
+    def test_search_normalizes_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com/one",
+                    "title": "One",
+                    "content": "First snippet",
+                },
+                {
+                    "url": "https://example.com/two",
+                    "title": "Two",
+                    "content": "Second snippet",
+                },
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"NIMBLE_API_KEY": "test-key"}):
+            results = NimbleSearch("test query").search(max_results=2)
+
+        # Verify the request shape: Bearer auth, correct endpoint, minimal
+        # non-enterprise-safe payload (no include_answer / search_depth).
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "https://sdk.nimbleway.com/v1/search")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(kwargs["json"], {"query": "test query", "max_results": 2})
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "href": "https://example.com/one",
+                    "body": "First snippet",
+                    "title": "One",
+                },
+                {
+                    "href": "https://example.com/two",
+                    "body": "Second snippet",
+                    "title": "Two",
+                },
+            ],
+        )
+
+    @patch("gpt_researcher.retrievers.nimble.nimble_search.requests.post")
+    def test_search_falls_back_to_description_in_lite_mode(self, mock_post):
+        # In the default (lite) depth, `content` is absent; `description`
+        # carries the snippet text.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com/lite",
+                    "title": "Lite",
+                    "description": "Lite snippet",
+                }
+            ]
+        }
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"NIMBLE_API_KEY": "test-key"}):
+            results = NimbleSearch("test query").search(max_results=1)
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "href": "https://example.com/lite",
+                    "body": "Lite snippet",
+                    "title": "Lite",
+                }
+            ],
+        )
+
+    @patch("gpt_researcher.retrievers.nimble.nimble_search.requests.post")
+    def test_search_returns_empty_on_no_results(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"NIMBLE_API_KEY": "test-key"}):
+            results = NimbleSearch("test query").search(max_results=5)
+
+        self.assertEqual(results, [])
+
+    @patch("gpt_researcher.retrievers.nimble.nimble_search.requests.post")
+    def test_query_domains_passed_as_include_domains(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"NIMBLE_API_KEY": "test-key"}):
+            NimbleSearch("test query", query_domains=["example.com"]).search(
+                max_results=3
+            )
+
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["json"]["include_domains"], ["example.com"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nimble_retriever.py
+++ b/tests/test_nimble_retriever.py
@@ -2,10 +2,16 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
+from gpt_researcher.retrievers.base import BaseRetriever
 from gpt_researcher.retrievers.nimble.nimble_search import NimbleSearch
 
 
 class TestNimbleSearch(unittest.TestCase):
+    def test_is_base_retriever_and_requires_scraping(self):
+        # Nimble lite returns snippets; pages still need to be scraped.
+        self.assertTrue(issubclass(NimbleSearch, BaseRetriever))
+        self.assertIs(NimbleSearch.requires_scraping, True)
+
     def test_missing_api_key_defaults_to_blank(self):
         with patch.dict(os.environ, {}, clear=True):
             retriever = NimbleSearch("test query")

--- a/tests/test_retriever_requires_scraping.py
+++ b/tests/test_retriever_requires_scraping.py
@@ -119,6 +119,7 @@ def test_base_class_requires_a_search_method():
         ("gpt_researcher.retrievers.tavily.tavily_search", "TavilySearch", True),
         ("gpt_researcher.retrievers.searx.searx", "SearxSearch", True),
         ("gpt_researcher.retrievers.duckduckgo.duckduckgo", "Duckduckgo", True),
+        ("gpt_researcher.retrievers.nimble.nimble_search", "NimbleSearch", True),
         ("gpt_researcher.retrievers.pubmed_central.pubmed_central", "PubMedCentralSearch", False),
         ("gpt_researcher.retrievers.custom.custom", "CustomRetriever", False),
     ],


### PR DESCRIPTION
## Hosted playground

- **Protected playground:** [Open the exact-revision playground](https://gpt-researcher-nimble-playground.kadosh.workers.dev) (access credentials are shared privately).
- **Live recording:** [Watch the authenticated Nimble research run](https://github.com/wildcard/gpt-researcher/blob/2a603a112b4aab75309a2f3d3b4b952c9bf6de0d/gpt-researcher-nimble-hosted-a0f2.mp4).
- **Revision:** `a0f2e1d6700f62447d61742fbc259dc2e3ebad45`.
- **Proof:** the recording shows the decision-oriented web query, live research progress, retrieved source URLs, and the completed cited report. The run used `RETRIEVER=nimble` with a real Nimble credential.
## Summary

- Adds a **`nimble`** retriever so research can run on the [Nimble Search API](https://docs.nimbleway.com/nimble-sdk/web-tools/search) with `RETRIEVER=nimble` and `NIMBLE_API_KEY`.
- `NimbleSearch` mirrors the existing `tavily` and `brave` retrievers: raw `requests` call, `{"href", "body", "title"}` result dicts, `[]` on failure — no new dependencies.
- Wires in the usual two spots — a `"nimble"` case in the `get_retriever` factory and a `NimbleSearch` export from `gpt_researcher.retrievers` — plus a one-line entry in the search-engines docs.
- Ships mocked unit tests, a live-API smoke, and a full end-to-end report run (`RETRIEVER=nimble` → a cited report from Nimble-retrieved sources).

## Demo

**Date:** 2026-08-26 (post-rebase onto current main, HEAD `a0f2e1d6`)

**Query shown:** What new real-time web search and data-access tools for AI agents launched in the last month?

**Proof:** playground used `RETRIEVER=nimble`; logs showed `Active retrievers: ['NimbleSearch']`.

This is a live playground capture of the rebased Nimble retriever, not the July 7 capture.

![gptr-nimble-demo](https://raw.githubusercontent.com/wildcard/gpt-researcher/nimble-demo-2026-08-26/gptr-nimble-demo.gif)

<details>
<summary>Stills — start / retrieving / report / sources</summary>

| Start | Retrieving |
| --- | --- |
| ![start](https://raw.githubusercontent.com/wildcard/gpt-researcher/nimble-demo-2026-08-26/01-query.png) | ![retrieving](https://raw.githubusercontent.com/wildcard/gpt-researcher/nimble-demo-2026-08-26/02-live-retrieval.png) |

| Report | Sources |
| --- | --- |
| ![report](https://raw.githubusercontent.com/wildcard/gpt-researcher/nimble-demo-2026-08-26/03-report.png) | ![sources](https://raw.githubusercontent.com/wildcard/gpt-researcher/nimble-demo-2026-08-26/04-references.png) |

</details>

## Motivation

GPT-Researcher already supports a range of search backends. Nimble runs its own web index with an emphasis on freshness, which is useful for a deep-research agent that fans a report out into many sub-queries. This change makes Nimble a drop-in option without touching any existing retriever — the default (Tavily) is unchanged.

It's implemented as a small raw-HTTP wrapper rather than pulling in an SDK, matching how `tavily` and `brave` are already written, so it adds no new runtime dependency.

## Configuration

```bash
RETRIEVER=nimble
NIMBLE_API_KEY=your_key
```

## How it works

`NimbleSearch(query).search(max_results)` POSTs to `https://sdk.nimbleway.com/v1/search` with a bearer token and returns normalized results. In the default (`lite`) search depth the snippet text arrives in `description`, so `body` falls back to it when `content` is absent.

Real output for `NimbleSearch("who won the most recent Formula 1 grand prix").search(max_results=5)` (key redacted):

```text
count=5
[0] title="List of Formula One Grand Prix winners" body_len=157 href=https://en.wikipedia.org/wiki/List_of_Formula_One_Grand_Prix_winners
[1] title="2025 Races" body_len=159 href=https://www.formula1.com/en/results/2025/races
[2] title="F1 - The Official Home of Formula 1 Racing" body_len=155 href=https://www.formula1.com/
[3] title="Lewis Hamilton wins first Formula 1 Grand Prix for Ferrari" body_len=159 href=https://www.nbcnews.com/sports/formula-1/...
[4] title="Formula One" body_len=160 href=https://en.wikipedia.org/wiki/Formula_One
```

## How this was tested

- [x] `python -m unittest tests.test_nimble_retriever -v` — **5 passed** (no API key required).
- [x] Live smoke against the real API — `NimbleSearch("who won the most recent Formula 1 grand prix").search(max_results=5)` returned **5 results** with populated `href`/`title`/`body` (sample above; key redacted).
- [x] Full `gpt-researcher` end-to-end report run — `RETRIEVER=nimble` produced a ~13k-char cited report from **15 Nimble-retrieved sources** in ~47s (the run log shows `Combined research context: 0 MCP sources, web content`, i.e. the web retriever supplied the sources). Sample sources: `aireleasetracker.com`, `llm-stats.com`, `hai.stanford.edu`.

The unit tests cover the result mapping (`url`→`href`, `content`/`description`→`body`, `title`), the `lite`-mode `description` fallback, empty results, forwarding `query_domains` as `include_domains`, and the missing-key path (defaults to a blank key like the Tavily retriever). The live smoke confirms the request shape and response mapping against the real endpoint.

## How this was reviewed

- Diffed the new retriever against `tavily/tavily_search.py` and `brave/brave.py` to keep the interface and the `{"href", "body"}` contract identical.
- Confirmed the request sends only `query` and `max_results` (plus `include_domains` when domains are supplied) — the standard search tier, no account-gated parameters.
- Scanned the diff for secrets/keys and hardcoded endpoints; the key is read from `NIMBLE_API_KEY` only.

## Known limitations

- Uses the default `lite` search depth, whose snippets are shorter than deeper modes; this keeps it on the standard tier and is sufficient for grounding.
- On a slow response or API error the retriever returns `[]` for that query (same graceful-degradation contract as the other retrievers), so an occasional slow sub-query drops its own sources rather than failing the run.

## Scope

**In:** the `nimble` web-search retriever, its factory/registration wiring, unit tests, and a docs entry.

**Not in (easy follow-ups):** exposing deeper search modes or an included-answer option behind opt-in configuration; Nimble Extract/Map/Crawl retrievers.