### PR TITLE
fix(retriever): guard Searx against malformed/missing result fields

### DIFF
--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -47,8 +47,8 @@ class SearxSearch():
         search_url = urljoin(self.base_url, "search")
         # TODO: Add support for query domains
         params = {
-            # The search query. 
-            'q': self.query, 
+            # The search query.
+            'q': self.query,
             # Output format of results. Format needs to be activated in searxng config.
             'format': 'json'
         }
@@ -61,18 +61,30 @@ class SearxSearch():
             )
             response.raise_for_status()
             results = response.json()
-
-            # Normalize results to match the expected format
-            search_response = []
-            for result in results.get('results', [])[:max_results]:
-                search_response.append({
-                    "href": result.get('url', ''),
-                    "body": result.get('content', '')
-                })
-
-            return search_response
-
         except requests.exceptions.RequestException as e:
             raise Exception(f"Error querying SearxNG: {str(e)}")
         except json.JSONDecodeError:
             raise Exception("Error parsing SearxNG response")
+
+        if not isinstance(results, dict):
+            return []
+
+        search_response = []
+        raw_results = results.get('results', [])
+        if not isinstance(raw_results, list):
+            return []
+
+        for result in raw_results:
+            if not isinstance(result, dict):
+                continue
+            href = result.get('url') or result.get('href') or ''
+            if not href:
+                continue
+            search_response.append({
+                "href": href,
+                "body": result.get('content') or result.get('snippet') or '',
+            })
+            if len(search_response) >= max_results:
+                break
+
+        return search_response

--- a/tests/test_searx_malformed_results.py
+++ b/tests/test_searx_malformed_results.py
@@ -1,0 +1,74 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "searx" / "searx.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    class RequestException(Exception):
+        pass
+    exceptions = types.ModuleType("requests.exceptions")
+    exceptions.RequestException = RequestException
+    requests_mod.exceptions = exceptions
+    requests_mod.get = MagicMock()
+    sys.modules["requests"] = requests_mod
+
+    for key in list(sys.modules):
+        if "searx.searx" in key:
+            sys.modules.pop(key, None)
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.searx.searx_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}, clear=False):
+        spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class SearxMalformedTests(unittest.TestCase):
+    def test_skips_missing_url_and_non_dict_items(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {"url": "https://a.example", "content": "A"},
+                {"content": "no url"},
+                "bad",
+                {"href": "https://b.example", "snippet": "B"},
+                None,
+            ]
+        }
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}):
+            out = mod.SearxSearch("q").search(max_results=10)
+        self.assertEqual(
+            out,
+            [
+                {"href": "https://a.example", "body": "A"},
+                {"href": "https://b.example", "body": "B"},
+            ],
+        )
+
+    def test_non_dict_json_returns_empty(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = ["not", "a", "dict"]
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}):
+            self.assertEqual(mod.SearxSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Harden SearxNG result parsing: skip non-dicts, require a URL (`url` or `href`), accept `snippet` as body alias.
- Non-dict JSON envelopes return `[]` instead of raising.

## Motivation

Prior path assumed every `results` item was a dict with `url`/`content`. Malformed public-instance payloads with missing URLs, string entries, or wrong envelope types either leak empty strings into the research pipeline or crash. Match the defensive pattern already applied to Tavily/Bing/SerpAPI retrievers.

## Verification

- `python3 -m pytest tests/test_searx_malformed_results.py -q` — 2 passed
- Proof: mixed malformed list compresses to two valid `{href, body}` rows; list-shaped JSON → `[]`

