### PR TITLE
Add agent observability with Monocle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,12 @@ DOC_PATH=./my-docs
 # LANGCHAIN_API_KEY=
 # LANGCHAIN_PROJECT="gpt-researcher"
 
+# Monocle Tracing - Optional OpenTelemetry-based agent tracing
+# Off by default. Requires the optional extra: pip install "gpt-researcher[monocle]"
+# MONOCLE_TRACING=true
+# MONOCLE_EXPORTERS=file          # file, console, okahu, s3, blob, gcs (default: file)
+# OKAHU_API_KEY=okh_xxxxxxxx      # required only for the `okahu` exporter
+
 # Token Limits
 # ------------
 # Maximum output tokens per LLM call. Leaving unset uses package defaults

--- a/README.md
+++ b/README.md
@@ -298,6 +298,24 @@ To enable tracing:
    ```
 2. Run your research tasks as usual. All LangGraph-based agent interactions will be automatically traced and visualized in your LangSmith dashboard.
 
+#### Monocle Tracing
+
+GPT Researcher also supports [Monocle](https://github.com/monocle2ai/monocle), an OpenTelemetry-based tracer for agentic applications. It records each run end-to-end: LLM calls, agent steps, and tool invocations, with their inputs, outputs, timings, and token counts.
+
+Monocle is an opt-in extra and is off by default. Install it, then add the following to your `.env` file:
+
+```bash
+pip install "gpt-researcher[monocle]"
+```
+
+```bash
+MONOCLE_TRACING=true
+MONOCLE_EXPORTERS=file          # file, console, okahu, s3, blob, gcs (default: file)
+OKAHU_API_KEY=okh_xxxxxxxx      # required only for the `okahu` exporter
+```
+
+Each run writes one trace file to `.monocle/`; open it in the [Monocle VS Code extension](https://marketplace.visualstudio.com/items?itemName=OkahuAI.monocle-apptrace). Connect to [Okahu](https://www.okahu.ai) to analyze traces across runs (via the `okahu` exporter).
+
 ## 🖥️ Frontend Applications
 
 GPT-Researcher now features an enhanced frontend to improve the user experience and streamline the research process. The frontend offers:

--- a/multi_agents/main.py
+++ b/multi_agents/main.py
@@ -4,6 +4,31 @@ import os
 import uuid
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+# Optional Monocle observability, gated by MONOCLE_TRACING (mirrors the LangSmith
+# toggle below). Runs before the framework imports so Monocle instruments them as
+# they load. The app owns MONOCLE_EXPORTERS: it validates the selection, then
+# forwards the raw comma-separated string to Monocle. No-op when unset.
+if os.environ.get("MONOCLE_TRACING", "").strip().lower() in ("1", "true", "yes", "on"):
+    _exporters = os.environ.get("MONOCLE_EXPORTERS", "").strip() or "file"
+    _allowed = ("file", "console", "okahu", "s3", "blob", "gcs")
+    _selected = [e.strip() for e in _exporters.split(",") if e.strip()]
+    _unknown = [e for e in _selected if e not in _allowed]
+    if _unknown:
+        raise ValueError(
+            f"MONOCLE_EXPORTERS has unknown exporter(s): {', '.join(_unknown)}. "
+            f"Allowed: {', '.join(_allowed)}."
+        )
+    if "okahu" in _selected and not os.environ.get("OKAHU_API_KEY"):
+        raise ValueError("Monocle 'okahu' exporter is selected but OKAHU_API_KEY is not set.")
+    try:
+        from monocle_apptrace import setup_monocle_telemetry
+    except ImportError as exc:
+        raise RuntimeError(
+            "MONOCLE_TRACING is enabled but monocle_apptrace is not installed. "
+            'Install the "monocle" extra: pip install "gpt-researcher[monocle]".'
+        ) from exc
+    setup_monocle_telemetry(workflow_name="gpt-researcher", monocle_exporters_list=_exporters)
+
 from multi_agents.agents import ChiefEditorAgent
 import asyncio
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,12 @@ requirements-txt = [
     "scrapy",
     "selenium",
 ]
+# Optional agent observability via Monocle. Install with:
+#   pip install "gpt-researcher[monocle]"
+# then enable at runtime with MONOCLE_TRACING=true. Not pulled by a plain install.
+monocle = [
+    "monocle_apptrace",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Adds Monocle observability to the agent. Monocle is an OpenTelemetry-based tracer for LLM applications. With it enabled, each run is recorded as a structured trace: the agent and graph invocations, tool calls, LLM inferences, token usage, and timings. The change is additive and does not alter application logic.

## What this adds

Instrumentation is one setup call plus one dependency:

- `multi_agents/requirements.txt`: adds `monocle_apptrace`.
- `multi_agents/main.py`: calls `setup_monocle_telemetry(workflow_name="gpt-researcher", monocle_exporters_list="file")` at startup.

That call auto-instruments the frameworks already in use (LangGraph and the LLM clients), so there is no per-tool or per-call wiring to maintain. Traces are written to `.monocle/` by default.

## What you get

Each run produces a trace of all the agents that were triggered and the LLM inferences they made. In effect, it's the path the run took to produce the report. This is useful for developers building the agent, since they can see how it actually behaved on a run. The same traces are also a good basis for a behavioral test suite, an integration test that asserts on that behavior, and I've opened a companion PR that shows how that works: [behavioral test suite](https://github.com/assafelovic/gpt-researcher/pull/1874). You can open the trace files directly, view them in the [Monocle VS Code extension](https://marketplace.visualstudio.com/items?itemName=OkahuAI.monocle-apptrace), or send them to [Okahu](https://www.okahu.ai) for analysis across many runs.


---

## Example trace (Okahu VS Code Extension)

GPT Researcher's multi-agent workflow (`ChiefEditorAgent` orchestrating researcher, writer, reviewer) captured as trace spans.

<img width="1710" height="1074" alt="image" src="https://github.com/user-attachments/assets/998b77e5-86cf-4958-bc8d-695a4465352c" />






---

PS: if Monocle looks useful, a ⭐ helps the project (https://github.com/monocle2ai/monocle). And if you want to turn these traces into tests, that's the companion PR (#1874).
