### PR TITLE
fix(retriever): always return a list from CustomRetriever.search

### DIFF
--- a/gpt_researcher/retrievers/custom/custom.py
+++ b/gpt_researcher/retrievers/custom/custom.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 import requests
 import os
 
@@ -26,7 +26,7 @@ class CustomRetriever:
             if key.startswith('RETRIEVER_ARG_')
         }
 
-    def search(self, max_results: int = 5) -> Optional[List[Dict[str, Any]]]:
+    def search(self, max_results: int = 5) -> List[Dict[str, Any]]:
         """
         Performs the search using the custom retriever endpoint.
 
@@ -44,9 +44,28 @@ class CustomRetriever:
             ]
         """
         try:
-            response = requests.get(self.endpoint, params={**self.params, 'query': self.query})
+            response = requests.get(
+                self.endpoint,
+                params={**self.params, "query": self.query},
+                timeout=20,
+            )
             response.raise_for_status()
-            return response.json()
-        except requests.RequestException as e:
+            payload = response.json()
+        except (requests.RequestException, ValueError) as e:
+            # ValueError covers JSONDecodeError (subclass) and other parse fails.
             print(f"Failed to retrieve search results: {e}")
-            return None
+            return []
+
+        # Contract: callers iterate the return value. A null JSON body or a
+        # non-list payload used to surface as TypeError later (or as the
+        # documented but surprising Optional). Always hand back a list.
+        if payload is None:
+            return []
+        if not isinstance(payload, list):
+            print(
+                "Custom retriever response must be a JSON list of "
+                "{url, raw_content} objects; got "
+                f"{type(payload).__name__}"
+            )
+            return []
+        return payload

--- a/tests/test_custom_retriever_guard.py
+++ b/tests/test_custom_retriever_guard.py
@@ -1,0 +1,58 @@
+"""CustomRetriever.search must always return a list, never None."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.custom.custom import CustomRetriever
+
+
+def _make(endpoint="https://example.test/search"):
+    with patch.dict("os.environ", {"RETRIEVER_ENDPOINT": endpoint}, clear=False):
+        return CustomRetriever(query="q")
+
+
+def test_custom_returns_empty_list_on_http_error():
+    c = _make()
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = Exception("boom")
+    # Use requests.RequestException path
+    import requests
+
+    resp.raise_for_status.side_effect = requests.HTTPError("boom")
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+        out = c.search()
+    assert out == []
+
+
+def test_custom_returns_empty_list_on_null_json():
+    c = _make()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = None
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+        out = c.search()
+    assert out == []
+
+
+def test_custom_returns_empty_list_on_non_list_json():
+    c = _make()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"url": "x"}
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+        out = c.search()
+    assert out == []
+
+
+def test_custom_returns_list_payload():
+    c = _make()
+    payload = [{"url": "https://a", "raw_content": "hi"}]
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp) as get:
+        out = c.search()
+    assert out == payload
+    # timeout is passed so the retriever cannot hang forever
+    assert get.call_args.kwargs.get("timeout") == 20


### PR DESCRIPTION
## Summary

- `CustomRetriever.search` always returns a `list` (never `None`).
- HTTP / JSON parse failures and non-list payloads become `[]`.
- HTTP calls now use `timeout=20`.

## Motivation

The previous contract was `Optional[List[...]]` and the error path returned `None`. Callers that `for x in retriever.search()` then raised `TypeError: 'NoneType' object is not iterable`, which often surfaced only as an opaque research failure. A JSON body of `null` or an object produced the same class of downstream crash. Returning an empty list matches the other retrievers (Serper/PubMed/…) and keeps the run alive when the custom endpoint misbehaves.

This is enforcement of the documented list contract — not a silent shim of bad data into fake results.

## Verification

- `.venv/bin/python -m pytest tests/test_custom_retriever_guard.py` → **4 passed**
- Real behavior without fix: network/HTTP error → `None` → `TypeError` on iteration.
- With fix: network/HTTP error, `null` JSON, and object JSON → `[]`; valid list payload returned as-is.

## Files

- `gpt_researcher/retrievers/custom/custom.py`
- `tests/test_custom_retriever_guard.py`
