### PR TITLE
fix(retriever): normalize DuckDuckGo results to href/body contract

### DIFF
--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -15,10 +15,13 @@ class Duckduckgo:
 
     def search(self, max_results=5):
         """
-        Performs the search
-        :param query:
-        :param max_results:
-        :return:
+        Performs the search and normalizes ddgs payloads to the shared
+        ``{href, body, title?}`` contract used by other retrievers.
+
+        ``ddgs`` historically returned dicts with ``href``/`body` keys; newer
+        releases emit ``link``/`url` and ``body`/`snippet`/`description``.
+        Downstream research steps expect ``href`` and would KeyError or skip
+        sources if the raw ddgs shape is returned unchanged.
         """
         # TODO: Add support for query domains
         try:
@@ -26,4 +29,33 @@ class Duckduckgo:
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []
-        return search_response
+
+        if not search_response:
+            return []
+
+        normalized = []
+        for result in search_response:
+            if not isinstance(result, dict):
+                continue
+            href = (
+                result.get("href")
+                or result.get("link")
+                or result.get("url")
+                or ""
+            )
+            if not href:
+                continue
+            body = (
+                result.get("body")
+                or result.get("snippet")
+                or result.get("description")
+                or ""
+            )
+            item = {"href": href, "body": body}
+            title = result.get("title")
+            if title:
+                item["title"] = title
+            normalized.append(item)
+
+        # Preserve caller-requested max_results even if the client ignored it.
+        return list(islice(normalized, max_results))

--- a/tests/test_duckduckgo_normalize.py
+++ b/tests/test_duckduckgo_normalize.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "duckduckgo" / "duckduckgo.py"
+
+
+def _load_duckduckgo_module():
+    # Load the module file directly so we never import gpt_researcher package
+    # (pulling json_repair and other heavy deps is unrelated to this unit).
+    utils_mod = types.ModuleType("gpt_researcher.retrievers.utils")
+    utils_mod.check_pkg = lambda *a, **k: None
+    pkg = types.ModuleType("gpt_researcher")
+    retrievers = types.ModuleType("gpt_researcher.retrievers")
+    sys.modules.setdefault("gpt_researcher", pkg)
+    sys.modules.setdefault("gpt_researcher.retrievers", retrievers)
+    sys.modules["gpt_researcher.retrievers.utils"] = utils_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.duckduckgo.duckduckgo", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class DuckduckgoNormalizeTests(unittest.TestCase):
+    def test_normalizes_href_body_shape(self):
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        retriever = Duckduckgo.__new__(Duckduckgo)
+        retriever.query = "python"
+        retriever.query_domains = None
+        retriever.ddg = MagicMock()
+        retriever.ddg.text.return_value = [
+            {"link": "https://example.com/a", "snippet": "A", "title": "One"},
+            {"url": "https://example.com/b", "description": "B"},
+            {"href": "https://example.com/c", "body": "C", "title": "Three"},
+            {"title": "no-url"},
+        ]
+        results = Duckduckgo.search(retriever, max_results=5)
+        self.assertEqual(
+            results,
+            [
+                {"href": "https://example.com/a", "body": "A", "title": "One"},
+                {"href": "https://example.com/b", "body": "B"},
+                {"href": "https://example.com/c", "body": "C", "title": "Three"},
+            ],
+        )
+
+    def test_empty_or_error_returns_list(self):
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        retriever = Duckduckgo.__new__(Duckduckgo)
+        retriever.query = "python"
+        retriever.query_domains = None
+        retriever.ddg = MagicMock()
+        retriever.ddg.text.side_effect = Exception("network")
+        self.assertEqual(Duckduckgo.search(retriever), [])
+
+        retriever.ddg.text.side_effect = None
+        retriever.ddg.text.return_value = None
+        self.assertEqual(Duckduckgo.search(retriever), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Normalize DuckDuckGo/`ddgs` result dicts to the shared `{href, body, title?}` retriever contract.
- Skip malformed items without a URL; retain empty-list-on-error behavior.

## Motivation

Other retrievers always return `href`/`body`. `Duckduckgo.search` previously returned the raw `ddgs` payload, which newer clients may emit as `link`/`url` + `snippet`/`description`. Downstream research steps key on `href` and mis-handle the alternate shape, dropping sources or raising KeyError-style failures.

## Verification

- `python3 -m pytest tests/test_duckduckgo_normalize.py -q` — 2 passed
- Proof: raw `{link, snippet}` becomes `{href, body}`; no-url entries skipped; exceptions → `[]`

## Differential value

N/A — no open PR targets DuckDuckGo normalization (Bartok open PRs cover other retrievers).
