### PR TITLE
fix(retriever): guard GroundRoute against malformed result fields

### DIFF
--- a/gpt_researcher/retrievers/groundroute/groundroute.py
+++ b/gpt_researcher/retrievers/groundroute/groundroute.py
@@ -47,12 +47,30 @@ class GroundRouteSearch:
                 timeout=20,
             )
             response.raise_for_status()
-            results = response.json().get("results", [])
-            return [
-                {"href": r.get("url"), "body": r.get("content") or r.get("snippet") or ""}
-                for r in results
-                if r.get("url")
-            ]
+            payload = response.json()
         except Exception as e:
             print(f"Error performing GroundRoute search: {e}")
             return []
+
+        if isinstance(payload, list):
+            results = payload
+        elif isinstance(payload, dict):
+            results = payload.get("results", [])
+        else:
+            return []
+
+        if not isinstance(results, list):
+            return []
+
+        normalized = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            href = r.get("url") or r.get("href") or r.get("link") or ""
+            if not href:
+                continue
+            body = r.get("content") or r.get("snippet") or r.get("body") or ""
+            normalized.append({"href": href, "body": body})
+            if len(normalized) >= max_results:
+                break
+        return normalized

--- a/tests/test_groundroute_malformed_results.py
+++ b/tests/test_groundroute_malformed_results.py
@@ -1,0 +1,63 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "groundroute" / "groundroute.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    requests_mod.post = MagicMock()
+    sys.modules["requests"] = requests_mod
+    for key in list(sys.modules):
+        if "groundroute.groundroute" in key:
+            sys.modules.pop(key, None)
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.groundroute.groundroute_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    with patch.dict(os.environ, {"GROUNDROUTE_API_KEY": "k"}):
+        spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class GroundRouteMalformedTests(unittest.TestCase):
+    def test_skips_missing_url(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {"url": "https://a.example", "content": "A"},
+                {"content": "no url"},
+                "bad",
+                {"link": "https://b.example", "snippet": "B"},
+            ]
+        }
+        requests_mod.post.return_value = resp
+        with patch.dict(os.environ, {"GROUNDROUTE_API_KEY": "k"}):
+            out = mod.GroundRouteSearch("q").search(max_results=10)
+        self.assertEqual(
+            out,
+            [
+                {"href": "https://a.example", "body": "A"},
+                {"href": "https://b.example", "body": "B"},
+            ],
+        )
+
+    def test_error_returns_empty(self):
+        mod, requests_mod = _load()
+        requests_mod.post.side_effect = Exception("boom")
+        with patch.dict(os.environ, {"GROUNDROUTE_API_KEY": "k"}):
+            self.assertEqual(mod.GroundRouteSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Harden GroundRoute result parsing against missing URLs, non-dict items, and list-shaped JSON envelopes.

## Motivation

`search()` assumed every `results` entry was a dict with `url`. Malformed multi-engine payloads dropped None `href` values into the research context or crashed on non-dict rows. Match the defensive filters already used for Tavily/Bing-class retrievers without silently inventing URLs.

## Verification

- `python3 -m pytest tests/test_groundroute_malformed_results.py -q` — 2 passed
- Proof: mixed payload keeps only URL-bearing rows; network error → `[]`

