### PR TITLE
fix(deep-research): stop descent when a level yields zero results

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -225,6 +225,15 @@ Format each question on a new line starting with 'Question: '"""}
         serp_queries = await self.generate_search_queries(query, num_queries=breadth)
         print(f"✅ Generated {len(serp_queries)} queries: {[q['query'] for q in serp_queries]}", flush=True)
         progress.total_queries = len(serp_queries)
+        if not serp_queries:
+            logger.warning("Deep research generated zero search queries; stopping descent.")
+            return {
+                'learnings': all_learnings,
+                'visited_urls': all_visited_urls,
+                'citations': all_citations,
+                'context': all_context,
+                'sources': all_sources,
+            }
 
         all_learnings = learnings.copy()
         all_citations = citations.copy()
@@ -302,6 +311,26 @@ Format each question on a new line starting with 'Question: '"""}
         progress.current_breadth = len(results)
         if on_progress:
             on_progress(progress)
+
+        # #1579: if every branch at this level failed (bad API key, offline
+        # retriever, etc.), stop instead of endlessly generating follow-ups
+        # from empty goals / empty learnings.
+        if not results:
+            logger.warning(
+                "Deep research produced no successful query results at depth=%s; stopping descent.",
+                depth,
+            )
+            print(
+                f"\nDEEP RESEARCH: no successful results at depth={depth}; stopping to avoid infinite work.",
+                flush=True,
+            )
+            return {
+                'learnings': all_learnings,
+                'visited_urls': all_visited_urls,
+                'citations': all_citations,
+                'context': all_context,
+                'sources': all_sources,
+            }
 
         # Collect all results
         for result in results:

--- a/tests/skills/test_deep_research_empty_results.py
+++ b/tests/skills/test_deep_research_empty_results.py
@@ -1,0 +1,55 @@
+"""Deep research terminates when a level yields no results (#1579)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gpt_researcher.skills.deep_research import DeepResearchSkill
+
+
+@pytest.mark.asyncio
+async def test_stops_when_all_query_processors_return_none():
+    researcher = SimpleNamespace(
+        cfg=SimpleNamespace(
+            deep_research_breadth=2,
+            deep_research_depth=3,
+            deep_research_concurrency=2,
+            strategic_llm_provider="openai",
+            strategic_llm_model="gpt",
+            reasoning_effort=None,
+            config_path=None,
+        ),
+        websocket=None,
+        tone=None,
+        headers={},
+        visited_urls=set(),
+        mcp_configs=None,
+        mcp_strategy=None,
+    )
+    skill = DeepResearchSkill(researcher)
+
+    async def fake_generate(query, num_queries=3):
+        return [
+            {"query": "q1", "researchGoal": "g1"},
+            {"query": "q2", "researchGoal": "g2"},
+        ]
+
+    # Force every process_query path to fail by making nested research raise
+    async def boom(*a, **k):
+        raise RuntimeError("retriever misconfigured")
+
+    skill.generate_search_queries = fake_generate  # type: ignore
+
+    with patch("gpt_researcher.GPTResearcher") as MockR:
+        inst = MockR.return_value
+        inst.conduct_research = AsyncMock(side_effect=boom)
+        inst.visited_urls = set()
+        inst.research_sources = []
+        out = await skill.deep_research(query="topic", breadth=2, depth=3)
+
+    assert out["learnings"] == []
+    assert out["context"] == []
+    # No recursion into deeper layers with empty goals
+    assert MockR.call_count == 2  # one per top-level query only


### PR DESCRIPTION
## Summary

- Deep research aborts descent when a breadth level returns zero successful query results or zero generated queries.
- Prevents multi-depth thrash when retrievers are misconfigured (e.g. missing Tavily key) — addresses the freeze reported in #1579.

## Motivation

Closes #1579.

With bad retriever config, every process_query path fails. The good branches for recursion never run cleanly, but empty/failed levels could still leave operators stuck spinning. Explicitly return accumulated state and stop when a level is entirely empty.

## Verification

- `.venv/bin/python -m pytest tests/skills/test_deep_research_empty_results.py -q` — 1 passed
- Misconfigured nested research raises → two top-level attempts only (depth does not recurse).