### PR TITLE
fix(retriever): guard BoCha against malformed result payloads

### DIFF
--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -40,19 +40,39 @@ class BoChaSearch():
             "count": max_results
         }
 
-        response = requests.post(url, headers=headers, json=data)
+        try:
+            response = requests.post(url, headers=headers, json=data, timeout=30)
+            response.raise_for_status()
+            json_response = response.json()
+        except Exception as e:
+            logging.getLogger(__name__).error(
+                "BoCha search request failed: %s. Returning empty results.", e
+            )
+            return []
 
-        json_response = response.json()
-        results = json_response["data"]["webPages"]["value"]
+        data_block = json_response.get("data") if isinstance(json_response, dict) else None
+        web_pages = data_block.get("webPages") if isinstance(data_block, dict) else None
+        results = web_pages.get("value") if isinstance(web_pages, dict) else None
+        if not isinstance(results, list):
+            logging.getLogger(__name__).warning(
+                "BoCha search returned unexpected payload shape. Returning empty results."
+            )
+            return []
+
         search_results = []
-
         # Normalize the results to match the format of the other search APIs
         for result in results:
-            search_result = {
-                "title": result["name"],
-                "href": result["url"],
-                "body": result["snippet"],
-            }
-            search_results.append(search_result)
+            if not isinstance(result, dict):
+                continue
+            url = result.get("url")
+            if not url:
+                continue
+            search_results.append(
+                {
+                    "title": result.get("name") or "",
+                    "href": url,
+                    "body": result.get("snippet") or "",
+                }
+            )
 
         return search_results

--- a/tests/test_bocha_retriever.py
+++ b/tests/test_bocha_retriever.py
@@ -1,0 +1,45 @@
+"""Guards for BoChaSearch malformed payloads."""
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.bocha.bocha import BoChaSearch
+
+
+def _resp(payload, status=200):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = payload
+    r.raise_for_status.return_value = None
+    return r
+
+
+@patch.dict("os.environ", {"BOCHA_API_KEY": "k"}, clear=False)
+@patch("gpt_researcher.retrievers.bocha.bocha.requests.post")
+def test_bocha_skips_malformed_items(mock_post):
+    mock_post.return_value = _resp(
+        {
+            "data": {
+                "webPages": {
+                    "value": [
+                        None,
+                        {"name": "n"},
+                        {
+                            "name": "ok",
+                            "url": "https://example.com",
+                            "snippet": "snip",
+                        },
+                    ]
+                }
+            }
+        }
+    )
+    out = BoChaSearch("q").search()
+    assert out == [
+        {"title": "ok", "href": "https://example.com", "body": "snip"}
+    ]
+
+
+@patch.dict("os.environ", {"BOCHA_API_KEY": "k"}, clear=False)
+@patch("gpt_researcher.retrievers.bocha.bocha.requests.post")
+def test_bocha_bad_envelope_returns_empty(mock_post):
+    mock_post.return_value = _resp({"data": {}})
+    assert BoChaSearch("q").search() == []


### PR DESCRIPTION
## Summary

- Harden BoChaSearch.search for missing data.webPages.value structure and per-item missing url/name/snippet.
- Return only valid {title,href,body} rows instead of failing the whole window.

## Motivation

BoCha normalization used result["url"] / result["name"] / result["snippet"] without guards. API envelope drift or partial objects raise KeyError and drop all results for the query. Matches the defensive pattern already used on Serper/Tavily-adjacent Bartok9 PRs.

## Verification

Isolated load of bocha.py with mocked POST:
- mixed None + missing-url + good item -> one cleaned result
- empty/malformed envelope -> []

## Diff scope

- gpt_researcher/retrievers/bocha/bocha.py
- tests/test_bocha_retriever.py
