### PR TITLE
docs: add DaoXE multi-protocol gateway LLM guide

### DIFF
--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -447,6 +447,32 @@ SMART_LLM=vllm_openai:Qwen/Qwen3-8B-AWQ
 STRATEGIC_LLM=vllm_openai:Qwen/Qwen3-8B-AWQ
 ```
 
+## DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway (OpenAI Chat Completions / Responses and Anthropic Messages, plus image-compatible endpoints where available). GPT Researcher can call it through the OpenAI-compatible Chat Completions path.
+
+Use **exact** model IDs from your DaoXE account catalog (`GET https://daoxe.com/v1/models` or the pricing / model square in the dashboard). Do not hardcode a public model list—availability is account-scoped. DaoXE is not available in mainland China.
+
+```env
+# DaoXE OpenAI-compatible Chat Completions base
+OPENAI_API_KEY=[Your DaoXE API key]
+OPENAI_BASE_URL=https://daoxe.com/v1
+
+# Replace placeholders with exact IDs from your account catalog
+FAST_LLM=openai:YOUR_FAST_MODEL_ID
+SMART_LLM=openai:YOUR_SMART_MODEL_ID
+STRATEGIC_LLM=openai:YOUR_STRATEGIC_MODEL_ID
+
+# Prefer a separate embedding provider if your DaoXE plan does not expose embeddings
+# EMBEDDING=openai:YOUR_EMBEDDING_MODEL_ID
+```
+
+Smoke-test with a small research query before long runs. Prefer models that support tool calling / long context for SMART and STRATEGIC roles.
+
+For a longer walkthrough (protocol notes, smoke checks, troubleshooting), see [Running with DaoXE](/docs/gpt-researcher/llms/running-with-daoxe).
+
+> Disclosure: this section was contributed by a DaoXE maintainer. Examples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+
 ## Other Embedding Models
 
 ### Nomic

--- a/docs/docs/gpt-researcher/llms/running-with-daoxe.md
+++ b/docs/docs/gpt-researcher/llms/running-with-daoxe.md
@@ -1,0 +1,89 @@
+# Running with DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway. It exposes:
+
+- OpenAI-compatible Chat Completions (`https://daoxe.com/v1`)
+- OpenAI Responses (where available)
+- Anthropic Messages / Claude protocol (`/v1/messages` and related Anthropic-shaped paths)
+- Image-compatible endpoints where enabled for your account
+
+GPT Researcher talks to LLMs through LangChain-style providers. The simplest path is the **OpenAI-compatible** provider with DaoXE as `OPENAI_BASE_URL`. Other clients (Claude Code, Anthropic SDK, etc.) can use DaoXE’s Anthropic Messages path separately; this guide focuses on GPTR.
+
+DaoXE is **not available in mainland China**. Model IDs, pricing, and capability flags are account-scoped—always resolve them from your live catalog, not from a static blog list.
+
+## 1. Get credentials and model IDs
+
+1. Create an account at [daoxe.com](https://daoxe.com) and issue an API key.
+2. List models available to your key:
+
+```bash
+curl -sS https://daoxe.com/v1/models \
+  -H "Authorization: Bearer $DAOXE_API_KEY" | head
+```
+
+3. Pick three IDs that fit GPTR roles (fast / smart / strategic). Prefer long-context, tool-capable models for `SMART_LLM` and `STRATEGIC_LLM`.
+
+## 2. Configure environment
+
+```env
+OPENAI_API_KEY=[Your DaoXE API key]
+OPENAI_BASE_URL=https://daoxe.com/v1
+
+# Exact IDs from GET /v1/models for your account
+FAST_LLM=openai:YOUR_FAST_MODEL_ID
+SMART_LLM=openai:YOUR_SMART_MODEL_ID
+STRATEGIC_LLM=openai:YOUR_STRATEGIC_MODEL_ID
+```
+
+Notes:
+
+- The `openai:` prefix tells GPTR to use the OpenAI-compatible stack; traffic still goes to DaoXE via `OPENAI_BASE_URL`.
+- If embeddings are not on your DaoXE plan, keep a separate embedding provider (for example OpenAI, Voyage, or Ollama) and set `EMBEDDING=...` accordingly.
+- Raise token limits for modern long-output models when reports truncate—see [config documentation](../gptr/config).
+
+## 3. Optional: Python OpenAI client smoke test
+
+Before a full research run, verify the gateway:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["OPENAI_API_KEY"],
+    base_url=os.environ.get("OPENAI_BASE_URL", "https://daoxe.com/v1"),
+)
+
+model = os.environ["FAST_LLM"].split(":", 1)[-1]  # strip openai: prefix if present
+
+resp = client.chat.completions.create(
+    model=model,
+    messages=[{"role": "user", "content": "Reply with the single word: pong"}],
+    max_tokens=16,
+)
+print(resp.choices[0].message.content)
+```
+
+You can also use GPTR’s `tests/test-your-llm` helper after the env is set—see [Testing your LLM](/docs/gpt-researcher/llms/testing-your-llm).
+
+## 4. Run a small research query
+
+Start with a short topic and a single retriever to keep cost low, then scale concurrency and depth once the path is stable.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| `401` / auth errors | API key value and `Authorization: Bearer` shape; no extra whitespace |
+| `404` model not found | ID must match your account catalog exactly (including vendor prefixes) |
+| Context / truncate errors | Smaller model for `FAST_LLM`; raise `SMART_TOKEN_LIMIT` / related limits |
+| Slow or rate-limited runs | Lower concurrency; pick a faster model for `FAST_LLM` |
+| Region / access denied | DaoXE is not available in mainland China; use a supported region |
+
+## Multi-protocol note
+
+This GPTR path uses **Chat Completions** only. DaoXE’s Anthropic Messages and OpenAI Responses surfaces are useful for other stacks (Claude clients, Responses-native apps). Keep protocol and model choices explicit—DaoXE is not an OpenAI-only or Claude-only gateway.
+
+## Disclosure
+
+This guide was contributed by a DaoXE maintainer. Sample clients: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -96,7 +96,8 @@
         'gpt-researcher/llms/supported-llms',
         'gpt-researcher/llms/testing-your-llm',
         'gpt-researcher/llms/running-with-azure',
-        'gpt-researcher/llms/running-with-ollama'
+        'gpt-researcher/llms/running-with-ollama',
+        'gpt-researcher/llms/running-with-daoxe'
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add a **DaoXE** section to `docs/docs/gpt-researcher/llms/llms.md` showing OpenAI-compatible env setup (`OPENAI_BASE_URL=https://daoxe.com/v1`).
- Add walkthrough `docs/docs/gpt-researcher/llms/running-with-daoxe.md` (credentials, account-scoped model IDs, smoke test, troubleshooting).
- Link the guide from the LLM Providers sidebar.

DaoXE is a multi-model multi-protocol API gateway (OpenAI Chat Completions / Responses **and** Anthropic Messages, plus image-compatible endpoints where available). This docs path uses Chat Completions for GPTR; no hardcoded public model list.

Service is **not available in mainland China**. I maintain DaoXE. Examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [ ] Confirm sidebar builds with the new `running-with-daoxe` doc id
- [ ] Spot-check env example against current GPTR `OPENAI_BASE_URL` / `openai:` provider behavior
- [ ] Optional: smoke `GET https://daoxe.com/v1/models` + tiny chat completion with a real key