### PR TITLE
fix(export): avoid outputs/.pdf when export filename is empty

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -29,7 +29,12 @@ async def write_text_to_md(text: str, filename: str = "") -> str:
     Returns:
         str: The file path of the generated Markdown file.
     """
-    file_path = f"outputs/{filename[:60]}.md"
+    import uuid
+
+    safe_name = (filename or "").strip()[:60] or f"report-{uuid.uuid4().hex[:12]}"
+    safe_name = safe_name.replace("/", "-").replace("\\", "-")
+    os.makedirs("outputs", exist_ok=True)
+    file_path = f"outputs/{safe_name}.md"
     await write_to_file(file_path, text)
     return urllib.parse.quote(file_path)
 
@@ -68,7 +73,15 @@ async def write_md_to_pdf(text: str, filename: str = "") -> str:
     Returns:
         str: The encoded file path of the generated PDF.
     """
-    file_path = f"outputs/{filename[:60]}.pdf"
+    import uuid
+
+    # Empty / whitespace-only filename previously wrote "outputs/.pdf" which
+    # confuses download UIs (#1718). Prefer a stable non-empty basename.
+    safe_name = (filename or "").strip()[:60] or f"report-{uuid.uuid4().hex[:12]}"
+    # Replace path separators to keep the PDF under outputs/.
+    safe_name = safe_name.replace("/", "-").replace("\\", "-")
+    os.makedirs("outputs", exist_ok=True)
+    file_path = f"outputs/{safe_name}.pdf"
 
     try:
         # Resolve css path relative to this backend module to avoid
@@ -105,7 +118,12 @@ async def write_md_to_word(text: str, filename: str = "") -> str:
     Returns:
         str: The encoded file path of the generated DOCX.
     """
-    file_path = f"outputs/{filename[:60]}.docx"
+    import uuid
+
+    safe_name = (filename or "").strip()[:60] or f"report-{uuid.uuid4().hex[:12]}"
+    safe_name = safe_name.replace("/", "-").replace("\\", "-")
+    os.makedirs("outputs", exist_ok=True)
+    file_path = f"outputs/{safe_name}.docx"
 
     try:
         from docx import Document

--- a/tests/backend/test_write_md_to_pdf_filename.py
+++ b/tests/backend/test_write_md_to_pdf_filename.py
@@ -1,0 +1,60 @@
+"""Filename/directory hygiene for report PDF export (#1718)."""
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from backend import utils as backend_utils
+
+
+@pytest.mark.asyncio
+async def test_empty_filename_does_not_write_dot_pdf(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_md2pdf(file_path, raw=None, css=None, base_url=None):
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(file_path).write_text("pdf-bytes", encoding="utf-8")
+
+    with patch.dict("sys.modules", {}):
+        with patch("md2pdf.core.md2pdf", create=True, side_effect=fake_md2pdf):
+            # Import path used inside function: from md2pdf.core import md2pdf
+            import sys
+            import types
+            core = types.ModuleType("md2pdf.core")
+            core.md2pdf = fake_md2pdf
+            md2pdf_mod = types.ModuleType("md2pdf")
+            md2pdf_mod.core = core
+            sys.modules["md2pdf"] = md2pdf_mod
+            sys.modules["md2pdf.core"] = core
+
+            path = await backend_utils.write_md_to_pdf("# hi", filename="")
+
+    assert path
+    decoded = path.replace("%2F", "/")
+    assert not decoded.endswith("/.pdf")
+    assert decoded.startswith("outputs/")
+    assert Path(tmp_path / decoded).exists()
+
+
+@pytest.mark.asyncio
+async def test_explicit_filename_preserved(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    import sys, types
+
+    def fake_md2pdf(file_path, raw=None, css=None, base_url=None):
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(file_path).write_text("pdf", encoding="utf-8")
+
+    core = types.ModuleType("md2pdf.core")
+    core.md2pdf = fake_md2pdf
+    md2pdf_mod = types.ModuleType("md2pdf")
+    md2pdf_mod.core = core
+    sys.modules["md2pdf"] = md2pdf_mod
+    sys.modules["md2pdf.core"] = core
+
+    path = await backend_utils.write_md_to_pdf("# hi", filename="my-report")
+    assert "my-report.pdf" in path
+    assert (tmp_path / "outputs" / "my-report.pdf").exists()


### PR DESCRIPTION
## Summary

- PDF/MD/DOCX exporters no longer write \`outputs/.pdf\` when \`filename\` is empty; they use a generated \`report-<id>\` basename.
- Ensure \`outputs/\` exists before write to reduce silent export failures.

## Motivation

Closes #1718.

Empty research IDs produced \`outputs/.pdf\`, which UI download buttons treat as a broken path. Create the directory and always use a non-empty safe basename.

## Verification

- \`.venv/bin/python -m pytest tests/backend/test_write_md_to_pdf_filename.py -q\` — 2 passed
- Empty filename path does not end with \`/.pdf\`; explicit names preserved.