### PR TITLE
fix(config): coerce none/null/empty for Optional env fields

### DIFF
--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -260,16 +260,19 @@ class Config:
         args = get_args(type_hint)
 
         if origin is Union:
-            # Handle Union types (e.g., Union[str, None])
+            # Handle Union types (e.g., Union[str, None] / Optional[str]).
+            # Check the None sentinel BEFORE non-None args: for Optional[str],
+            # str conversion never raises, so looping str-first permanently
+            # shadowed the none/null/"" → None branch (see issue #1899).
+            if type(None) in args and env_value.lower() in ("none", "null", ""):
+                return None
             for arg in args:
                 if arg is type(None):
-                    if env_value.lower() in ("none", "null", ""):
-                        return None
-                else:
-                    try:
-                        return Config.convert_env_value(key, env_value, arg)
-                    except ValueError:
-                        continue
+                    continue
+                try:
+                    return Config.convert_env_value(key, env_value, arg)
+                except ValueError:
+                    continue
             raise ValueError(f"Cannot convert {env_value} to any of {args}")
 
         if type_hint is bool:

--- a/tests/test_convert_env_value_optional.py
+++ b/tests/test_convert_env_value_optional.py
@@ -1,0 +1,25 @@
+"""Regression tests for Optional[str] env coercion (issue #1899)."""
+from typing import Optional, Union
+
+import pytest
+
+from gpt_researcher.config.config import Config
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["none", "null", "", "NONE", "Null"],
+)
+def test_optional_str_coerces_none_sentinels(raw):
+    assert Config.convert_env_value("AGENT_ROLE", raw, Union[str, None]) is None
+    assert Config.convert_env_value("AGENT_ROLE", raw, Optional[str]) is None
+
+
+def test_optional_str_preserves_real_values():
+    assert Config.convert_env_value("AGENT_ROLE", "researcher", Optional[str]) == "researcher"
+    assert Config.convert_env_value("AGENT_ROLE", "0", Union[str, None]) == "0"
+
+
+def test_optional_int_still_coerces_and_parses():
+    assert Config.convert_env_value("SEED", "none", Optional[int]) is None
+    assert Config.convert_env_value("SEED", "42", Optional[int]) == 42


### PR DESCRIPTION
## Summary

- Coerce env strings none/null/empty to Python None for Optional config fields before str conversion can swallow them.
- AGENT_ROLE=none (and similar) now falls through writer role fallback instead of becoming the literal system role "none".

## Motivation

Closes #1899.

convert_env_value already intended to treat none/null/empty as None for Union[..., None] types, but get_args orders str before NoneType and the str branch returns unconditionally. The None-sentinel branch was therefore unreachable for every Optional[str] field (AGENT_ROLE, REPORT_SOURCE, IMAGE_GENERATION_MODEL).

## Verification

Real behavior after fix (same static method as issue repro):
- none/null/""/NONE/Null -> None
- researcher stays researcher
- Optional[int] none -> None; 42 -> 42

Unit tests: tests/test_convert_env_value_optional.py

Diff scope:
- gpt_researcher/config/config.py
- tests/test_convert_env_value_optional.py