### PR TITLE
fix(scraper): don't discard extracted content when image/title enrichment fails

### DIFF
--- a/gpt_researcher/scraper/tavily_extract/tavily_extract.py
+++ b/gpt_researcher/scraper/tavily_extract/tavily_extract.py
@@ -40,20 +40,23 @@ class TavilyExtract:
             if response['failed_results']:
                 return "", [], ""
 
-            # Parse the HTML content of the response to create a BeautifulSoup object for the utility functions
-            response_bs = self.session.get(self.link, timeout=4)
-            soup = BeautifulSoup(
-                response_bs.content, "lxml", from_encoding=response_bs.encoding
-            )
-
             # Since only a single link is provided to tavily_client, the results will contain only one entry.
             content = response['results'][0]['raw_content']
 
-            # Get relevant images using the utility function
-            image_urls = get_relevant_images(soup, self.link)
-
-            # Extract the title using the utility function
-            title = extract_title(soup)
+            # Image and title enrichment fetches the page a second time, directly. That
+            # can fail on the very sites Tavily is used for (bot-blocked, JS-only, slow),
+            # so treat it as best-effort: never discard the content Tavily already returned.
+            image_urls: list = []
+            title = ""
+            try:
+                response_bs = self.session.get(self.link, timeout=4)
+                soup = BeautifulSoup(
+                    response_bs.content, "lxml", from_encoding=response_bs.encoding
+                )
+                image_urls = get_relevant_images(soup, self.link)
+                title = extract_title(soup)
+            except Exception as e:
+                print(f"Error enriching Tavily result for {self.link}, skipping images/title: {e}")
 
             return content, image_urls, title
 

--- a/gpt_researcher/scraper/web_base_loader/web_base_loader.py
+++ b/gpt_researcher/scraper/web_base_loader/web_base_loader.py
@@ -29,12 +29,17 @@ class WebBaseLoaderScraper:
             for doc in docs:
                 content += doc.page_content
 
-            response = self.session.get(self.link)
-            soup = BeautifulSoup(response.content, 'html.parser')
-            image_urls = get_relevant_images(soup, self.link)
-            
-            # Extract the title using the utility function
-            title = extract_title(soup)
+            # Image and title enrichment fetches the page a second time; treat it as
+            # best-effort so a failure here never discards the content already loaded.
+            image_urls: list = []
+            title = ""
+            try:
+                response = self.session.get(self.link)
+                soup = BeautifulSoup(response.content, 'html.parser')
+                image_urls = get_relevant_images(soup, self.link)
+                title = extract_title(soup)
+            except Exception as e:
+                print(f"Error enriching WebBaseLoader result for {self.link}, skipping images/title: {e}")
 
             return content, image_urls, title
 

--- a/tests/test_scrapers_preserve_content.py
+++ b/tests/test_scrapers_preserve_content.py
@@ -1,0 +1,51 @@
+"""Regression tests: scrapers must return successfully-extracted primary content
+even when the best-effort image/title enrichment (a second, direct page fetch)
+fails.
+
+The enrichment step fetches the page directly, so it fails on exactly the
+bot-blocked / JS-only / slow sites these scrapers exist to handle (Tavily is
+used precisely because a plain request is rejected). A failure there must not
+discard the content the primary extractor already produced.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_tavily_extract_returns_content_when_enrichment_fetch_fails(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "test-key")
+    from gpt_researcher.scraper.tavily_extract.tavily_extract import TavilyExtract
+
+    session = MagicMock()
+    session.get.side_effect = Exception("403 Forbidden")  # the secondary fetch is blocked
+
+    scraper = TavilyExtract("https://example.com/blocked", session=session)
+    scraper.tavily_client = MagicMock()
+    scraper.tavily_client.extract.return_value = {
+        "failed_results": [],
+        "results": [{"raw_content": "PRIMARY CONTENT"}],
+    }
+
+    content, image_urls, title = scraper.scrape()
+
+    assert content == "PRIMARY CONTENT"  # returned "" on main
+    assert image_urls == []
+    assert title == ""
+
+
+def test_web_base_loader_returns_content_when_enrichment_fetch_fails():
+    from gpt_researcher.scraper.web_base_loader.web_base_loader import WebBaseLoaderScraper
+
+    session = MagicMock()
+    session.get.side_effect = Exception("403 Forbidden")  # the secondary fetch is blocked
+
+    scraper = WebBaseLoaderScraper("https://example.com/blocked", session=session)
+
+    doc = MagicMock()
+    doc.page_content = "PRIMARY CONTENT"
+    with patch("langchain_community.document_loaders.WebBaseLoader") as web_base_loader:
+        web_base_loader.return_value.load.return_value = [doc]
+        content, image_urls, title = scraper.scrape()
+
+    assert content == "PRIMARY CONTENT"  # returned "" on main
+    assert image_urls == []
+    assert title == ""


### PR DESCRIPTION
## Problem

`TavilyExtract.scrape()` and `WebBaseLoaderScraper.scrape()` read the primary content (Tavily's extract result / the WebBaseLoader documents) inside the same `try`/`except` as a second, direct page fetch (`self.session.get(...)`) that exists only to enrich the result with images and a title.

That secondary fetch is exactly the request that fails on the sites these scrapers are used for: Tavily Extract is reached for pages that reject a plain request (Cloudflare, 403 bot-blocks, JS-only, slow). `TavilyExtract` uses `timeout=4`, and `WebBaseLoaderScraper` uses no timeout at all. When the secondary fetch raises, the blanket `except` returns `("", [], "")`, discarding content that was already extracted (and, for Tavily, already billed to the API). So on the hardest sites, the ones Tavily exists to handle, the content is reliably thrown away.

## Root cause

In both scrapers the good content and the fragile enrichment fetch share one `try` block. Tavily (`gpt_researcher/scraper/tavily_extract/tavily_extract.py`):

```python
response = self.tavily_client.extract(urls=self.link)   # primary content (paid)
...
response_bs = self.session.get(self.link, timeout=4)    # secondary fetch; raises on blocked sites
...
content = response['results'][0]['raw_content']         # not reached if the line above raised
...
except Exception:
    return "", [], ""                                    # content discarded
```

`WebBaseLoaderScraper` has the same shape (content built from `loader.load()`, then a fragile `self.session.get(self.link)` for images/title, one shared `except`).

## Fix

Read the primary content first, then make the image and title enrichment best-effort: wrap the secondary fetch in its own `try`/`except` that logs and degrades to empty images/title, so the content is always returned. The outer `except` still handles a genuine primary-extraction failure.

The same pattern exists in `firecrawl.py`, but that file has an open PR (#1756), so it is left out of this change to avoid a conflict.

## Verification

Clean container, dependencies from `requirements.txt`:

- New regression tests in `tests/test_scrapers_preserve_content.py` (one per scraper) mock the primary extractor to succeed and the enrichment fetch to raise. They fail on `main` (content discarded, returns `""`) and pass with the fix.
- Both scrapers still return the content (with empty images/title) when enrichment fails, and are unchanged on the success path.
