### PR TITLE
fix(retriever): guard OpenAlex against malformed result payloads

### DIFF
--- a/gpt_researcher/retrievers/openalex/openalex.py
+++ b/gpt_researcher/retrievers/openalex/openalex.py
@@ -65,9 +65,17 @@ class OpenAlexSearch:
             print(f"An error occurred while accessing OpenAlex API: {e}")
             return []
 
-        results = response.json().get("results", [])
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return []
+        results = payload.get("results", [])
+        if not isinstance(results, list):
+            return []
+
         search_result = []
         for result in results:
+            if not isinstance(result, dict):
+                continue
             title = result.get("title") or "No Title"
             href = self._pick_href(result)
             body = self._reconstruct_abstract(result.get("abstract_inverted_index"))
@@ -107,11 +115,18 @@ class OpenAlexSearch:
         OpenAlex returns abstracts as an inverted index (word -> positions).
         Reconstruct the original text.
         """
-        if not inverted:
+        if not inverted or not isinstance(inverted, dict):
             return None
         positions: List[tuple] = []
         for word, indexes in inverted.items():
+            if not isinstance(indexes, (list, tuple)):
+                continue
             for i in indexes:
-                positions.append((i, word))
+                try:
+                    positions.append((int(i), word))
+                except (TypeError, ValueError):
+                    continue
+        if not positions:
+            return None
         positions.sort(key=lambda x: x[0])
         return " ".join(word for _, word in positions)

--- a/tests/test_openalex_malformed_results.py
+++ b/tests/test_openalex_malformed_results.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "openalex" / "openalex.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    class RequestException(Exception):
+        pass
+    requests_mod.RequestException = RequestException
+    requests_mod.get = MagicMock()
+    sys.modules["requests"] = requests_mod
+    for key in list(sys.modules):
+        if "openalex.openalex" in key:
+            sys.modules.pop(key, None)
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.openalex.openalex_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class OpenAlexMalformedTests(unittest.TestCase):
+    def test_skips_non_dict_and_guards_abstract(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {
+                    "title": "Paper",
+                    "id": "https://openalex.org/W1",
+                    "abstract_inverted_index": {"hello": [0], "world": [1]},
+                    "best_oa_location": {},
+                    "primary_location": {},
+                },
+                "bad",
+                {
+                    "title": "Broken abstract",
+                    "id": "https://openalex.org/W2",
+                    "abstract_inverted_index": "not-a-dict",
+                        "best_oa_location": {},
+                    "primary_location": {},
+                },
+            ]
+        }
+        requests_mod.get.return_value = resp
+        out = mod.OpenAlexSearch("q").search()
+        self.assertEqual(out[0]["href"], "https://openalex.org/W1")
+        self.assertEqual(out[0]["body"], "hello world")
+        self.assertEqual(out[1]["href"], "https://openalex.org/W2")
+        self.assertEqual(out[1]["body"], "Abstract not available")
+
+    def test_non_dict_payload(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = ["nope"]
+        requests_mod.get.return_value = resp
+        self.assertEqual(mod.OpenAlexSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Guard OpenAlex `search()` against non-dict envelopes / non-list `results` / non-dict items.
- Harden inverted-index abstract reconstruction against non-dict indexes and non-int positions.

## Motivation

OpenAlex sometimes returns incomplete works records; a non-dict inverted index (`None`/string) or bad index entries crashed `_reconstruct_abstract` mid-loop and wiped the entire result set. Envelope shape checks plus safe reconstruction match the robustness pattern used on commercial search retrievers.

## Verification

- `python3 -m pytest tests/test_openalex_malformed_results.py -q` — 2 passed
- Proof: mixed payload yields two works; broken abstract → "Abstract not available"; list envelope → `[]`

