### PR TITLE
fix(retriever): guard TavilySearch against malformed/missing result fields

### DIFF
--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -115,10 +115,17 @@ class TavilySearch:
             sources = results.get("results", [])
             if not sources:
                 raise Exception("No results found with Tavily API search.")
-            # Return the results
-            search_response = [
-                {"href": obj["url"], "body": obj["content"]} for obj in sources
-            ]
+            # Return the results. Guard each source against missing/None
+            # fields so a single malformed hit does not drop the whole page.
+            search_response = []
+            for obj in sources:
+                if not isinstance(obj, dict):
+                    continue
+                href = obj.get("url")
+                if not href:
+                    continue
+                body = obj.get("content") or obj.get("snippet") or ""
+                search_response.append({"href": href, "body": body})
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_tavily_malformed.py
+++ b/tests/test_tavily_malformed.py
@@ -1,0 +1,39 @@
+"""TavilySearch must skip malformed sources instead of raising KeyError."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gpt_researcher.retrievers.tavily.tavily_search import TavilySearch
+
+
+def test_tavily_skips_sources_missing_url_or_non_dict():
+    sources = [
+        {"url": "https://a.example", "content": "ok"},
+        {"content": "no url"},
+        "not-a-dict",
+        {"url": "https://b.example", "snippet": "from snippet"},
+        {"url": None, "content": "null url"},
+        {"url": "https://c.example", "content": None},
+    ]
+
+    searcher = TavilySearch.__new__(TavilySearch)
+    searcher.query = "q"
+    searcher.topic = "general"
+    searcher.query_domains = None
+    searcher.api_key = "fake"
+    searcher.headers = {}
+    searcher.base_url = "https://api.tavily.com/search"
+
+    with patch.object(
+        searcher,
+        "_search",
+        return_value={"results": sources},
+    ):
+        out = searcher.search(max_results=10)
+
+    assert out == [
+        {"href": "https://a.example", "body": "ok"},
+        {"href": "https://b.example", "body": "from snippet"},
+        {"href": "https://c.example", "body": ""},
+    ]


### PR DESCRIPTION
## Summary

- Guard `TavilySearch.search` so one malformed hit does not abort the whole result set.
- Skip non-dict items and empty/missing `url`; prefer `content`, then `snippet`, then empty body.

## Motivation

The list comprehension used `obj["url"]` / `obj["content"]`. Tavily occasionally returns partial objects (or callers inject edge cases); a single `KeyError` was caught by the outer `except Exception` and converted to an **empty** search response — discarding every good source for that query. Same class of bug already fixed for Bing/SerpApi/SearchAPI/CRW retrievers in this fork.

## Verification

- `.venv/bin/python -m pytest tests/test_tavily_malformed.py` → **1 passed**
- Real behavior without fix: one source missing `"url"` → `KeyError` → empty list from outer handler.
- With fix: good sources are kept; bad ones are skipped.

## Differential value

Does not shim invalid input into fake content — surfaces only valid `href`s and uses empty body when content is absent.
