### PR TITLE
fix(report): skip LLM write when research context is empty

### DIFF
--- a/gpt_researcher/skills/writer.py
+++ b/gpt_researcher/skills/writer.py
@@ -46,6 +46,29 @@ class ReportGenerator:
             "headers": self.researcher.headers,
         }
 
+    @staticmethod
+    def _is_empty_context(context) -> bool:
+        """Return True when context has no usable research content."""
+        if context is None:
+            return True
+        if isinstance(context, str):
+            return len(context.strip()) == 0
+        if isinstance(context, (list, tuple, set)):
+            if len(context) == 0:
+                return True
+            # list of empty strings / empty dicts still unusable
+            usable = []
+            for item in context:
+                if isinstance(item, str) and item.strip():
+                    usable.append(item)
+                elif isinstance(item, dict) and any(str(v).strip() for v in item.values() if v is not None):
+                    usable.append(item)
+                elif item not in (None, "", [], {}):
+                    usable.append(item)
+            return len(usable) == 0
+        return False
+
+
     async def write_report(self, existing_headers: list = [], relevant_written_contents: list = [], ext_context=None, custom_prompt="", available_images: list = None) -> str:
         """
         Write a report based on existing headers and relevant contents.
@@ -74,7 +97,25 @@ class ReportGenerator:
                 research_images
             )
 
-        context = ext_context or self.researcher.context
+        context = ext_context if ext_context is not None else self.researcher.context
+
+        # Surface empty retrieval instead of letting the LLM invent sources.
+        # Aligns with report integrity when retrievers return no usable context.
+        if self._is_empty_context(context):
+            empty_report = (
+                f"## No Relevant Sources Found\n\n"
+                f"Research for **{self.researcher.query}** could not gather any "
+                f"source context. The report was not generated to avoid "
+                f"fabricated claims or citations.\n"
+            )
+            if self.researcher.verbose:
+                await stream_output(
+                    "logs",
+                    "empty_context",
+                    "⚠️ No research context available; skipping report generation to avoid hallucination.",
+                    self.researcher.websocket,
+                )
+            return empty_report
         
         # Log image availability
         if available_images and self.researcher.verbose:

--- a/tests/skills/test_report_empty_context.py
+++ b/tests/skills/test_report_empty_context.py
@@ -1,0 +1,80 @@
+"""Empty-context guard for ReportGenerator (#1572)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gpt_researcher.skills.writer import ReportGenerator
+
+
+def _make_generator(context):
+    researcher = SimpleNamespace(
+        query="What is ZZZnotareal topic?",
+        context=context,
+        verbose=False,
+        websocket=None,
+        report_type="research_report",
+        role="researcher",
+        cfg=SimpleNamespace(agent_role=None),
+        headers={},
+        kwargs={},
+        get_research_images=lambda: [],
+        parent_query="",
+        add_costs=lambda *a, **k: None,
+        tone=None,
+        report_source="web",
+    )
+    return ReportGenerator(researcher)
+
+
+@pytest.mark.asyncio
+async def test_empty_string_context_skips_llm(monkeypatch):
+    gen = _make_generator("")
+    called = {"n": 0}
+
+    async def boom(**kwargs):
+        called["n"] += 1
+        raise AssertionError("generate_report should not be called")
+
+    monkeypatch.setattr(
+        "gpt_researcher.skills.writer.generate_report", boom
+    )
+    report = await gen.write_report()
+    assert "No Relevant Sources Found" in report
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_list_context_skips_llm(monkeypatch):
+    gen = _make_generator([])
+    called = {"n": 0}
+
+    async def boom(**kwargs):
+        called["n"] += 1
+        raise AssertionError("generate_report should not be called")
+
+    monkeypatch.setattr(
+        "gpt_researcher.skills.writer.generate_report", boom
+    )
+    report = await gen.write_report()
+    assert "No Relevant Sources Found" in report
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_nonempty_context_still_calls_generate(monkeypatch):
+    gen = _make_generator(["real source for the query"])
+    called = {"n": 0}
+
+    async def fake_generate(**kwargs):
+        called["n"] += 1
+        return "ok report"
+
+    monkeypatch.setattr(
+        "gpt_researcher.skills.writer.generate_report", fake_generate
+    )
+    report = await gen.write_report()
+    assert report == "ok report"
+    assert called["n"] == 1


### PR DESCRIPTION
## Summary

- `ReportGenerator.write_report` detects empty/missing research context and returns a clear \"no sources\" report instead of calling the LLM.
- Prevents hallucinated sources when retrievers return nothing (custom RAG, misconfigured API keys, empty crawl).

## Motivation

Closes #1572.

When `self.context` is empty the writer still invoked `generate_report`, so the model invented plausible links/content with no grounded sources. Surface the empty-context condition and force a deterministic non-hallucinated response.

## Verification

- `.venv/bin/python -m pytest tests/skills/test_report_empty_context.py -q` — 3 passed
- Real behavior: empty `\"\"` / `[]` never call `generate_report`; non-empty context still does.

## Differential value

N/A — no open competing PR for #1572.