### PR TITLE
fix(research): record prefetched full-text sources in visited_urls

### DIFF
--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -780,6 +780,12 @@ class ResearchConductor:
                     if url and raw_content and len(raw_content) > 100:
                         # Only raw_content signals that a retriever already fetched the full page.
                         # body is snippet-sized text for most web retrievers and still needs scraping.
+                        # Record prefetched URLs in visited_urls, same as scraped URLs: their
+                        # content feeds the context, so they must be deduped across sub-queries
+                        # (and across retrievers) and listed in the report's sources/references.
+                        if url in self.researcher.visited_urls:
+                            continue
+                        self.researcher.visited_urls.add(url)
                         prefetched_content.append({
                             "url": url,
                             "raw_content": raw_content,

--- a/tests/test_prefetched_sources_tracked.py
+++ b/tests/test_prefetched_sources_tracked.py
@@ -1,0 +1,82 @@
+"""Regression tests: prefetched full-text sources (retrievers that already
+return raw_content, e.g. PubMed Central or Tavily with include_raw_content)
+must be tracked in visited_urls, exactly like scraped URLs.
+
+Their content is merged into the research context (_scrape_data_by_urls:
+`scraped_content.extend(prefetched_content)`), so they must be:
+  1. recorded in visited_urls, which drives get_source_urls() and the report's
+     references (add_references(report, visited_urls)); and
+  2. deduped across sub-queries, so an article that matches several related
+     sub-queries is not merged into the context (and billed) more than once.
+
+Before the fix, prefetched URLs went only into research_sources, never
+visited_urls, so they were omitted from references and re-collected every
+sub-query while scraped URLs were correctly deduped.
+"""
+import asyncio
+import types
+
+from gpt_researcher.skills.researcher import ResearchConductor
+
+PREFETCH_URL = "https://pmc.example.org/article/PMC123"
+SCRAPE_URL = "https://blog.example.org/post"
+
+
+class _FakeRetriever:
+    """Returns the same prefetched (raw_content) result + bare-url result for
+    every sub-query, modelling an article that matches related sub-queries."""
+
+    def __init__(self, query, query_domains=None):
+        self.query = query
+
+    def search(self, max_results=5):
+        return [
+            {"href": PREFETCH_URL, "raw_content": "F" * 500},
+            {"href": SCRAPE_URL, "body": "short snippet"},
+        ]
+
+
+def _make_researcher():
+    r = types.SimpleNamespace()
+    r.retrievers = [_FakeRetriever]
+    r.cfg = types.SimpleNamespace(max_search_results_per_query=5)
+    r.visited_urls = set()
+    r.research_sources = []
+    r.add_research_sources = lambda sources: r.research_sources.extend(sources)
+    r.get_source_urls = lambda: list(r.visited_urls)
+    r.verbose = False
+    r.websocket = None
+    r.vector_store = None
+
+    async def browse_urls(urls):
+        return [{"url": u, "raw_content": "scraped body"} for u in urls]
+
+    r.scraper_manager = types.SimpleNamespace(browse_urls=browse_urls)
+    return r
+
+
+def test_prefetched_source_is_recorded_in_visited_urls():
+    r = _make_researcher()
+    conductor = ResearchConductor(r)
+
+    asyncio.run(conductor._scrape_data_by_urls("sub query 1"))
+
+    # The prefetched full-text source contributes content, so it must appear in
+    # the source/reference list, not only the scraped URL.
+    assert PREFETCH_URL in r.visited_urls
+    assert PREFETCH_URL in r.get_source_urls()
+    assert SCRAPE_URL in r.visited_urls
+
+
+def test_prefetched_source_deduped_across_sub_queries():
+    r = _make_researcher()
+    conductor = ResearchConductor(r)
+
+    sq1 = asyncio.run(conductor._scrape_data_by_urls("sub query 1"))
+    sq2 = asyncio.run(conductor._scrape_data_by_urls("sub query 2"))
+
+    context_urls = [d["url"] for d in sq1 + sq2]
+    # The same prefetched article must be merged into the context exactly once,
+    # matching the dedup the scraped path already gets via visited_urls.
+    assert context_urls.count(PREFETCH_URL) == 1
+    assert context_urls.count(SCRAPE_URL) == 1


### PR DESCRIPTION
### Root cause

`ResearchConductor._search_relevant_source_urls` splits each retriever result into two paths. A result that already carries `raw_content` (a retriever that fetched the full page, e.g. PubMed Central, or Tavily with `include_raw_content`) goes into `prefetched_content` and is registered only via `add_research_sources([{"url": url}])`. Only the bare-URL results reach `_get_new_urls`, the sole place a URL is added to `visited_urls`.

But prefetched content is merged straight into the research context:

```python
# _scrape_data_by_urls
scraped_content = await self.researcher.scraper_manager.browse_urls(new_search_urls)
scraped_content.extend(prefetched_content)   # prefetched text feeds the context
```

So a prefetched source contributes content exactly like a scraped one, yet never enters `visited_urls`. Two consequences:

1. **Missing from references/sources.** `visited_urls` drives `get_source_urls()` and the report's reference list (`add_references(report, visited_urls)`). A full-text source is used in the report but omitted from its sources.
2. **Duplicated across sub-queries.** Scraped URLs are deduped across sub-queries via `visited_urls` in `_get_new_urls`; prefetched URLs bypass that, so an article matching several related sub-queries is re-merged into the context (and re-billed) every time.

### Fix

Record prefetched URLs in `visited_urls` (skip if already seen), same as scraped URLs. Lists them as sources and dedups them across sub-queries and retrievers. +6 lines.

### Verified (clean Docker container, python:3.12-slim + requirements.txt)

Driving the real `_scrape_data_by_urls` across two sub-queries with a retriever returning one `raw_content` result + one bare-url result:

- On `main` (18d40516): prefetched URL absent from `visited_urls`; merged into context **2×**.
- On the branch: prefetched URL present in `visited_urls`/`get_source_urls()`; merged **1×**; scraped URL stays at 1×.

Regression test `tests/test_prefetched_sources_tracked.py` (2 cases) fails on main, passes on the branch. Existing `tests/test_research_conductor_retrieval.py` stays green; no new ruff findings on the changed file.

### Note

I included prefetched URLs in `visited_urls` because their content contributes to the report exactly like scraped content, and the method's own docstring treats them as sources. If you'd rather keep `visited_urls` scraped-only and track prefetched sources for references separately, happy to adjust.
