### PR TITLE
fix(multi_agents): exact "no" for human plan approval and bound revisions

### DIFF
--- a/multi_agents/agents/human.py
+++ b/multi_agents/agents/human.py
@@ -44,7 +44,9 @@ class HumanAgent:
                     f"Any feedback on this plan? {layout}? If not, please reply with 'no'.\n>> "
                 )
 
-        if user_feedback and "no" in user_feedback.strip().lower():
+        from .utils.none_sentinels import is_human_plan_approval
+
+        if is_human_plan_approval(user_feedback):
             user_feedback = None
 
         plan_revision_count = research_state.get("plan_revision_count", 0)

--- a/multi_agents/agents/orchestrator.py
+++ b/multi_agents/agents/orchestrator.py
@@ -84,16 +84,12 @@ class ChiefEditorAgent:
         workflow.set_entry_point("browser")
         workflow.add_edge('publisher', END)
 
-        # Add human in the loop
-        MAX_REVISIONS = 5
+        # Human loop: exact "no" approval (human agent) + bounded plan revisions
+        # via plan_review.route_human_feedback (task.max_plan_revisions).
         workflow.add_conditional_edges(
             'human',
-            lambda state: (
-                "accept" if state['human_feedback'] is None
-                else "force_accept" if state.get('revisions_count', 0) >= MAX_REVISIONS
-                else "revise"
-            ),
-            {"accept": "researcher", "force_accept": "researcher", "revise": "planner"}
+            self._route_human_feedback,
+            {"accept": "researcher", "revise": "planner"},
         )
 
         # Fact-checker loop — bounded via task.max_fact_check_revisions
@@ -104,9 +100,20 @@ class ChiefEditorAgent:
         )
 
     def _route_human_feedback(self, review):
+        """Route human plan feedback; force-accept after max_plan_revisions.
+
+        ``route_human_feedback`` raises when the configured ceiling is exceeded.
+        For the graph edge we treat that as accept so the run proceeds to
+        research instead of dying at LangGraph's default recursion_limit.
+        """
+        from .plan_review import MaxPlanRevisionsExceededError
+
         max_plan_revisions = self.task.get(
             "max_plan_revisions", DEFAULT_MAX_PLAN_REVISIONS)
-        return route_human_feedback(review, max_plan_revisions)
+        try:
+            return route_human_feedback(review, max_plan_revisions)
+        except MaxPlanRevisionsExceededError:
+            return "accept"
 
     def init_research_team(self):
         """Initialize and create a workflow for the research team."""


### PR DESCRIPTION
## Summary

- Human plan gate: replace substring `"no" in feedback` with exact-token `is_human_plan_approval` so feedback like "not enough on evaluation methods" is no longer treated as approval.
- Wire the existing `route_human_feedback` / `plan_revision_count` / `max_plan_revisions` path into the orchestrator graph (the method existed but the edge used a broken `revisions_count` counter that was never incremented).
- On exceeding `max_plan_revisions` (default 3), force-accept and proceed to research instead of sailing into LangGraph `recursion_limit`.

## Motivation

Closes #1882.

The human feedback prompt grepped for the letters "no" anywhere in the reply, which silently threw away real revision requests. The conditional edge also ignored the existing `plan_revision_count` state and never used `_route_human_feedback`.

## Verification

```
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464
  /Users/bartokmoltbot/clawd/repos/gpt-researcher/.venv/lib/python3.14/site-packages/_pytest/config/__init__.py:1464: PytestConfigWarning: Unknown config option: asyncio_fixture_loop_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 7 passed, 1 warning in 0.01s =========================
```

- Real behavior: `"not enough on evaluation methods"` → not approval; exact `"no"` → approval; revision limit raises / edge maps to accept.
- Did NOT change: reviewer None substring (#1883 already covers that); fact-checker on this branch untouched.

## Duplicates

PR search for #1882 only hits unrelated #1883 body mention from our concurrent None fix; no competing open PR for the human "no" path.