### PR TITLE
fix(retriever): guard Tavily against malformed result fields

### DIFF
--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -131,10 +131,17 @@ class TavilySearch:
             sources = results.get("results", [])
             if not sources:
                 raise Exception("No results found with Tavily API search.")
-            # Return the results
-            search_response = [
-                {"href": obj["url"], "body": obj["content"]} for obj in sources
-            ]
+            # Return the results; skip non-dict / missing-URL items so one bad
+            # payload entry does not KeyError the whole search() call.
+            search_response = []
+            for obj in sources:
+                if not isinstance(obj, dict):
+                    continue
+                url = obj.get("url") or obj.get("href")
+                if not url:
+                    continue
+                body = obj.get("content") or obj.get("snippet") or obj.get("body") or ""
+                search_response.append({"href": url, "body": body})
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_tavily_result_guard.py
+++ b/tests/test_tavily_result_guard.py
@@ -1,0 +1,27 @@
+"""Ensure TavilySearch normalizes significantly-malformed result rows."""
+from unittest.mock import patch
+
+from gpt_researcher.retrievers.tavily.tavily_search import TavilySearch
+
+
+@patch.dict("os.environ", {"TAVILY_API_KEY": "k"}, clear=False)
+def test_tavily_skips_malformed_items():
+    searcher = TavilySearch("q")
+    with patch.object(
+        searcher,
+        "_search",
+        return_value={
+            "results": [
+                None,
+                "bad",
+                {"content": "no-url"},
+                {"url": "https://ok", "content": "body"},
+                {"href": "https://href", "snippet": "snip"},
+            ]
+        },
+    ):
+        out = searcher.search()
+    assert out == [
+        {"href": "https://ok", "body": "body"},
+        {"href": "https://href", "body": "snip"},
+    ]


### PR DESCRIPTION
## Summary

- Harden TavilySearch.search normalization: skip non-dict/missing-URL items; accept content/snippet/body for body text.
- Prevents a single bad results[] element from KeyErroring and wiping the whole query.

## Motivation

Current code does obj["url"] / obj["content"] in a list comprehension. Partial API payloads raise and the broad except returns []. Same defensive contract as other retriever guards.

## Verification

Isolated module load + mocked _search with mixed bad/good rows -> only valid href/body pairs.

## Diff scope

- gpt_researcher/retrievers/tavily/tavily_search.py
- tests/test_tavily_result_guard.py
