### PR TITLE
fix(retriever): guard ExaSearch against null url/id/text on result objects

### DIFF
--- a/gpt_researcher/retrievers/exa/exa.py
+++ b/gpt_researcher/retrievers/exa/exa.py
@@ -60,9 +60,13 @@ class ExaSearch:
             **filters
         )
 
-        search_response = [
-            {"href": result.url, "body": result.text} for result in results.results
-        ]
+        search_response = []
+        for result in results.results or []:
+            href = getattr(result, "url", None)
+            if not href:
+                continue
+            body = getattr(result, "text", None) or getattr(result, "summary", None) or ""
+            search_response.append({"href": href, "body": body})
         return search_response
 
     def find_similar(self, url, exclude_source_domain=False, **filters):
@@ -79,9 +83,13 @@ class ExaSearch:
             url, exclude_source_domain=exclude_source_domain, **filters
         )
 
-        similar_response = [
-            {"href": result.url, "body": result.text} for result in results.results
-        ]
+        similar_response = []
+        for result in results.results or []:
+            href = getattr(result, "url", None)
+            if not href:
+                continue
+            body = getattr(result, "text", None) or getattr(result, "summary", None) or ""
+            similar_response.append({"href": href, "body": body})
         return similar_response
 
     def get_contents(self, ids, **options):
@@ -95,7 +103,11 @@ class ExaSearch:
         """
         results = self.client.get_contents(ids, **options)
 
-        contents_response = [
-            {"id": result.id, "content": result.text} for result in results.results
-        ]
+        contents_response = []
+        for result in results.results or []:
+            result_id = getattr(result, "id", None)
+            if result_id is None:
+                continue
+            content = getattr(result, "text", None) or ""
+            contents_response.append({"id": result_id, "content": content})
         return contents_response

--- a/tests/test_exa_null_attrs.py
+++ b/tests/test_exa_null_attrs.py
@@ -1,0 +1,53 @@
+"""ExaSearch must skip hits with missing url/id rather than raising."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.exa.exa import ExaSearch
+
+
+def _searcher():
+    # bypass __init__ pkg/API setup
+    s = ExaSearch.__new__(ExaSearch)
+    s.query = "q"
+    s.query_domains = None
+    s.api_key = "k"
+    s.client = MagicMock()
+    return s
+
+
+def test_search_skips_missing_url_and_uses_summary_fallback():
+    s = _searcher()
+    s.client.search.return_value = SimpleNamespace(
+        results=[
+            SimpleNamespace(url="https://a.example", text="body a"),
+            SimpleNamespace(url=None, text="orphan"),
+            SimpleNamespace(url="https://b.example", text=None, summary="sum b"),
+        ]
+    )
+    out = s.search(max_results=5)
+    assert out == [
+        {"href": "https://a.example", "body": "body a"},
+        {"href": "https://b.example", "body": "sum b"},
+    ]
+
+
+def test_find_similar_skips_missing_url():
+    s = _searcher()
+    s.client.find_similar.return_value = SimpleNamespace(
+        results=[SimpleNamespace(url="", text="x"), SimpleNamespace(url="https://c", text="y")]
+    )
+    assert s.find_similar("https://seed") == [{"href": "https://c", "body": "y"}]
+
+
+def test_get_contents_skips_missing_id():
+    s = _searcher()
+    s.client.get_contents.return_value = SimpleNamespace(
+        results=[
+            SimpleNamespace(id="1", text="t"),
+            SimpleNamespace(id=None, text="nope"),
+        ]
+    )
+    assert s.get_contents(["1"]) == [{"id": "1", "content": "t"}]


### PR DESCRIPTION
## Summary

- Guard `ExaSearch.search`, `find_similar`, and `get_contents` against missing `url` / `id` / `text`.
- Fall back to `summary` (then empty string) for body when `text` is absent; skip unusable rows.

## Motivation

The result mappers used attribute access + list comprehensions. Exa occasionally returns sparse result objects (or mock/test doubles omit fields); one incomplete hit raised `AttributeError` and discarded siblings. Same defensive pattern as Bing/SerpApi/Tavily/Google guards already in-flight for this repo.

Does not invent URLs — rows without `url`/`id` are dropped so only addressable sources flow downstream.

## Verification

- `.venv/bin/python -m pytest tests/test_exa_null_attrs.py` → **3 passed**
- Real behavior without fix: result with `url=None` → `AttributeError` / unusable `href: None` propagating downstream.
- With fix: valid rows kept; orphan rows skipped; summary used when text missing.

## Files

- `gpt_researcher/retrievers/exa/exa.py`
- `tests/test_exa_null_attrs.py`
