### PR TITLE
feat: add Nebius Token Factory as LLM and embedding provider

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -3,9 +3,9 @@
 As described in the [introduction](/docs/gpt-researcher/gptr/config), the default LLM and embedding is OpenAI due to its superior performance and speed. 
 With that said, GPT Researcher supports various open/closed source LLMs and embeddings, and you can easily switch between them by updating the `SMART_LLM`, `FAST_LLM` and `EMBEDDING` env variables. You might also need to include the provider API key and corresponding configuration params.
 
-Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `groq`, `bedrock`, `litellm`, `minimax` and `atlascloud`.
+Current supported LLMs are `openai`, `anthropic`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `groq`, `bedrock`, `litellm`, `minimax`, `atlascloud` and `nebius`.
 
-Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `nomic` ,`voyageai` and `bedrock`.
+Current supported embeddings are `openai`, `azure_openai`, `cohere`, `google_vertexai`, `google_genai`, `fireworks`, `ollama`, `together`, `mistralai`, `huggingface`, `nomic` ,`voyageai`, `bedrock` and `nebius`.
 
 To learn more about support customization options see [here](/docs/gpt-researcher/gptr/config).
 
@@ -437,6 +437,23 @@ FAST_LLM=atlascloud:deepseek-ai/DeepSeek-V3
 SMART_LLM=atlascloud:deepseek-ai/DeepSeek-R1
 STRATEGIC_LLM=atlascloud:deepseek-ai/DeepSeek-R1
 ```
+
+## Nebius Token Factory
+
+[Nebius Token Factory](https://tokenfactory.nebius.com) serves 60+ open models (DeepSeek, Qwen, Llama, Kimi, and more) through an OpenAI-compatible API, and also hosts text-embedding models — so GPTR can run both its LLM and its embedding stack on a single provider.
+
+Sign up at [tokenfactory.nebius.com](https://tokenfactory.nebius.com) to get an API key, then set the following environment variables:
+
+```env
+NEBIUS_API_KEY=[Your Key]
+FAST_LLM=nebius:meta-llama/Llama-3.3-70B-Instruct
+SMART_LLM=nebius:Qwen/Qwen3-235B-A22B-Instruct-2507
+STRATEGIC_LLM=nebius:openai/gpt-oss-120b
+
+EMBEDDING=nebius:Qwen/Qwen3-Embedding-8B
+```
+
+Browse the full model catalog [_here_](https://tokenfactory.nebius.com/models). To point at a self-hosted or regional endpoint, set `NEBIUS_BASE_URL` (defaults to `https://api.tokenfactory.nebius.com/v1`).
 
 ## vLLM
 ```env

--- a/docs/docs/gpt-researcher/llms/supported-llms.md
+++ b/docs/docs/gpt-researcher/llms/supported-llms.md
@@ -24,6 +24,7 @@ The following LLMs are supported by GPTR (though you'll need to install the rele
 - forge
 - avian
 - atlascloud
+- nebius
 - vllm
 
 If you'd like to know the name of the langchain package for each LLM, you can check the [Langchain documentation](https://python.langchain.com/v0.2/docs/integrations/platforms/), or run GPTR as is and inspect the error message.

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -37,6 +37,7 @@ _SUPPORTED_PROVIDERS = {
     "avian",
     "minimax",
     "atlascloud",
+    "nebius",
 }
 
 NO_SUPPORT_TEMPERATURE_MODELS = [
@@ -302,6 +303,15 @@ class GenericLLMProvider:
 
             llm = ChatOpenAI(openai_api_base='https://api.minimax.io/v1',
                      openai_api_key=os.environ["MINIMAX_API_KEY"],
+                     **kwargs
+                )
+        elif provider == "nebius":
+            _check_pkg("langchain_openai")
+            from langchain_openai import ChatOpenAI
+
+            # NEBIUS_BASE_URL overrides the default endpoint (self-hosted / regional)
+            llm = ChatOpenAI(openai_api_base=os.getenv("NEBIUS_BASE_URL", 'https://api.tokenfactory.nebius.com/v1'),
+                     openai_api_key=os.environ["NEBIUS_API_KEY"],
                      **kwargs
                 )
         elif provider == 'netmind':

--- a/gpt_researcher/memory/embeddings.py
+++ b/gpt_researcher/memory/embeddings.py
@@ -50,6 +50,7 @@ _SUPPORTED_PROVIDERS = {
     "netmind",
     "openrouter",
     "minimax",
+    "nebius",
 }
 
 
@@ -209,6 +210,15 @@ class Memory:
                     model=model,
                     openai_api_key=os.getenv("MINIMAX_API_KEY"),
                     openai_api_base="https://api.minimax.io/v1",
+                    **embedding_kwargs,
+                )
+            case "nebius":
+                from langchain_openai import OpenAIEmbeddings
+
+                _embeddings = OpenAIEmbeddings(
+                    model=model,
+                    openai_api_key=os.getenv("NEBIUS_API_KEY"),
+                    openai_api_base=os.getenv("NEBIUS_BASE_URL", "https://api.tokenfactory.nebius.com/v1"),
                     **embedding_kwargs,
                 )
             case _:

--- a/tests/test_nebius_provider.py
+++ b/tests/test_nebius_provider.py
@@ -1,0 +1,66 @@
+"""Unit tests for the Nebius Token Factory provider (LLM + embeddings).
+
+These tests construct the provider objects with a dummy key and assert they
+point at the Token Factory endpoint; no network calls are made.
+"""
+import os
+import unittest
+
+from gpt_researcher.llm_provider.generic.base import (
+    GenericLLMProvider,
+    _SUPPORTED_PROVIDERS as LLM_PROVIDERS,
+)
+from gpt_researcher.memory.embeddings import (
+    Memory,
+    _SUPPORTED_PROVIDERS as EMBEDDING_PROVIDERS,
+)
+
+NEBIUS_BASE_URL = "https://api.tokenfactory.nebius.com/v1"
+
+
+class TestNebiusProvider(unittest.TestCase):
+    def setUp(self):
+        self._orig = {k: os.environ.get(k) for k in ("NEBIUS_API_KEY", "NEBIUS_BASE_URL")}
+        os.environ["NEBIUS_API_KEY"] = "test-key"
+        os.environ.pop("NEBIUS_BASE_URL", None)
+
+    def tearDown(self):
+        for k, v in self._orig.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_nebius_registered_for_llm_and_embeddings(self):
+        self.assertIn("nebius", LLM_PROVIDERS)
+        self.assertIn("nebius", EMBEDDING_PROVIDERS)
+
+    def test_llm_construction_uses_token_factory_base_url(self):
+        provider = GenericLLMProvider.from_provider(
+            "nebius", model="Qwen/Qwen3-235B-A22B-Instruct-2507", verbose=False
+        )
+        self.assertEqual(str(provider.llm.openai_api_base), NEBIUS_BASE_URL)
+
+    def test_embeddings_construction_uses_token_factory_base_url(self):
+        embeddings = Memory("nebius", "Qwen/Qwen3-Embedding-8B").get_embeddings()
+        self.assertEqual(str(embeddings.openai_api_base), NEBIUS_BASE_URL)
+
+    def test_base_url_can_be_overridden(self):
+        os.environ["NEBIUS_BASE_URL"] = "https://self-hosted.example.com/v1"
+        provider = GenericLLMProvider.from_provider(
+            "nebius", model="Qwen/Qwen3-32B", verbose=False
+        )
+        self.assertEqual(
+            str(provider.llm.openai_api_base), "https://self-hosted.example.com/v1"
+        )
+
+    def test_llm_requires_api_key(self):
+        os.environ.pop("NEBIUS_API_KEY", None)
+        with self.assertRaises(KeyError):
+            GenericLLMProvider.from_provider(
+                "nebius", model="Qwen/Qwen3-32B", verbose=False
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds **Nebius Token Factory** as a first-class provider for both LLMs and embeddings. Token Factory exposes an OpenAI-compatible API for 60+ open models (DeepSeek, Qwen, Llama, Kimi, …) and hosts text-embedding models, so GPTR can run its full LLM **and** embedding stack on a single provider.

## Why this belongs as a dedicated provider (not just `litellm`)

Nebius is currently the only major open-model inference cloud missing from GPTR — `together`, `fireworks`, `groq`, `deepseek`, `openrouter`, `atlascloud`, `aimlapi`, `avian` and others are all first-class. Two concrete reasons a dedicated branch is the right call rather than "use the `litellm` prefix":

- **Embeddings have no `litellm` path.** `memory/embeddings.py` has no `litellm` case, so Nebius embeddings are impossible today. This branch is what enables them — and since Token Factory hosts `Qwen/Qwen3-Embedding-8B`, GPTR can run the *whole* stack (LLM + embeddings) on one provider/key.
- **DX parity.** `fireworks`/`together`/`groq`/`deepseek` all technically work via `litellm` too, yet each has a first-class branch so models are addressable as `provider:model` in `FAST_LLM`/`SMART_LLM`/`STRATEGIC_LLM`/`EMBEDDING`. This adds the same ergonomics for Nebius.

## Design decisions (kept convention-faithful)

- **Mirrors the existing OpenAI-compatible pattern** — the LLM branch follows `atlascloud`/`minimax`; the embeddings case follows `aimlapi`/`openrouter`. **No new dependencies** (reuses `langchain-openai`, already required).
- **Optional `NEBIUS_BASE_URL` override** for self-hosted / regional endpoints (defaults to the public URL), mirroring the `aimlapi` embeddings and `mistralai` LLM base-URL pattern.
- **Embeddings intentionally do *not* set `check_embedding_ctx_length=False`** — this matches the other OpenAI-compatible embedding providers (`aimlapi`/`openrouter`/`minimax`) and is verified working end-to-end (below).
- **`.env.example` left unchanged** — consistent with the other OpenAI-compatible providers, whose keys are documented here rather than in `.env.example`.
- **All example model IDs are live-verified** against `/v1/models` as of this PR.

## Config

```env
NEBIUS_API_KEY=[Your Key]
FAST_LLM=nebius:meta-llama/Llama-3.3-70B-Instruct
SMART_LLM=nebius:Qwen/Qwen3-235B-A22B-Instruct-2507
STRATEGIC_LLM=nebius:openai/gpt-oss-120b

EMBEDDING=nebius:Qwen/Qwen3-Embedding-8B
```

## Test plan

- [x] Unit tests (`tests/test_nebius_provider.py`, 5 cases): provider registration (LLM + embeddings), base-URL wiring for both, `NEBIUS_BASE_URL` override, and the missing-key error path. No network.
- [x] Live smoke test: chat completion (`Llama-3.3-70B-Instruct`, `Qwen3-235B-A22B-Instruct-2507`, `gpt-oss-120b`) and embeddings (`Qwen3-Embedding-8B`, 4096-dim) return successfully.
- [x] **End-to-end research run** with `FAST_LLM`/`SMART_LLM`/`STRATEGIC_LLM`/`EMBEDDING` all set to `nebius:…` produced a cited report — 14 sources, 568 embedded context chunks, exercising both the LLM and embedding paths in the real pipeline.
