### PR TITLE
Resolve post-merge conflicts: 4 retriever/context fixes (supersedes #1895-1898)

### DIFF
--- a/gpt_researcher/context/compression.py
+++ b/gpt_researcher/context/compression.py
@@ -166,10 +166,15 @@ class ContextCompressor:
         # If total content is small, skip expensive compression and return directly
         if total_chars < chunk_threshold and len(self.documents) <= max_results:
             # Fast path: no compression needed
+            # Map scraper/retriever dict keys into metadata that pretty_print_docs expects.
+            # Raw dicts use `url`; SearchAPIRetriever / pretty_print use `source`.
             direct_docs = [
                 Document(
-                    page_content=doc.get('raw_content', ''),
-                    metadata=doc
+                    page_content=doc.get('raw_content', '') or '',
+                    metadata={
+                        "title": doc.get("title", "") or "",
+                        "source": doc.get("source") or doc.get("url") or "",
+                    },
                 )
                 for doc in self.documents[:max_results]
             ]

--- a/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
+++ b/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
@@ -43,17 +43,29 @@ class SemanticScholarSearch:
             print(f"An error occurred while accessing Semantic Scholar API: {e}")
             return []
 
-        results = response.json().get("data", [])
-        search_result = []
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return []
+        results = payload.get("data") or []
+        if not isinstance(results, list):
+            return []
 
+        search_result = []
         for result in results:
-            if result.get("isOpenAccess") and result.get("openAccessPdf"):
-                search_result.append(
-                    {
-                        "title": result.get("title", "No Title"),
-                        "href": result["openAccessPdf"].get("url", "No URL"),
-                        "body": result.get("abstract", "Abstract not available"),
-                    }
-                )
+            if not isinstance(result, dict):
+                continue
+            pdf = result.get("openAccessPdf")
+            if not (result.get("isOpenAccess") and isinstance(pdf, dict)):
+                continue
+            href = pdf.get("url") or ""
+            if not href:
+                continue
+            search_result.append(
+                {
+                    "title": result.get("title") or "No Title",
+                    "href": href,
+                    "body": result.get("abstract") or "Abstract not available",
+                }
+            )
 
         return search_result

--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -114,17 +114,25 @@ class SerperSearch():
         if search_results is None:
             return
 
-        results = search_results.get("organic", [])
+        results = search_results.get("organic") or []
+        if not isinstance(results, list):
+            return []
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         # Excluded sites should already be filtered out by the query parameters
         for result in results:
-            search_result = {
-                "title": result["title"],
-                "href": result["link"],
-                "body": result["snippet"],
-            }
-            search_results.append(search_result)
+            if not isinstance(result, dict):
+                continue
+            href = result.get("link") or result.get("url") or ""
+            if not href:
+                continue
+            search_results.append(
+                {
+                    "title": result.get("title") or "",
+                    "href": href,
+                    "body": result.get("snippet") or result.get("body") or "",
+                }
+            )
 
         return search_results

--- a/gpt_researcher/scraper/arxiv/arxiv.py
+++ b/gpt_researcher/scraper/arxiv/arxiv.py
@@ -1,28 +1,60 @@
-from langchain_community.retrievers import ArxivRetriever
+"""ArXiv paper scraper using the maintained `arxiv` Client API.
+
+Avoids langchain_community.ArxivRetriever, which still calls the removed
+`arxiv.Search.results()` method (broken for arxiv>=2.2).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_ID_RE = re.compile(
+    r"(?:arxiv\.org/(?:abs|pdf|html)/)?(?P<id>\d{4}\.\d{4,5}(?:v\d+)?|[a-z\-]+/\d{7})(?:\.pdf)?",
+    re.IGNORECASE,
+)
+
+
+def _paper_id_from_link(link: str) -> str:
+    """Extract an arXiv id from a URL or bare id string."""
+    if not link:
+        return ""
+    m = _ID_RE.search(link.strip())
+    if m:
+        return m.group("id")
+    # last path segment fallback (legacy behavior)
+    return link.rstrip("/").split("/")[-1].removesuffix(".pdf")
 
 
 class ArxivScraper:
-
     def __init__(self, link, session=None):
         self.link = link
         self.session = session
 
     def scrape(self):
-        """
-        The function scrapes relevant documents from Arxiv based on a given link and returns the content
-        of the first document.
-        
+        """Fetch paper abstract/content via arxiv.Client.
+
         Returns:
-          The code is returning the page content of the first document retrieved by the ArxivRetriever
-        for a given query extracted from the link.
+            (context, images, title) matching other scrapers.
         """
-        query = self.link.split("/")[-1]
-        retriever = ArxivRetriever(load_max_docs=2, doc_content_chars_max=None)
-        docs = retriever.invoke(query)
+        import arxiv
 
-        # Include the published date and author to provide additional context, 
-        # aligning with APA-style formatting in the report.
-        context = f"Published: {docs[0].metadata['Published']}; Author: {docs[0].metadata['Authors']}; Content: {docs[0].page_content}"
-        image = []
+        paper_id = _paper_id_from_link(self.link)
+        client = arxiv.Client()
+        search = arxiv.Search(id_list=[paper_id], max_results=1)
+        try:
+            paper = next(client.results(search))
+        except StopIteration as exc:
+            raise ValueError(f"No arXiv paper found for id {paper_id!r}") from exc
 
-        return context, image, docs[0].metadata["Title"]
+        authors = ", ".join(a.name for a in (paper.authors or []))
+        published = paper.published.date().isoformat() if paper.published else ""
+        summary = paper.summary or ""
+        title = paper.title or paper_id
+
+        context = (
+            f"Published: {published}; Author: {authors}; Content: {summary}"
+        )
+        image: list[Any] = []
+        return context, image, title

--- a/tests/test_arxiv_scraper.py
+++ b/tests/test_arxiv_scraper.py
@@ -1,0 +1,44 @@
+"""Regression: ArxivScraper must use arxiv.Client, not Search.results()."""
+
+from types import SimpleNamespace
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gpt_researcher.scraper.arxiv.arxiv import ArxivScraper, _paper_id_from_link
+
+
+def test_paper_id_from_abs_and_pdf_urls():
+    assert _paper_id_from_link("https://arxiv.org/abs/2605.19780v1") == "2605.19780v1"
+    assert _paper_id_from_link("https://arxiv.org/pdf/2605.19780v1.pdf") == "2605.19780v1"
+    assert _paper_id_from_link("2605.19780") == "2605.19780"
+
+
+def test_scrape_uses_client_results_not_search_results():
+    mock_paper = SimpleNamespace(
+        title="Example Paper",
+        summary="An abstract long enough to matter.",
+        authors=[SimpleNamespace(name="Ada Lovelace")],
+        published=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    mock_client = MagicMock()
+    mock_client.results.return_value = iter([mock_paper])
+
+    with patch("arxiv.Client", return_value=mock_client) as client_ctor:
+        with patch("arxiv.Search") as search_ctor:
+            ctx, images, title = ArxivScraper(
+                "https://arxiv.org/pdf/2605.19780v1"
+            ).scrape()
+
+    client_ctor.assert_called_once_with()
+    search_ctor.assert_called_once()
+    kwargs = search_ctor.call_args.kwargs
+    assert kwargs["id_list"] == ["2605.19780v1"]
+    mock_client.results.assert_called_once()
+    # Never touch removed Search.results
+    assert not hasattr(search_ctor.return_value, "results") or True
+    assert title == "Example Paper"
+    assert "Ada Lovelace" in ctx
+    assert "An abstract long enough to matter." in ctx
+    assert images == []

--- a/tests/test_context_compressor_source_url.py
+++ b/tests/test_context_compressor_source_url.py
@@ -1,0 +1,54 @@
+"""Regression: ContextCompressor fast path must map url -> metadata.source."""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.documents import Document
+
+from gpt_researcher.context.compression import ContextCompressor
+from gpt_researcher.prompts import PromptFamily
+
+
+@pytest.mark.asyncio
+async def test_fast_path_maps_url_to_source_metadata(monkeypatch):
+    monkeypatch.setenv("COMPRESSION_THRESHOLD", "8000")
+    docs = [
+        {
+            "url": "https://real.example/report",
+            "title": "Market share report",
+            "raw_content": "snippet content under threshold",
+        }
+    ]
+    compressor = ContextCompressor(
+        documents=docs,
+        embeddings=MagicMock(),
+        max_results=5,
+        prompt_family=PromptFamily,
+    )
+    out = await compressor.async_get_context("market share", max_results=5)
+    assert "Source: https://real.example/report" in out
+    assert "Title: Market share report" in out
+    assert "Source: None" not in out
+
+
+@pytest.mark.asyncio
+async def test_fast_path_prefers_explicit_source_key(monkeypatch):
+    monkeypatch.setenv("COMPRESSION_THRESHOLD", "8000")
+    docs = [
+        {
+            "url": "https://ignored.example/",
+            "source": "https://canonical.example/doc",
+            "title": "Canonical",
+            "raw_content": "short body",
+        }
+    ]
+    compressor = ContextCompressor(
+        documents=docs,
+        embeddings=MagicMock(),
+        max_results=5,
+        prompt_family=PromptFamily,
+    )
+    out = await compressor.async_get_context("q", max_results=5)
+    assert "Source: https://canonical.example/doc" in out
+    assert "https://ignored.example" not in out

--- a/tests/test_semantic_scholar_retriever.py
+++ b/tests/test_semantic_scholar_retriever.py
@@ -1,0 +1,63 @@
+"""Guards for Semantic Scholar malformed payloads / openAccessPdf shapes."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.semantic_scholar.semantic_scholar import (
+    SemanticScholarSearch,
+)
+
+
+def _resp(payload):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+def test_open_access_pdf_none_does_not_crash():
+    payload = {
+        "data": [
+            {
+                "title": "A",
+                "isOpenAccess": True,
+                "openAccessPdf": None,
+                "abstract": "x",
+            }
+        ]
+    }
+    with patch("requests.get", return_value=_resp(payload)):
+        out = SemanticScholarSearch("q").search()
+    assert out == []
+
+
+def test_open_access_pdf_string_skipped():
+    payload = {
+        "data": [
+            {
+                "title": "A",
+                "isOpenAccess": True,
+                "openAccessPdf": "https://not-a-dict",
+                "abstract": "x",
+            }
+        ]
+    }
+    with patch("requests.get", return_value=_resp(payload)):
+        assert SemanticScholarSearch("q").search() == []
+
+
+def test_happy_path_url():
+    payload = {
+        "data": [
+            {
+                "title": "Paper",
+                "isOpenAccess": True,
+                "openAccessPdf": {"url": "https://pdf.example/p.pdf"},
+                "abstract": "abs",
+            }
+        ]
+    }
+    with patch("requests.get", return_value=_resp(payload)):
+        out = SemanticScholarSearch("q").search()
+    assert out == [
+        {"title": "Paper", "href": "https://pdf.example/p.pdf", "body": "abs"}
+    ]

--- a/tests/test_serper_retriever.py
+++ b/tests/test_serper_retriever.py
@@ -1,0 +1,24 @@
+"""Serper organic items must not KeyError on partial payloads."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.serper.serper import SerperSearch
+
+
+def test_skip_items_missing_link(monkeypatch):
+    monkeypatch.setenv("SERPER_API_KEY", "k")
+    resp = MagicMock()
+    resp.text = '{"organic":[{"title":"t","snippet":"s"},{"title":"ok","link":"https://e.example","snippet":"body"}]}'
+    with patch("requests.request", return_value=resp):
+        out = SerperSearch("q").search()
+    assert out == [
+        {"title": "ok", "href": "https://e.example", "body": "body"}
+    ]
+
+
+def test_organic_not_list_returns_empty(monkeypatch):
+    monkeypatch.setenv("SERPER_API_KEY", "k")
+    resp = MagicMock()
+    resp.text = '{"organic":"nope"}'
+    with patch("requests.request", return_value=resp):
+        assert SerperSearch("q").search() == []


### PR DESCRIPTION
Consolidates and rebases four contributor fixes from @Bartok9 that were opened against the now-diverged `master` branch and had become conflicting after the recent `main` merges (#1861, #1857). Each fix is cherry-picked clean onto current `main` **with its accompanying test**, and the full offline unit suite passes (50 tests).

Supersedes and closes:
- #1898 — guard Serper organic items against missing keys
- #1897 — guard Semantic Scholar openAccessPdf shapes
- #1896 — fetch arXiv via Client API not Search.results (fixes #1894)
- #1895 — map url to source on compressor fast path (fixes #1893 — reports citing `https://example.com`)

The compression fix was re-applied on top of #1861's rewrite of `compression.py`: the fast-path now maps the raw scraper `url` key into the `source` metadata that `pretty_print_docs` expects, so source URLs are no longer lost.

Authorship preserved via `git cherry-pick -x`. Tested: pytest offline unit suite — 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)