### PR TITLE
fix(retriever): skip redundant Tavily MCP when direct Tavily is active

### DIFF
--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -460,6 +460,34 @@ class ResearchConductor:
         
         return all_mcp_context
 
+    def _tavily_mcp_redundant_with_direct(self, mcp_retrievers, non_mcp_retrievers) -> bool:
+        """True when MCP would only re-query Tavily while direct Tavily is active.
+
+        The frontend Tavily Web Search MCP preset hits the same API as
+        `TavilySearch` and adds extra LLM tool-selection cost for no new data
+        when both run together (#1875).
+        """
+        if not mcp_retrievers or not non_mcp_retrievers:
+            return False
+        has_direct_tavily = any(
+            getattr(r, "__name__", "").lower() == "tavilysearch" for r in non_mcp_retrievers
+        )
+        if not has_direct_tavily:
+            return False
+        configs = getattr(self.researcher, "mcp_configs", None) or []
+        if not configs:
+            return False
+        # If every configured MCP server is a Tavily MCP package, treat as redundant.
+        def _is_tavily_mcp(cfg: dict) -> bool:
+            name = str(cfg.get("name", "")).lower()
+            args = " ".join(str(a) for a in (cfg.get("args") or [])).lower()
+            command = str(cfg.get("command", "")).lower()
+            blob = f"{name} {args} {command}"
+            return "tavily" in blob
+
+        return all(isinstance(c, dict) and _is_tavily_mcp(c) for c in configs)
+
+
     async def _process_sub_query(self, sub_query: str, scraped_data: list = [], query_domains: list = []):
         """Takes in a sub query and scrapes urls based on it and gathers context."""
         if self.json_handler:
@@ -480,6 +508,20 @@ class ResearchConductor:
             # Identify MCP retrievers
             mcp_retrievers = [r for r in self.researcher.retrievers if "mcpretriever" in r.__name__.lower()]
             non_mcp_retrievers = [r for r in self.researcher.retrievers if "mcpretriever" not in r.__name__.lower()]
+
+            # Avoid dual Tavily path (direct retriever + tavily-mcp) under default RETRIEVER=tavily.
+            if self._tavily_mcp_redundant_with_direct(mcp_retrievers, non_mcp_retrievers):
+                self.logger.warning(
+                    "Skipping LLM MCP Tavily path because TavilySearch is already configured as a direct retriever; set RETRIEVER without tavily or use non-Tavily MCP servers to keep MCP."
+                )
+                if self.researcher.verbose:
+                    await stream_output(
+                        "logs",
+                        "mcp_tavily_deduped",
+                        "⚠️ Skipping Tavily MCP (redundant with direct Tavily retriever) to avoid double API cost",
+                        self.researcher.websocket,
+                    )
+                mcp_retrievers = []
             
             # Initialize context components
             mcp_context = []

--- a/tests/skills/test_tavily_mcp_dedupe.py
+++ b/tests/skills/test_tavily_mcp_dedupe.py
@@ -1,0 +1,67 @@
+"""Skip redundant Tavily MCP when direct Tavily retriever is active (#1875)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gpt_researcher.skills.researcher import ResearchConductor
+
+
+class TavilySearch:
+    pass
+
+
+class MCPRetriever:  # name contains mcpretriever
+    pass
+
+
+@pytest.mark.asyncio
+async def test_redundant_tavily_mcp_is_skipped():
+    conductor = ResearchConductor(SimpleNamespace(
+        retrievers=[TavilySearch, MCPRetriever],
+        mcp_configs=[{"name": "tavily-mcp", "command": "npx", "args": ["-y", "tavily-mcp@0.1.2"]}],
+        mcp_strategy="fast",
+        verbose=False,
+        websocket=None,
+        headers={},
+        query_domains=[],
+        cfg=SimpleNamespace(max_search_results_per_query=5),
+        kwargs={},
+        context_manager=SimpleNamespace(
+            get_similar_content_by_query=AsyncMock(return_value="web-context")
+        ),
+    ))
+    conductor._mcp_results_cache = None
+    conductor._execute_mcp_research_for_queries = AsyncMock(return_value=["should-not-run"])
+    conductor._scrape_data_by_urls = AsyncMock(return_value=[{"url": "u", "raw_content": "c"}])
+    conductor._combine_mcp_and_web_context = MagicMock(return_value="combined")
+
+    out = await conductor._process_sub_query("topic")
+
+    conductor._execute_mcp_research_for_queries.assert_not_called()
+    assert out == "combined"
+
+
+@pytest.mark.asyncio
+async def test_non_tavily_mcp_still_runs():
+    conductor = ResearchConductor(SimpleNamespace(
+        retrievers=[TavilySearch, MCPRetriever],
+        mcp_configs=[{"name": "filesystem", "command": "npx", "args": ["@modelcontextprotocol/server-filesystem", "/tmp"]}],
+        mcp_strategy="deep",
+        verbose=False,
+        websocket=None,
+        headers={},
+        query_domains=[],
+        cfg=SimpleNamespace(max_search_results_per_query=5),
+        kwargs={},
+        context_manager=SimpleNamespace(
+            get_similar_content_by_query=AsyncMock(return_value="web-context")
+        ),
+    ))
+    conductor._execute_mcp_research_for_queries = AsyncMock(return_value=["mcp-context"])
+    conductor._scrape_data_by_urls = AsyncMock(return_value=[{"url": "u", "raw_content": "c"}])
+    conductor._combine_mcp_and_web_context = MagicMock(return_value="combined")
+
+    await conductor._process_sub_query("topic")
+    conductor._execute_mcp_research_for_queries.assert_called()


### PR DESCRIPTION
## Summary

- Detect when MCP configs are only Tavily MCP **and** `TavilySearch` is already a non-MCP retriever; skip the MCP path for that session.
- Logs a clear warning so users can keep MCP by changing `RETRIEVER` or using non-Tavily MCP servers.

## Motivation

Closes #1875.

Default `RETRIEVER=tavily` plus the frontend \"Tavily Web Search\" MCP preset double-hits the same API with 2+ extra LLM tool-selection calls. Prefer the direct retriever and surface that MCP was skipped rather than billing twice silently.

## Verification

- `.venv/bin/python -m pytest tests/skills/test_tavily_mcp_dedupe.py -q` — 2 passed
- Redundant case: `_execute_mcp_research_for_queries` not called; filesystem MCP still runs.