### PR TITLE
fix(multi_agents): exact None sentinel for reviewer and fact-checker

### DIFF
--- a/multi_agents/agents/fact_checker.py
+++ b/multi_agents/agents/fact_checker.py
@@ -44,7 +44,9 @@ class FactCheckerAgent:
 
         review = await self.check_facts(research_state)
 
-        if "None" in review:
+        from .utils.none_sentinels import is_none_accept_response
+
+        if is_none_accept_response(review):
             review = None
             if self.websocket and self.stream_output:
                 await self.stream_output("logs", "fact_checking", "Draft accepted by Fact Checker.", self.websocket)

--- a/multi_agents/agents/reviewer.py
+++ b/multi_agents/agents/reviewer.py
@@ -56,7 +56,9 @@ Guidelines: {guidelines}\nDraft: {draft_state.get("draft")}\n
                     f"Review feedback is: {response}...", agent="REVIEWER"
                 )
 
-        if "None" in response:
+        from .utils.none_sentinels import is_none_accept_response
+
+        if is_none_accept_response(response):
             return None
         return response
 

--- a/multi_agents/agents/reviser.py
+++ b/multi_agents/agents/reviser.py
@@ -34,7 +34,7 @@ class ReviserAgent:
             },
             {
                 "role": "user",
-                "content": f"""Draft:\n{draft_report}" + "Reviewer's notes:\n{review}\n\n
+                "content": f"""Draft:\n{draft_report}\nReviewer's notes:\n{review}\n\n
 You have been tasked by your reviewer with revising the following draft, which was written by a non-expert.
 If you decide to follow the reviewer's notes, please write a new draft and make sure to address all of the points they raised.
 Please keep all other aspects of the draft the same.

--- a/multi_agents/agents/utils/none_sentinels.py
+++ b/multi_agents/agents/utils/none_sentinels.py
@@ -1,0 +1,42 @@
+"""Strict parsers for LLM / human "none" / "no" acceptance sentinels.
+
+Substring checks (``"None" in response``, ``"no" in feedback``) false-accept
+review notes like "None of the criteria are met" or human plan feedback like
+"not enough cost data". Keep the sentinels exact (optional surrounding
+quotes / whitespace) so real critical notes are never treated as approval.
+"""
+
+from __future__ import annotations
+
+
+def is_none_accept_response(response: str | None) -> bool:
+    """True only when *response* is exactly the accept sentinel ``None``.
+
+    Accepts optional surrounding whitespace and a single pair of matching
+    ``'`` / ``"`` quotes (models often quote the token). Empty / ``None``
+    inputs are not treated as acceptance — callers that meant "no review"
+    should pass that state explicitly rather than lean on empty strings.
+    """
+    if response is None:
+        return False
+    if not isinstance(response, str):
+        response = str(response)
+    text = response.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        text = text[1:-1].strip()
+    return text.lower() == "none"
+
+
+def is_human_plan_approval(feedback: str | None) -> bool:
+    """True only when *feedback* is exactly the cancel/approve sentinel ``no``.
+
+    The human-feedback prompt asks users to reply with ``no`` when the plan
+    needs no changes. Matching the whole (normalized) string avoids dropping
+    real revision requests that merely contain the letters ``no``
+    (e.g. "not enough on evaluation", "novel methods").
+    """
+    if feedback is None:
+        return False
+    if not isinstance(feedback, str):
+        feedback = str(feedback)
+    return feedback.strip().lower() == "no"

--- a/tests/test_none_accept_sentinels.py
+++ b/tests/test_none_accept_sentinels.py
@@ -1,0 +1,62 @@
+"""Strict None/no acceptance sentinels for multi_agents loops.
+
+Regression for #1881 (reviewer/fact-checker false-accept on substring "None")
+and shared helpers for the human plan-approval gate (#1882).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SENTINEL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "multi_agents"
+    / "agents"
+    / "utils"
+    / "none_sentinels.py"
+)
+spec = importlib.util.spec_from_file_location("none_sentinels", SENTINEL_PATH)
+none_sentinels = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(none_sentinels)
+
+is_none_accept_response = none_sentinels.is_none_accept_response
+is_human_plan_approval = none_sentinels.is_human_plan_approval
+
+
+def test_none_accept_exact_token():
+    assert is_none_accept_response("None") is True
+    assert is_none_accept_response("none") is True
+    assert is_none_accept_response("  NONE  ") is True
+
+
+def test_none_accept_optional_quotes():
+    assert is_none_accept_response('"None"') is True
+    assert is_none_accept_response("'none'") is True
+
+
+def test_none_accept_rejects_critical_feedback_containing_none():
+    critical = "None of the guideline criteria are met — cite sources."
+    assert is_none_accept_response(critical) is False
+    assert is_none_accept_response("Return None of these claims.") is False
+    assert is_none_accept_response("The draft is None of the requirements") is False
+
+
+def test_none_accept_rejects_empty_and_unrelated():
+    assert is_none_accept_response("") is False
+    assert is_none_accept_response(None) is False
+    assert is_none_accept_response("looks good") is False
+
+
+def test_human_plan_approval_exact_no_only():
+    assert is_human_plan_approval("no") is True
+    assert is_human_plan_approval("  NO  ") is True
+    assert is_human_plan_approval("No") is True
+
+
+def test_human_plan_approval_rejects_feedback_containing_no():
+    assert is_human_plan_approval("not enough on evaluation methods") is False
+    assert is_human_plan_approval("add a section on novel applications") is False
+    assert is_human_plan_approval("nope, rewrite it") is False
+    assert is_human_plan_approval(None) is False
+    assert is_human_plan_approval("") is False


### PR DESCRIPTION
## Summary

- Replace substring `"None" in response` acceptance in multi_agents reviewer and fact-checker with an exact-token parser (`is_none_accept_response`).
- Prevents critical reviews such as "None of the guideline criteria are met…" from being treated as approval and publishing unrevised drafts.
- Bonus: fix reviser prompt leftover `" + "` concat so Reviewer's notes are attached cleanly.

## Motivation

Closes #1881.

The draft-reviewer loop asked the model to return `None` on accept, but checked with a bare substring membership test. Any critical note containing the letters "None" false-accepted the draft. Fact-checker had the same pitfall. This surfaces real feedback instead of silently absorbing it.

## Verification

```
============================= test session starts ==============================
platform darwin -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/bartokmoltbot/clawd/repos/gpt-researcher
configfile: pyproject.toml
plugins: anyio-4.14.1, asyncio-1.4.0, langsmith-0.9.3
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 6 items

tests/test_none_accept_sentinels.py ......                               [100%]

=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464
  /Users/bartokmoltbot/clawd/repos/gpt-researcher/.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464: PytestConfigWarning: Unknown config option: asyncio_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 6 passed, 1 warning in 0.01s =========================
```

- Real behavior proof: helper previously-equivalent path — `"None of the criteria"` is **rejected** as accept; bare `"None"` / `"none"` / `"None"` still accept.
- Did NOT change: unbounded revision loop / LangGraph recursion limit (that half of #1881 is intentionally out of scope for this focused PR; human plan gate is #1882).

## Duplicates

`check-duplicates.sh 1881` — no open/closed PRs referencing #1881.