### PR TITLE
fix(retriever): guard CRW against malformed search items

### DIFF
--- a/gpt_researcher/retrievers/crw/crw.py
+++ b/gpt_researcher/retrievers/crw/crw.py
@@ -110,14 +110,21 @@ class CRWRetriever:
             sources = results.get("data", [])
             if not sources:
                 raise Exception("No results found with fastCRW API search.")
-            # Return the results
-            search_response = [
-                {
-                    "href": obj["url"],
-                    "body": obj.get("markdown") or obj.get("description", ""),
-                }
-                for obj in sources
-            ]
+            # Return the results. Tolerate non-dict / missing-URL items so one
+            # bad payload entry does not KeyError the whole search call.
+            search_response = []
+            for obj in sources:
+                if not isinstance(obj, dict):
+                    continue
+                url = obj.get("url") or obj.get("href")
+                if not url:
+                    continue
+                search_response.append(
+                    {
+                        "href": url,
+                        "body": obj.get("markdown") or obj.get("description") or "",
+                    }
+                )
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_crw_retriever.py
+++ b/tests/test_crw_retriever.py
@@ -106,3 +106,29 @@ class CRWRetrieverTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+    @patch.dict("os.environ", {"CRW_API_KEY": "test-key"}, clear=False)
+    @patch("gpt_researcher.retrievers.crw.crw.requests.post")
+    def test_search_skips_malformed_items(self, mock_post):
+        mock_post.return_value = make_response(
+            {
+                "success": True,
+                "data": [
+                    None,
+                    "not-a-dict",
+                    {"description": "missing-url"},
+                    {"url": "https://example.com/ok", "description": "ok"},
+                    {"href": "https://example.com/href-only", "markdown": "md"},
+                ],
+            }
+        )
+
+        results = CRWRetriever("query").search()
+        self.assertEqual(
+            results,
+            [
+                {"href": "https://example.com/ok", "body": "ok"},
+                {"href": "https://example.com/href-only", "body": "md"},
+            ],
+        )


### PR DESCRIPTION
## Summary

- Harden CRWRetriever.search so non-dict / missing-URL payload items are skipped instead of KeyErroring on obj["url"].
- Preserve markdown-over-description body selection and accept href as a URL alias.

## Motivation

Malformed entries in fastCRW data[] currently raise KeyError during list comprehension, which the outer except converts into an empty result set for the whole query. One bad item should not discard valid results.

## Verification

Direct module load of gpt_researcher/retrievers/crw/crw.py (avoiding package-level json_repair import) with mocked POST:

- malformed mix [None, str, missing-url, url+desc, href+markdown] -> two clean href/body dicts
- Existing shape tests remain valid

## Diff scope

- gpt_researcher/retrievers/crw/crw.py
- tests/test_crw_retriever.py (test_search_skips_malformed_items)
