### PR TITLE
Retriever hardening: 20 guard fixes against malformed results (supersedes #1837…#1890)

### DIFF
--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -144,14 +144,17 @@ def get_retrievers(headers: dict[str, str], cfg):
             retrievers = cfg.retrievers.split(",")
         else:
             retrievers = cfg.retrievers
-        # Strip whitespace from each retriever name
-        retrievers = [r.strip() for r in retrievers]
     # If not found, check config for a single retriever
     elif cfg.retriever:
         retrievers = [cfg.retriever]
     # If still not set, use default retriever
     else:
         retrievers = [get_default_retriever().__name__]
+
+    # Strip whitespace from each retriever name so comma-separated lists with
+    # spaces (e.g. "tavily, exa" from a header or config) resolve correctly
+    # instead of silently falling back to the default retriever.
+    retrievers = [r.strip() for r in retrievers if r and r.strip()]
 
     # Convert retriever names to actual retriever classes
     # Use get_default_retriever() as a fallback for any invalid retriever names

--- a/gpt_researcher/context/retriever.py
+++ b/gpt_researcher/context/retriever.py
@@ -23,7 +23,10 @@ class SearchAPIRetriever(BaseRetriever):
 
         docs = [
             Document(
-                page_content=page.get("raw_content", "")[:_MAX_CONTENT_CHARS],
+                # ``raw_content`` may be explicitly None (the scraper sets it to
+                # None for pages that failed to scrape), and slicing None raises
+                # TypeError. Coerce to a string before truncating.
+                page_content=(page.get("raw_content") or "")[:_MAX_CONTENT_CHARS],
                 metadata={
                     "title": page.get("title", ""),
                     "source": page.get("url", ""),

--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -70,26 +70,26 @@ class BingSearch():
             return []
         try:
             search_results = json.loads(resp.text)
-            results = search_results["webPages"]["value"]
+            results = search_results.get("webPages", {}).get("value", [])
         except Exception as e:
             self.logger.error(
                 f"Error parsing Bing search results: {e}. Resulting in empty response.")
             return []
-        if search_results is None:
+        if not results:
             self.logger.warning(f"No search results found for query: {self.query}")
             return []
-        search_results = []
 
         # Normalize the results to match the format of the other search APIs
+        search_response = []
         for result in results:
+            url = result.get("url", "")
             # skip youtube results
-            if "youtube.com" in result["url"]:
+            if "youtube.com" in url:
                 continue
-            search_result = {
-                "title": result["name"],
-                "href": result["url"],
-                "body": result["snippet"],
-            }
-            search_results.append(search_result)
+            search_response.append({
+                "title": result.get("name", ""),
+                "href": url,
+                "body": result.get("snippet", ""),
+            })
 
-        return search_results
+        return search_response

--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -40,19 +40,32 @@ class BoChaSearch():
             "count": max_results
         }
 
-        response = requests.post(url, headers=headers, json=data)
+        try:
+            response = requests.post(url, headers=headers, json=data, timeout=10)
+            response.raise_for_status()
+            json_response = response.json()
+        except (requests.RequestException, ValueError) as e:
+            logging.getLogger(__name__).warning(
+                f"Error: {e}. Failed fetching sources. Resulting in empty response."
+            )
+            return []
 
-        json_response = response.json()
-        results = json_response["data"]["webPages"]["value"]
+        # The BoCha response shape is data.webPages.value; any of these may be
+        # missing on an error/empty payload, so walk it defensively rather than
+        # KeyError-ing the whole research run.
+        results = (
+            ((json_response or {}).get("data") or {}).get("webPages") or {}
+        ).get("value") or []
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
-            search_result = {
-                "title": result["name"],
-                "href": result["url"],
-                "body": result["snippet"],
-            }
-            search_results.append(search_result)
+            search_results.append(
+                {
+                    "title": result.get("name", ""),
+                    "href": result.get("url", ""),
+                    "body": result.get("snippet", ""),
+                }
+            )
 
         return search_results

--- a/gpt_researcher/retrievers/crw/crw.py
+++ b/gpt_researcher/retrievers/crw/crw.py
@@ -107,16 +107,18 @@ class CRWRetriever:
         try:
             # Search the query
             results = self._search(self.query, max_results=max_results)
-            sources = results.get("data", [])
+            sources = results.get("data") or []
             if not sources:
                 raise Exception("No results found with fastCRW API search.")
-            # Return the results
+            # Return the results. A source missing "url" is unusable, so skip it
+            # rather than raising a KeyError that discards the whole result set.
             search_response = [
                 {
                     "href": obj["url"],
                     "body": obj.get("markdown") or obj.get("description", ""),
                 }
                 for obj in sources
+                if obj.get("url")
             ]
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")

--- a/gpt_researcher/retrievers/custom/custom.py
+++ b/gpt_researcher/retrievers/custom/custom.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 import requests
 import os
 
@@ -26,7 +26,7 @@ class CustomRetriever:
             if key.startswith('RETRIEVER_ARG_')
         }
 
-    def search(self, max_results: int = 5) -> Optional[List[Dict[str, Any]]]:
+    def search(self, max_results: int = 5) -> List[Dict[str, Any]]:
         """
         Performs the search using the custom retriever endpoint.
 
@@ -44,9 +44,28 @@ class CustomRetriever:
             ]
         """
         try:
-            response = requests.get(self.endpoint, params={**self.params, 'query': self.query})
+            response = requests.get(
+                self.endpoint,
+                params={**self.params, "query": self.query},
+                timeout=20,
+            )
             response.raise_for_status()
-            return response.json()
-        except requests.RequestException as e:
+            payload = response.json()
+        except (requests.RequestException, ValueError) as e:
+            # ValueError covers JSONDecodeError (subclass) and other parse fails.
             print(f"Failed to retrieve search results: {e}")
-            return None
+            return []
+
+        # Contract: callers iterate the return value. A null JSON body or a
+        # non-list payload used to surface as TypeError later (or as the
+        # documented but surprising Optional). Always hand back a list.
+        if payload is None:
+            return []
+        if not isinstance(payload, list):
+            print(
+                "Custom retriever response must be a JSON list of "
+                "{url, raw_content} objects; got "
+                f"{type(payload).__name__}"
+            )
+            return []
+        return payload

--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -15,10 +15,13 @@ class Duckduckgo:
 
     def search(self, max_results=5):
         """
-        Performs the search
-        :param query:
-        :param max_results:
-        :return:
+        Performs the search and normalizes ddgs payloads to the shared
+        ``{href, body, title?}`` contract used by other retrievers.
+
+        ``ddgs`` historically returned dicts with ``href``/`body` keys; newer
+        releases emit ``link``/`url` and ``body`/`snippet`/`description``.
+        Downstream research steps expect ``href`` and would KeyError or skip
+        sources if the raw ddgs shape is returned unchanged.
         """
         # TODO: Add support for query domains
         try:
@@ -26,4 +29,33 @@ class Duckduckgo:
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []
-        return search_response
+
+        if not search_response:
+            return []
+
+        normalized = []
+        for result in search_response:
+            if not isinstance(result, dict):
+                continue
+            href = (
+                result.get("href")
+                or result.get("link")
+                or result.get("url")
+                or ""
+            )
+            if not href:
+                continue
+            body = (
+                result.get("body")
+                or result.get("snippet")
+                or result.get("description")
+                or ""
+            )
+            item = {"href": href, "body": body}
+            title = result.get("title")
+            if title:
+                item["title"] = title
+            normalized.append(item)
+
+        # Preserve caller-requested max_results even if the client ignored it.
+        return list(islice(normalized, max_results))

--- a/gpt_researcher/retrievers/exa/exa.py
+++ b/gpt_researcher/retrievers/exa/exa.py
@@ -60,9 +60,13 @@ class ExaSearch:
             **filters
         )
 
-        search_response = [
-            {"href": result.url, "body": result.text} for result in results.results
-        ]
+        search_response = []
+        for result in results.results or []:
+            href = getattr(result, "url", None)
+            if not href:
+                continue
+            body = getattr(result, "text", None) or getattr(result, "summary", None) or ""
+            search_response.append({"href": href, "body": body})
         return search_response
 
     def find_similar(self, url, exclude_source_domain=False, **filters):
@@ -79,9 +83,13 @@ class ExaSearch:
             url, exclude_source_domain=exclude_source_domain, **filters
         )
 
-        similar_response = [
-            {"href": result.url, "body": result.text} for result in results.results
-        ]
+        similar_response = []
+        for result in results.results or []:
+            href = getattr(result, "url", None)
+            if not href:
+                continue
+            body = getattr(result, "text", None) or getattr(result, "summary", None) or ""
+            similar_response.append({"href": href, "body": body})
         return similar_response
 
     def get_contents(self, ids, **options):
@@ -95,7 +103,11 @@ class ExaSearch:
         """
         results = self.client.get_contents(ids, **options)
 
-        contents_response = [
-            {"id": result.id, "content": result.text} for result in results.results
-        ]
+        contents_response = []
+        for result in results.results or []:
+            result_id = getattr(result, "id", None)
+            if result_id is None:
+                continue
+            content = getattr(result, "text", None) or ""
+            contents_response.append({"id": result_id, "content": content})
         return contents_response

--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -71,30 +71,32 @@ class GoogleSearch:
             print("Google search: unexpected response status: ", resp.status_code)
 
         if resp is None:
-            return
+            return []
         try:
             search_results = json.loads(resp.text)
         except Exception:
-            return
-        if search_results is None:
-            return
+            return []
+        if not isinstance(search_results, dict):
+            return []
 
-        results = search_results.get("items", [])
-        search_results = []
+        results = search_results.get("items", []) or []
+        search_response = []
 
-        # Normalizing results to match the format of the other search APIs
+        # Normalizing results to match the format of the other search APIs.
+        # Use .get so a missing title/snippet cannot drop a valid link; skip
+        # non-dict rows and empty links outright.
         for result in results:
-            # skip youtube results
-            if "youtube.com" in result["link"]:
+            if not isinstance(result, dict):
                 continue
-            try:
-                search_result = {
-                    "title": result["title"],
-                    "href": result["link"],
-                    "body": result["snippet"],
+            link = result.get("link") or ""
+            if not link or "youtube.com" in link:
+                continue
+            search_response.append(
+                {
+                    "title": result.get("title") or "",
+                    "href": link,
+                    "body": result.get("snippet") or "",
                 }
-            except Exception:
-                continue
-            search_results.append(search_result)
+            )
 
-        return search_results[:max_results]
+        return search_response[:max_results]

--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -4,6 +4,7 @@
 import os
 import requests
 import json
+from urllib.parse import urlencode
 
 
 class GoogleSearch:
@@ -64,7 +65,18 @@ class GoogleSearch:
 
         print("Searching with query {0}...".format(search_query))
 
-        url = f"https://www.googleapis.com/customsearch/v1?key={self.api_key}&cx={self.cx_key}&q={search_query}&start=1"
+        # URL-encode every parameter. Interpolating the raw query broke any
+        # search containing reserved characters (e.g. "&" in "AT&T" added a
+        # spurious param, "#" truncated the rest of the query).
+        query_string = urlencode(
+            {
+                "key": self.api_key,
+                "cx": self.cx_key,
+                "q": search_query,
+                "start": 1,
+            }
+        )
+        url = f"https://www.googleapis.com/customsearch/v1?{query_string}"
         resp = requests.get(url)
 
         if resp.status_code < 200 or resp.status_code >= 300:

--- a/gpt_researcher/retrievers/groundroute/groundroute.py
+++ b/gpt_researcher/retrievers/groundroute/groundroute.py
@@ -47,12 +47,30 @@ class GroundRouteSearch:
                 timeout=20,
             )
             response.raise_for_status()
-            results = response.json().get("results", [])
-            return [
-                {"href": r.get("url"), "body": r.get("content") or r.get("snippet") or ""}
-                for r in results
-                if r.get("url")
-            ]
+            payload = response.json()
         except Exception as e:
             print(f"Error performing GroundRoute search: {e}")
             return []
+
+        if isinstance(payload, list):
+            results = payload
+        elif isinstance(payload, dict):
+            results = payload.get("results", [])
+        else:
+            return []
+
+        if not isinstance(results, list):
+            return []
+
+        normalized = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            href = r.get("url") or r.get("href") or r.get("link") or ""
+            if not href:
+                continue
+            body = r.get("content") or r.get("snippet") or r.get("body") or ""
+            normalized.append({"href": href, "body": body})
+            if len(normalized) >= max_results:
+                break
+        return normalized

--- a/gpt_researcher/retrievers/openalex/openalex.py
+++ b/gpt_researcher/retrievers/openalex/openalex.py
@@ -65,9 +65,17 @@ class OpenAlexSearch:
             print(f"An error occurred while accessing OpenAlex API: {e}")
             return []
 
-        results = response.json().get("results", [])
+        payload = response.json()
+        if not isinstance(payload, dict):
+            return []
+        results = payload.get("results", [])
+        if not isinstance(results, list):
+            return []
+
         search_result = []
         for result in results:
+            if not isinstance(result, dict):
+                continue
             title = result.get("title") or "No Title"
             href = self._pick_href(result)
             body = self._reconstruct_abstract(result.get("abstract_inverted_index"))
@@ -107,11 +115,18 @@ class OpenAlexSearch:
         OpenAlex returns abstracts as an inverted index (word -> positions).
         Reconstruct the original text.
         """
-        if not inverted:
+        if not inverted or not isinstance(inverted, dict):
             return None
         positions: List[tuple] = []
         for word, indexes in inverted.items():
+            if not isinstance(indexes, (list, tuple)):
+                continue
             for i in indexes:
-                positions.append((i, word))
+                try:
+                    positions.append((int(i), word))
+                except (TypeError, ValueError):
+                    continue
+        if not positions:
+            return None
         positions.sort(key=lambda x: x[0])
         return " ".join(word for _, word in positions)

--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -125,7 +125,7 @@ class PubMedCentralSearch:
         except requests.RequestException as e:
             return None
 
-    def search(self, max_results: int = 5) -> Optional[List[Dict[str, Any]]]:
+    def search(self, max_results: int = 5) -> List[Dict[str, Any]]:
         """
         Performs the search and retrieves full text content.
 
@@ -139,10 +139,13 @@ class PubMedCentralSearch:
               ...
             ]
         """
-        # Step 1: Search for article IDs
+        # Step 1: Search for article IDs. Always return a list (never None):
+        # callers such as actions.query_processing.get_search_results are typed
+        # -> List[Dict] and skills.researcher does len(search_results), which
+        # raises TypeError on None.
         article_ids = self._search_articles(max_results)
         if not article_ids:
-            return None
+            return []
         
         # Step 2: Fetch full text for each article
         results = []

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -47,8 +47,8 @@ class SearxSearch():
         search_url = urljoin(self.base_url, "search")
         # TODO: Add support for query domains
         params = {
-            # The search query. 
-            'q': self.query, 
+            # The search query.
+            'q': self.query,
             # Output format of results. Format needs to be activated in searxng config.
             'format': 'json'
         }
@@ -61,18 +61,30 @@ class SearxSearch():
             )
             response.raise_for_status()
             results = response.json()
-
-            # Normalize results to match the expected format
-            search_response = []
-            for result in results.get('results', [])[:max_results]:
-                search_response.append({
-                    "href": result.get('url', ''),
-                    "body": result.get('content', '')
-                })
-
-            return search_response
-
         except requests.exceptions.RequestException as e:
             raise Exception(f"Error querying SearxNG: {str(e)}")
         except json.JSONDecodeError:
             raise Exception("Error parsing SearxNG response")
+
+        if not isinstance(results, dict):
+            return []
+
+        search_response = []
+        raw_results = results.get('results', [])
+        if not isinstance(raw_results, list):
+            return []
+
+        for result in raw_results:
+            if not isinstance(result, dict):
+                continue
+            href = result.get('url') or result.get('href') or ''
+            if not href:
+                continue
+            search_response.append({
+                "href": href,
+                "body": result.get('content') or result.get('snippet') or '',
+            })
+            if len(search_response) >= max_results:
+                break
+
+        return search_response

--- a/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
+++ b/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
@@ -20,7 +20,11 @@ class SemanticScholarSearch:
         """
         self.query = query
         assert sort in self.VALID_SORT_CRITERIA, "Invalid sort criterion"
-        self.sort = sort.lower()
+        # Preserve the exact (camelCase) criterion. The Semantic Scholar API
+        # expects ``citationCount`` / ``publicationDate`` verbatim; lowercasing
+        # them produced ``citationcount`` / ``publicationdate``, which the API
+        # rejects or silently ignores.
+        self.sort = sort
 
     def search(self, max_results: int = 20) -> List[Dict[str, str]]:
         """

--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -60,18 +60,26 @@ class SerpApiSearch():
             if response.status_code == 200:
                 search_results = response.json()
                 if search_results:
-                    results = search_results["organic_results"]
+                    # A response with no organic results (e.g. an error payload
+                    # or a query that matched nothing) has no "organic_results"
+                    # key; default to [] instead of raising KeyError.
+                    results = search_results.get("organic_results") or []
                     results_processed = 0
                     for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
                         if results_processed >= max_results:
                             break
+                        link = result.get("link")
+                        # A result without a link is unusable; skip it rather
+                        # than emitting an entry with href=None.
+                        if not link:
+                            continue
+                        # skip youtube results
+                        if "youtube.com" in link:
+                            continue
                         search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
+                            "title": result.get("title", ""),
+                            "href": link,
+                            "body": result.get("snippet", ""),
                         }
                         search_response.append(search_result)
                         results_processed += 1

--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -104,15 +104,16 @@ class SerperSearch():
 
         resp = requests.request("POST", url, timeout=10, headers=headers, data=data)
 
-        # Preprocess the results
+        # Preprocess the results. Always return a list so callers (which do
+        # `len(...)` / iterate over the result) never receive None.
         if resp is None:
-            return
+            return []
         try:
             search_results = json.loads(resp.text)
         except Exception:
-            return
+            return []
         if search_results is None:
-            return
+            return []
 
         results = search_results.get("organic", [])
         search_results = []

--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -131,10 +131,17 @@ class TavilySearch:
             sources = results.get("results", [])
             if not sources:
                 raise Exception("No results found with Tavily API search.")
-            # Return the results
-            search_response = [
-                {"href": obj["url"], "body": obj["content"]} for obj in sources
-            ]
+            # Return the results. Guard each source against missing/None
+            # fields so a single malformed hit does not drop the whole page.
+            search_response = []
+            for obj in sources:
+                if not isinstance(obj, dict):
+                    continue
+                href = obj.get("url")
+                if not href:
+                    continue
+                body = obj.get("content") or obj.get("snippet") or ""
+                search_response.append({"href": href, "body": body})
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/gpt_researcher/retrievers/xquik/xquik.py
+++ b/gpt_researcher/retrievers/xquik/xquik.py
@@ -68,14 +68,19 @@ class XquikSearch:
         with urllib.request.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read().decode("utf-8"))
 
-        tweets = data.get("tweets", [])
+        # Use `or` fallbacks so an explicit JSON null ("tweets": null,
+        # "author": null, "text": null) does not slip a None past `.get()`'s
+        # default and crash slicing / attribute access below — which the
+        # broad except in search() would swallow, silently dropping every
+        # result. Mirrors the sibling GetXAPI retriever.
+        tweets = data.get("tweets") or []
         search_results = []
 
         for tweet in tweets[:max_results]:
-            author = tweet.get("author", {})
-            username = author.get("username", "unknown")
-            text = tweet.get("text", "")
-            tweet_id = tweet.get("id", "")
+            author = tweet.get("author") or {}
+            username = author.get("username") or "unknown"
+            text = tweet.get("text") or ""
+            tweet_id = tweet.get("id") or ""
 
             likes = tweet.get("likeCount", 0)
             retweets = tweet.get("retweetCount", 0)

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -463,6 +463,34 @@ class ResearchConductor:
         
         return all_mcp_context
 
+    def _tavily_mcp_redundant_with_direct(self, mcp_retrievers, non_mcp_retrievers) -> bool:
+        """True when MCP would only re-query Tavily while direct Tavily is active.
+
+        The frontend Tavily Web Search MCP preset hits the same API as
+        `TavilySearch` and adds extra LLM tool-selection cost for no new data
+        when both run together (#1875).
+        """
+        if not mcp_retrievers or not non_mcp_retrievers:
+            return False
+        has_direct_tavily = any(
+            getattr(r, "__name__", "").lower() == "tavilysearch" for r in non_mcp_retrievers
+        )
+        if not has_direct_tavily:
+            return False
+        configs = getattr(self.researcher, "mcp_configs", None) or []
+        if not configs:
+            return False
+        # If every configured MCP server is a Tavily MCP package, treat as redundant.
+        def _is_tavily_mcp(cfg: dict) -> bool:
+            name = str(cfg.get("name", "")).lower()
+            args = " ".join(str(a) for a in (cfg.get("args") or [])).lower()
+            command = str(cfg.get("command", "")).lower()
+            blob = f"{name} {args} {command}"
+            return "tavily" in blob
+
+        return all(isinstance(c, dict) and _is_tavily_mcp(c) for c in configs)
+
+
     async def _process_sub_query(self, sub_query: str, scraped_data: list = [], query_domains: list = []):
         """Takes in a sub query and scrapes urls based on it and gathers context."""
         if self.json_handler:
@@ -483,6 +511,20 @@ class ResearchConductor:
             # Identify MCP retrievers
             mcp_retrievers = [r for r in self.researcher.retrievers if "mcpretriever" in r.__name__.lower()]
             non_mcp_retrievers = [r for r in self.researcher.retrievers if "mcpretriever" not in r.__name__.lower()]
+
+            # Avoid dual Tavily path (direct retriever + tavily-mcp) under default RETRIEVER=tavily.
+            if self._tavily_mcp_redundant_with_direct(mcp_retrievers, non_mcp_retrievers):
+                self.logger.warning(
+                    "Skipping LLM MCP Tavily path because TavilySearch is already configured as a direct retriever; set RETRIEVER without tavily or use non-Tavily MCP servers to keep MCP."
+                )
+                if self.researcher.verbose:
+                    await stream_output(
+                        "logs",
+                        "mcp_tavily_deduped",
+                        "⚠️ Skipping Tavily MCP (redundant with direct Tavily retriever) to avoid double API cost",
+                        self.researcher.websocket,
+                    )
+                mcp_retrievers = []
             
             # Initialize context components
             mcp_context = []

--- a/tests/skills/test_tavily_mcp_dedupe.py
+++ b/tests/skills/test_tavily_mcp_dedupe.py
@@ -1,0 +1,67 @@
+"""Skip redundant Tavily MCP when direct Tavily retriever is active (#1875)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gpt_researcher.skills.researcher import ResearchConductor
+
+
+class TavilySearch:
+    pass
+
+
+class MCPRetriever:  # name contains mcpretriever
+    pass
+
+
+@pytest.mark.asyncio
+async def test_redundant_tavily_mcp_is_skipped():
+    conductor = ResearchConductor(SimpleNamespace(
+        retrievers=[TavilySearch, MCPRetriever],
+        mcp_configs=[{"name": "tavily-mcp", "command": "npx", "args": ["-y", "tavily-mcp@0.1.2"]}],
+        mcp_strategy="fast",
+        verbose=False,
+        websocket=None,
+        headers={},
+        query_domains=[],
+        cfg=SimpleNamespace(max_search_results_per_query=5),
+        kwargs={},
+        context_manager=SimpleNamespace(
+            get_similar_content_by_query=AsyncMock(return_value="web-context")
+        ),
+    ))
+    conductor._mcp_results_cache = None
+    conductor._execute_mcp_research_for_queries = AsyncMock(return_value=["should-not-run"])
+    conductor._scrape_data_by_urls = AsyncMock(return_value=[{"url": "u", "raw_content": "c"}])
+    conductor._combine_mcp_and_web_context = MagicMock(return_value="combined")
+
+    out = await conductor._process_sub_query("topic")
+
+    conductor._execute_mcp_research_for_queries.assert_not_called()
+    assert out == "combined"
+
+
+@pytest.mark.asyncio
+async def test_non_tavily_mcp_still_runs():
+    conductor = ResearchConductor(SimpleNamespace(
+        retrievers=[TavilySearch, MCPRetriever],
+        mcp_configs=[{"name": "filesystem", "command": "npx", "args": ["@modelcontextprotocol/server-filesystem", "/tmp"]}],
+        mcp_strategy="deep",
+        verbose=False,
+        websocket=None,
+        headers={},
+        query_domains=[],
+        cfg=SimpleNamespace(max_search_results_per_query=5),
+        kwargs={},
+        context_manager=SimpleNamespace(
+            get_similar_content_by_query=AsyncMock(return_value="web-context")
+        ),
+    ))
+    conductor._execute_mcp_research_for_queries = AsyncMock(return_value=["mcp-context"])
+    conductor._scrape_data_by_urls = AsyncMock(return_value=[{"url": "u", "raw_content": "c"}])
+    conductor._combine_mcp_and_web_context = MagicMock(return_value="combined")
+
+    await conductor._process_sub_query("topic")
+    conductor._execute_mcp_research_for_queries.assert_called()

--- a/tests/test_bing_retriever_malformed.py
+++ b/tests/test_bing_retriever_malformed.py
@@ -1,0 +1,53 @@
+"""Regression tests for BingSearch result normalization.
+
+Without the fix, a single result missing an expected key (``url``/``name``/
+``snippet``) raises a KeyError that aborts the whole ``search()`` call, and a
+response without a ``webPages`` block raises a KeyError instead of returning [].
+"""
+import importlib.util
+import json
+import os
+import pathlib
+from unittest.mock import patch
+
+# Import the module directly to avoid importing the heavy gpt_researcher package
+# (which pulls optional deps like json_repair at import time).
+_BING_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher" / "retrievers" / "bing" / "bing.py"
+)
+_spec = importlib.util.spec_from_file_location("_bing_under_test", _BING_PATH)
+_bing = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_bing)
+BingSearch = _bing.BingSearch
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self.text = json.dumps(payload)
+
+
+@patch.dict(os.environ, {"BING_API_KEY": "test-key"})
+def test_bing_skips_results_missing_keys():
+    payload = {
+        "webPages": {
+            "value": [
+                {"name": "A", "url": "https://a.example", "snippet": "sa"},
+                {"name": "B", "url": "https://b.example"},  # missing snippet
+                {"url": "https://c.example"},  # missing name + snippet
+            ]
+        }
+    }
+    with patch.object(_bing.requests, "get", return_value=_FakeResp(payload)):
+        results = BingSearch("q").search()
+
+    assert len(results) == 3
+    assert results[0] == {"title": "A", "href": "https://a.example", "body": "sa"}
+    assert results[1]["body"] == ""
+    assert results[2]["title"] == ""
+
+
+@patch.dict(os.environ, {"BING_API_KEY": "test-key"})
+def test_bing_no_webpages_returns_empty():
+    with patch.object(_bing.requests, "get", return_value=_FakeResp({})):
+        assert BingSearch("q").search() == []

--- a/tests/test_bocha_error_handling.py
+++ b/tests/test_bocha_error_handling.py
@@ -1,0 +1,69 @@
+"""Regression tests for BoChaSearch robustness.
+
+Unlike every sibling retriever (which returns ``[]`` and uses ``.get()`` on a
+bad/empty payload), BoChaSearch indexed ``json_response["data"]["webPages"]
+["value"]`` directly and had no error handling. A non-200 response, a body
+that doesn't decode as JSON, or a payload missing those keys crashed the whole
+research run with an unhandled ``KeyError`` / ``JSONDecodeError``.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_search():
+    with patch.dict(os.environ, {"BOCHA_API_KEY": "test-key"}):
+        from gpt_researcher.retrievers.bocha.bocha import BoChaSearch
+
+        return BoChaSearch("test query")
+
+
+def test_missing_keys_returns_empty_list():
+    search = _make_search()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"unexpected": "shape"}  # no data.webPages.value
+
+    with patch(
+        "gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp
+    ):
+        assert search.search() == []
+
+
+def test_request_exception_returns_empty_list():
+    import requests
+
+    search = _make_search()
+    with patch(
+        "gpt_researcher.retrievers.bocha.bocha.requests.post",
+        side_effect=requests.RequestException("boom"),
+    ):
+        assert search.search() == []
+
+
+def test_valid_payload_is_normalized():
+    search = _make_search()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "data": {
+            "webPages": {
+                "value": [
+                    {"name": "T", "url": "https://e.com", "snippet": "B"},
+                    {"name": "T2", "url": "https://e2.com"},  # missing snippet
+                ]
+            }
+        }
+    }
+
+    with patch(
+        "gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp
+    ):
+        results = search.search()
+
+    assert results == [
+        {"title": "T", "href": "https://e.com", "body": "B"},
+        {"title": "T2", "href": "https://e2.com", "body": ""},
+    ]

--- a/tests/test_crw_retriever_malformed.py
+++ b/tests/test_crw_retriever_malformed.py
@@ -1,0 +1,50 @@
+"""Regression tests for CRWRetriever (fastCRW) result normalization.
+
+Without the fix, a source missing the ``url`` key raises a KeyError that is
+swallowed by the broad ``except`` in ``search()`` — discarding every other
+(valid) source in the same response and returning an empty list.
+"""
+import importlib.util
+import os
+import pathlib
+from unittest.mock import patch
+
+# Import the module directly to avoid importing the heavy gpt_researcher package.
+_CRW_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher" / "retrievers" / "crw" / "crw.py"
+)
+_spec = importlib.util.spec_from_file_location("_crw_under_test", _CRW_PATH)
+_crw = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_crw)
+CRWRetriever = _crw.CRWRetriever
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+@patch.dict(os.environ, {"CRW_API_KEY": "test-key"})
+def test_crw_skips_sources_missing_url():
+    payload = {
+        "success": True,
+        "data": [
+            {"url": "https://a.example", "markdown": "ma"},
+            {"url": "https://b.example", "description": "db"},  # no markdown
+            {"markdown": "orphan"},  # no url -> skipped, must not abort the rest
+        ],
+    }
+    with patch.object(_crw.requests, "post", return_value=_FakeResp(payload)):
+        results = CRWRetriever("q").search()
+
+    assert results == [
+        {"href": "https://a.example", "body": "ma"},
+        {"href": "https://b.example", "body": "db"},
+    ]

--- a/tests/test_custom_retriever_guard.py
+++ b/tests/test_custom_retriever_guard.py
@@ -1,0 +1,58 @@
+"""CustomRetriever.search must always return a list, never None."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.custom.custom import CustomRetriever
+
+
+def _make(endpoint="https://example.test/search"):
+    with patch.dict("os.environ", {"RETRIEVER_ENDPOINT": endpoint}, clear=False):
+        return CustomRetriever(query="q")
+
+
+def test_custom_returns_empty_list_on_http_error():
+    c = _make()
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = Exception("boom")
+    # Use requests.RequestException path
+    import requests
+
+    resp.raise_for_status.side_effect = requests.HTTPError("boom")
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+        out = c.search()
+    assert out == []
+
+
+def test_custom_returns_empty_list_on_null_json():
+    c = _make()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = None
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+        out = c.search()
+    assert out == []
+
+
+def test_custom_returns_empty_list_on_non_list_json():
+    c = _make()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"url": "x"}
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+        out = c.search()
+    assert out == []
+
+
+def test_custom_returns_list_payload():
+    c = _make()
+    payload = [{"url": "https://a", "raw_content": "hi"}]
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp) as get:
+        out = c.search()
+    assert out == payload
+    # timeout is passed so the retriever cannot hang forever
+    assert get.call_args.kwargs.get("timeout") == 20

--- a/tests/test_duckduckgo_normalize.py
+++ b/tests/test_duckduckgo_normalize.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "duckduckgo" / "duckduckgo.py"
+
+
+def _load_duckduckgo_module():
+    # Load the module file directly so we never import gpt_researcher package
+    # (pulling json_repair and other heavy deps is unrelated to this unit).
+    utils_mod = types.ModuleType("gpt_researcher.retrievers.utils")
+    utils_mod.check_pkg = lambda *a, **k: None
+    pkg = types.ModuleType("gpt_researcher")
+    retrievers = types.ModuleType("gpt_researcher.retrievers")
+    sys.modules.setdefault("gpt_researcher", pkg)
+    sys.modules.setdefault("gpt_researcher.retrievers", retrievers)
+    sys.modules["gpt_researcher.retrievers.utils"] = utils_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.duckduckgo.duckduckgo", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class DuckduckgoNormalizeTests(unittest.TestCase):
+    def test_normalizes_href_body_shape(self):
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        retriever = Duckduckgo.__new__(Duckduckgo)
+        retriever.query = "python"
+        retriever.query_domains = None
+        retriever.ddg = MagicMock()
+        retriever.ddg.text.return_value = [
+            {"link": "https://example.com/a", "snippet": "A", "title": "One"},
+            {"url": "https://example.com/b", "description": "B"},
+            {"href": "https://example.com/c", "body": "C", "title": "Three"},
+            {"title": "no-url"},
+        ]
+        results = Duckduckgo.search(retriever, max_results=5)
+        self.assertEqual(
+            results,
+            [
+                {"href": "https://example.com/a", "body": "A", "title": "One"},
+                {"href": "https://example.com/b", "body": "B"},
+                {"href": "https://example.com/c", "body": "C", "title": "Three"},
+            ],
+        )
+
+    def test_empty_or_error_returns_list(self):
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        retriever = Duckduckgo.__new__(Duckduckgo)
+        retriever.query = "python"
+        retriever.query_domains = None
+        retriever.ddg = MagicMock()
+        retriever.ddg.text.side_effect = Exception("network")
+        self.assertEqual(Duckduckgo.search(retriever), [])
+
+        retriever.ddg.text.side_effect = None
+        retriever.ddg.text.return_value = None
+        self.assertEqual(Duckduckgo.search(retriever), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exa_null_attrs.py
+++ b/tests/test_exa_null_attrs.py
@@ -1,0 +1,53 @@
+"""ExaSearch must skip hits with missing url/id rather than raising."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.exa.exa import ExaSearch
+
+
+def _searcher():
+    # bypass __init__ pkg/API setup
+    s = ExaSearch.__new__(ExaSearch)
+    s.query = "q"
+    s.query_domains = None
+    s.api_key = "k"
+    s.client = MagicMock()
+    return s
+
+
+def test_search_skips_missing_url_and_uses_summary_fallback():
+    s = _searcher()
+    s.client.search.return_value = SimpleNamespace(
+        results=[
+            SimpleNamespace(url="https://a.example", text="body a"),
+            SimpleNamespace(url=None, text="orphan"),
+            SimpleNamespace(url="https://b.example", text=None, summary="sum b"),
+        ]
+    )
+    out = s.search(max_results=5)
+    assert out == [
+        {"href": "https://a.example", "body": "body a"},
+        {"href": "https://b.example", "body": "sum b"},
+    ]
+
+
+def test_find_similar_skips_missing_url():
+    s = _searcher()
+    s.client.find_similar.return_value = SimpleNamespace(
+        results=[SimpleNamespace(url="", text="x"), SimpleNamespace(url="https://c", text="y")]
+    )
+    assert s.find_similar("https://seed") == [{"href": "https://c", "body": "y"}]
+
+
+def test_get_contents_skips_missing_id():
+    s = _searcher()
+    s.client.get_contents.return_value = SimpleNamespace(
+        results=[
+            SimpleNamespace(id="1", text="t"),
+            SimpleNamespace(id=None, text="nope"),
+        ]
+    )
+    assert s.get_contents(["1"]) == [{"id": "1", "content": "t"}]

--- a/tests/test_get_retrievers_whitespace.py
+++ b/tests/test_get_retrievers_whitespace.py
@@ -1,0 +1,61 @@
+"""Regression tests for whitespace handling in get_retrievers.
+
+Comma-separated retriever lists supplied via request headers
+(e.g. ``"tavily, exa"``) previously kept the surrounding whitespace,
+so every name after the first failed the exact ``match`` in
+``get_retriever`` and silently fell back to the default retriever.
+The config path already stripped whitespace; these tests pin the same
+behavior for the header path (and for a single-retriever value).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from gpt_researcher.actions.retriever import (
+    get_retrievers,
+    get_retriever,
+    get_default_retriever,
+)
+
+
+def _cfg(retrievers=None, retriever=None):
+    return SimpleNamespace(retrievers=retrievers, retriever=retriever)
+
+
+class GetRetrieversWhitespaceTests(unittest.TestCase):
+    def test_header_comma_list_with_spaces_resolves_each_retriever(self):
+        # "tavily, exa" -> the second name has a leading space.
+        headers = {"retrievers": "tavily, exa"}
+        result = get_retrievers(headers, _cfg())
+
+        expected = [get_retriever("tavily"), get_retriever("exa")]
+        self.assertEqual(result, expected)
+
+        # The buggy behavior silently substituted the default retriever for
+        # the un-stripped " exa"; assert that did NOT happen.
+        default = get_default_retriever()
+        self.assertEqual(result[1], get_retriever("exa"))
+        self.assertNotEqual(
+            result[1].__name__ if result[1] else None,
+            None,
+        )
+        # exa is not the default, so a correct parse must differ from default
+        self.assertNotEqual(get_retriever("exa"), default)
+
+    def test_single_header_retriever_with_spaces_is_stripped(self):
+        headers = {"retriever": "  tavily  "}
+        result = get_retrievers(headers, _cfg())
+        self.assertEqual(result, [get_retriever("tavily")])
+
+    def test_blank_entries_are_dropped(self):
+        headers = {"retrievers": "tavily, , exa,"}
+        result = get_retrievers(headers, _cfg())
+        self.assertEqual(result, [get_retriever("tavily"), get_retriever("exa")])
+
+    def test_config_string_path_still_strips(self):
+        result = get_retrievers({}, _cfg(retrievers="tavily, exa"))
+        self.assertEqual(result, [get_retriever("tavily"), get_retriever("exa")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_google_malformed.py
+++ b/tests/test_google_malformed.py
@@ -1,0 +1,53 @@
+"""GoogleSearch must tolerate malformed CSE items / response shapes."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.google.google import GoogleSearch
+
+
+def _searcher():
+    g = GoogleSearch.__new__(GoogleSearch)
+    g.query = "q"
+    g.headers = {}
+    g.query_domains = None
+    g.api_key = "k"
+    g.cx_key = "cx"
+    return g
+
+
+def test_google_skips_non_dict_and_missing_link():
+    g = _searcher()
+    payload = {
+        "items": [
+            {"title": "A", "link": "https://a.example", "snippet": "sa"},
+            "not-a-dict",
+            {"title": "No link"},
+            {"title": "YT", "link": "https://youtube.com/watch?v=1", "snippet": "y"},
+            {"link": "https://b.example"},  # title/snippet optional
+        ]
+    }
+    resp = MagicMock(status_code=200, text='{}')
+    with patch(
+        "gpt_researcher.retrievers.google.google.requests.get", return_value=resp
+    ), patch(
+        "gpt_researcher.retrievers.google.google.json.loads", return_value=payload
+    ):
+        out = g.search(max_results=10)
+
+    assert out == [
+        {"title": "A", "href": "https://a.example", "body": "sa"},
+        {"title": "", "href": "https://b.example", "body": ""},
+    ]
+
+
+def test_google_returns_empty_list_on_non_dict_json():
+    g = _searcher()
+    resp = MagicMock(status_code=200, text='[]')
+    with patch(
+        "gpt_researcher.retrievers.google.google.requests.get", return_value=resp
+    ), patch(
+        "gpt_researcher.retrievers.google.google.json.loads", return_value=[]
+    ):
+        assert g.search() == []

--- a/tests/test_google_search_url_encoding.py
+++ b/tests/test_google_search_url_encoding.py
@@ -1,0 +1,63 @@
+"""Regression test: GoogleSearch must URL-encode the query.
+
+The Custom Search request URL was built by f-string interpolating the raw
+query: ``...&q={search_query}&start=1``. Any reserved character in the
+query corrupted the request:
+  * ``&`` (e.g. "AT&T") injected a spurious query parameter,
+  * ``#`` truncated everything after it (fragment),
+  * spaces produced an invalid URL.
+
+These tests pin proper percent-encoding by inspecting the URL handed to
+``requests.get``.
+"""
+
+import os
+import unittest
+from unittest import mock
+from urllib.parse import urlparse, parse_qs
+
+from gpt_researcher.retrievers.google.google import GoogleSearch
+
+
+class _Resp:
+    status_code = 200
+    text = '{"items": []}'
+
+
+class GoogleSearchUrlEncodingTests(unittest.TestCase):
+    def _search(self, query):
+        env = {"GOOGLE_API_KEY": "k", "GOOGLE_CX_KEY": "c"}
+        with mock.patch.dict(os.environ, env):
+            gs = GoogleSearch(query)
+        with mock.patch(
+            "gpt_researcher.retrievers.google.google.requests.get",
+            return_value=_Resp(),
+        ) as m:
+            gs.search()
+        return m.call_args[0][0]  # the URL passed positionally
+
+    def test_ampersand_in_query_is_encoded_not_split(self):
+        url = self._search("AT&T market share")
+        parsed = parse_qs(urlparse(url).query)
+        # The whole query must survive as a single q param.
+        self.assertEqual(parsed["q"], ["AT&T market share"])
+        # No spurious top-level param leaked from the "&T".
+        self.assertNotIn("T", parsed)
+
+    def test_hash_in_query_is_not_treated_as_fragment(self):
+        url = self._search("python #1 framework")
+        self.assertEqual(urlparse(url).fragment, "")
+        parsed = parse_qs(urlparse(url).query)
+        self.assertEqual(parsed["q"], ["python #1 framework"])
+        # start must still be present (the bug dropped it after the #).
+        self.assertEqual(parsed["start"], ["1"])
+
+    def test_spaces_are_encoded(self):
+        url = self._search("hello world")
+        self.assertNotIn(" ", url)
+        parsed = parse_qs(urlparse(url).query)
+        self.assertEqual(parsed["q"], ["hello world"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_groundroute_malformed_results.py
+++ b/tests/test_groundroute_malformed_results.py
@@ -1,0 +1,63 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "groundroute" / "groundroute.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    requests_mod.post = MagicMock()
+    sys.modules["requests"] = requests_mod
+    for key in list(sys.modules):
+        if "groundroute.groundroute" in key:
+            sys.modules.pop(key, None)
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.groundroute.groundroute_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    with patch.dict(os.environ, {"GROUNDROUTE_API_KEY": "k"}):
+        spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class GroundRouteMalformedTests(unittest.TestCase):
+    def test_skips_missing_url(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {"url": "https://a.example", "content": "A"},
+                {"content": "no url"},
+                "bad",
+                {"link": "https://b.example", "snippet": "B"},
+            ]
+        }
+        requests_mod.post.return_value = resp
+        with patch.dict(os.environ, {"GROUNDROUTE_API_KEY": "k"}):
+            out = mod.GroundRouteSearch("q").search(max_results=10)
+        self.assertEqual(
+            out,
+            [
+                {"href": "https://a.example", "body": "A"},
+                {"href": "https://b.example", "body": "B"},
+            ],
+        )
+
+    def test_error_returns_empty(self):
+        mod, requests_mod = _load()
+        requests_mod.post.side_effect = Exception("boom")
+        with patch.dict(os.environ, {"GROUNDROUTE_API_KEY": "k"}):
+            self.assertEqual(mod.GroundRouteSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openalex_malformed_results.py
+++ b/tests/test_openalex_malformed_results.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "openalex" / "openalex.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    class RequestException(Exception):
+        pass
+    requests_mod.RequestException = RequestException
+    requests_mod.get = MagicMock()
+    sys.modules["requests"] = requests_mod
+    for key in list(sys.modules):
+        if "openalex.openalex" in key:
+            sys.modules.pop(key, None)
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.openalex.openalex_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class OpenAlexMalformedTests(unittest.TestCase):
+    def test_skips_non_dict_and_guards_abstract(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {
+                    "title": "Paper",
+                    "id": "https://openalex.org/W1",
+                    "abstract_inverted_index": {"hello": [0], "world": [1]},
+                    "best_oa_location": {},
+                    "primary_location": {},
+                },
+                "bad",
+                {
+                    "title": "Broken abstract",
+                    "id": "https://openalex.org/W2",
+                    "abstract_inverted_index": "not-a-dict",
+                        "best_oa_location": {},
+                    "primary_location": {},
+                },
+            ]
+        }
+        requests_mod.get.return_value = resp
+        out = mod.OpenAlexSearch("q").search()
+        self.assertEqual(out[0]["href"], "https://openalex.org/W1")
+        self.assertEqual(out[0]["body"], "hello world")
+        self.assertEqual(out[1]["href"], "https://openalex.org/W2")
+        self.assertEqual(out[1]["body"], "Abstract not available")
+
+    def test_non_dict_payload(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = ["nope"]
+        requests_mod.get.return_value = resp
+        self.assertEqual(mod.OpenAlexSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pubmed_central_returns_list.py
+++ b/tests/test_pubmed_central_returns_list.py
@@ -1,0 +1,31 @@
+"""Regression test: PubMedCentralSearch.search must return [] (never None).
+
+Callers (actions.query_processing.get_search_results -> List[Dict]) and
+skills.researcher (`len(search_results)`) crash on None.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+if "requests" not in sys.modules:
+    sys.modules["requests"] = types.ModuleType("requests")
+
+from gpt_researcher.retrievers.pubmed_central.pubmed_central import (  # noqa: E402
+    PubMedCentralSearch,
+)
+
+
+def test_search_returns_list_when_no_article_ids():
+    s = PubMedCentralSearch("cancer")
+    with patch.object(PubMedCentralSearch, "_search_articles", return_value=None):
+        out = s.search()
+    assert out == []
+    assert len(out) == 0  # would TypeError if None
+
+
+def test_search_returns_list_when_empty_article_ids():
+    s = PubMedCentralSearch("cancer")
+    with patch.object(PubMedCentralSearch, "_search_articles", return_value=[]):
+        out = s.search()
+    assert out == []

--- a/tests/test_searchapi_retriever_none.py
+++ b/tests/test_searchapi_retriever_none.py
@@ -1,0 +1,32 @@
+"""Regression: SearchAPIRetriever must tolerate raw_content=None.
+
+The scraper sets ``raw_content`` to ``None`` for pages that failed to scrape.
+Slicing ``None`` raises ``TypeError``, so the retriever must coerce a missing
+or None ``raw_content`` to an empty string.
+"""
+
+from gpt_researcher.context.retriever import SearchAPIRetriever
+
+
+def test_none_raw_content_yields_empty_page_content():
+    retriever = SearchAPIRetriever(
+        pages=[{"raw_content": None, "title": "t", "url": "https://u.example"}]
+    )
+    docs = retriever.invoke("q")
+    assert len(docs) == 1
+    assert docs[0].page_content == ""
+    assert docs[0].metadata["source"] == "https://u.example"
+
+
+def test_present_raw_content_is_preserved():
+    retriever = SearchAPIRetriever(
+        pages=[{"raw_content": "hello world", "title": "t", "url": "u"}]
+    )
+    docs = retriever.invoke("q")
+    assert docs[0].page_content == "hello world"
+
+
+def test_missing_raw_content_key_yields_empty():
+    retriever = SearchAPIRetriever(pages=[{"title": "t", "url": "u"}])
+    docs = retriever.invoke("q")
+    assert docs[0].page_content == ""

--- a/tests/test_searx_malformed_results.py
+++ b/tests/test_searx_malformed_results.py
@@ -1,0 +1,74 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "searx" / "searx.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    class RequestException(Exception):
+        pass
+    exceptions = types.ModuleType("requests.exceptions")
+    exceptions.RequestException = RequestException
+    requests_mod.exceptions = exceptions
+    requests_mod.get = MagicMock()
+    sys.modules["requests"] = requests_mod
+
+    for key in list(sys.modules):
+        if "searx.searx" in key:
+            sys.modules.pop(key, None)
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.searx.searx_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}, clear=False):
+        spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class SearxMalformedTests(unittest.TestCase):
+    def test_skips_missing_url_and_non_dict_items(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {"url": "https://a.example", "content": "A"},
+                {"content": "no url"},
+                "bad",
+                {"href": "https://b.example", "snippet": "B"},
+                None,
+            ]
+        }
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}):
+            out = mod.SearxSearch("q").search(max_results=10)
+        self.assertEqual(
+            out,
+            [
+                {"href": "https://a.example", "body": "A"},
+                {"href": "https://b.example", "body": "B"},
+            ],
+        )
+
+    def test_non_dict_json_returns_empty(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = ["not", "a", "dict"]
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}):
+            self.assertEqual(mod.SearxSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_semantic_scholar_sort.py
+++ b/tests/test_semantic_scholar_sort.py
@@ -1,0 +1,33 @@
+"""Regression test for Semantic Scholar sort-criterion casing.
+
+``VALID_SORT_CRITERIA`` holds the API's exact camelCase values
+(``citationCount``, ``publicationDate``), and ``__init__`` asserts the
+incoming value is one of them. It then stored ``sort.lower()``, corrupting
+``citationCount`` -> ``citationcount`` before it was sent as the ``sort``
+query parameter. The Semantic Scholar API expects the camelCase form.
+"""
+
+from gpt_researcher.retrievers.semantic_scholar.semantic_scholar import (
+    SemanticScholarSearch,
+)
+
+
+def test_camelcase_sort_preserved():
+    s = SemanticScholarSearch("anything", sort="citationCount")
+    assert s.sort == "citationCount"
+
+
+def test_publication_date_sort_preserved():
+    s = SemanticScholarSearch("anything", sort="publicationDate")
+    assert s.sort == "publicationDate"
+
+
+def test_relevance_default_preserved():
+    s = SemanticScholarSearch("anything")
+    assert s.sort == "relevance"
+
+
+def test_stored_sort_is_a_valid_api_value():
+    # Whatever is stored must round-trip as an accepted API criterion.
+    s = SemanticScholarSearch("anything", sort="citationCount")
+    assert s.sort in SemanticScholarSearch.VALID_SORT_CRITERIA

--- a/tests/test_serpapi_retriever_malformed.py
+++ b/tests/test_serpapi_retriever_malformed.py
@@ -1,0 +1,55 @@
+"""Regression tests for SerpApiSearch result normalization.
+
+Without the fix, a response missing ``organic_results`` raises a KeyError, and
+a single result missing ``title``/``link``/``snippet`` raises a KeyError that
+aborts the whole ``search()`` call.
+"""
+import importlib.util
+import os
+import pathlib
+from unittest.mock import patch
+
+# Import the module directly to avoid importing the heavy gpt_researcher package
+# (which pulls optional deps at import time).
+_SERPAPI_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher" / "retrievers" / "serpapi" / "serpapi.py"
+)
+_spec = importlib.util.spec_from_file_location("_serpapi_under_test", _SERPAPI_PATH)
+_serpapi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_serpapi)
+SerpApiSearch = _serpapi.SerpApiSearch
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+def test_serpapi_skips_results_missing_keys():
+    payload = {
+        "organic_results": [
+            {"title": "A", "link": "https://a.example", "snippet": "sa"},
+            {"title": "B", "link": "https://b.example"},  # missing snippet
+            {"link": "https://c.example"},  # missing title + snippet
+            {"title": "D", "snippet": "sd"},  # missing link -> skipped
+        ]
+    }
+    with patch.object(_serpapi.requests, "get", return_value=_FakeResp(payload)):
+        results = SerpApiSearch("q").search()
+
+    assert len(results) == 3
+    assert results[0] == {"title": "A", "href": "https://a.example", "body": "sa"}
+    assert results[1]["body"] == ""
+    assert results[2]["title"] == ""
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+def test_serpapi_no_organic_results_returns_empty():
+    with patch.object(_serpapi.requests, "get", return_value=_FakeResp({})):
+        assert SerpApiSearch("q").search() == []

--- a/tests/test_serper_returns_list.py
+++ b/tests/test_serper_returns_list.py
@@ -1,0 +1,62 @@
+"""Regression test: SerperSearch.search must always return a list, never None.
+
+Sibling retrievers (serpapi/brave/bing/searx) return [] on error; callers
+(`get_search_results` -> `len(search_results)`) crash on None.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+# serper.py only imports os, requests, json — stub requests so import works
+# without the dependency and so we can drive the error paths deterministically.
+if "requests" not in sys.modules:
+    sys.modules["requests"] = types.ModuleType("requests")
+
+from gpt_researcher.retrievers.serper.serper import SerperSearch  # noqa: E402
+
+
+def _make(monkeypatch_env):
+    import os
+
+    os.environ["SERPER_API_KEY"] = "test-key"
+    return SerperSearch("hello world")
+
+
+def test_search_returns_list_when_response_none():
+    s = _make(None)
+    with patch(
+        "gpt_researcher.retrievers.serper.serper.requests.request",
+        return_value=None,
+    ):
+        out = s.search()
+    assert out == []
+    assert len(out) == 0  # would TypeError if None
+
+
+def test_search_returns_list_when_body_unparseable():
+    s = _make(None)
+
+    class _Resp:
+        text = "<<not json>>"
+
+    with patch(
+        "gpt_researcher.retrievers.serper.serper.requests.request",
+        return_value=_Resp(),
+    ):
+        out = s.search()
+    assert out == []
+
+
+def test_search_returns_list_when_json_null():
+    s = _make(None)
+
+    class _Resp:
+        text = "null"
+
+    with patch(
+        "gpt_researcher.retrievers.serper.serper.requests.request",
+        return_value=_Resp(),
+    ):
+        out = s.search()
+    assert out == []

--- a/tests/test_tavily_malformed.py
+++ b/tests/test_tavily_malformed.py
@@ -1,0 +1,39 @@
+"""TavilySearch must skip malformed sources instead of raising KeyError."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gpt_researcher.retrievers.tavily.tavily_search import TavilySearch
+
+
+def test_tavily_skips_sources_missing_url_or_non_dict():
+    sources = [
+        {"url": "https://a.example", "content": "ok"},
+        {"content": "no url"},
+        "not-a-dict",
+        {"url": "https://b.example", "snippet": "from snippet"},
+        {"url": None, "content": "null url"},
+        {"url": "https://c.example", "content": None},
+    ]
+
+    searcher = TavilySearch.__new__(TavilySearch)
+    searcher.query = "q"
+    searcher.topic = "general"
+    searcher.query_domains = None
+    searcher.api_key = "fake"
+    searcher.headers = {}
+    searcher.base_url = "https://api.tavily.com/search"
+
+    with patch.object(
+        searcher,
+        "_search",
+        return_value={"results": sources},
+    ):
+        out = searcher.search(max_results=10)
+
+    assert out == [
+        {"href": "https://a.example", "body": "ok"},
+        {"href": "https://b.example", "body": "from snippet"},
+        {"href": "https://c.example", "body": ""},
+    ]

--- a/tests/test_xquik_null_fields.py
+++ b/tests/test_xquik_null_fields.py
@@ -1,0 +1,62 @@
+"""Regression tests for XquikSearch null-field handling.
+
+The Xquik API can return an explicit JSON ``null`` for ``tweets`` (no
+results) or for a tweet's ``author`` / ``text`` fields. ``dict.get(key,
+default)`` only substitutes the default when the key is *absent*, not when
+its value is ``None`` — so ``tweet.get("author", {})`` returns ``None`` for
+``{"author": null}``. The subsequent ``author.get("username")`` /
+``text[:120]`` then raise, and the broad ``except`` in ``search()`` swallows
+the error and silently drops *every* result.
+"""
+
+import io
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from gpt_researcher.retrievers.xquik.xquik import XquikSearch
+
+
+class TestXquikNullFields(unittest.TestCase):
+    def setUp(self):
+        os.environ["XQUIK_API_KEY"] = "test-key"
+
+    def _run_with_payload(self, payload):
+        raw = json.dumps(payload).encode("utf-8")
+
+        class FakeResp:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def read(self_inner):
+                return raw
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            return XquikSearch("test query").search(max_results=5)
+
+    def test_null_author_still_returns_result(self):
+        results = self._run_with_payload(
+            {"tweets": [{"author": None, "text": "hello world", "id": "1"}]}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIn("@unknown", results[0]["title"])
+        self.assertIn("hello world", results[0]["body"])
+
+    def test_null_text_and_id_do_not_crash(self):
+        results = self._run_with_payload(
+            {"tweets": [{"author": {"username": "bob"}, "text": None, "id": None}]}
+        )
+        self.assertEqual(len(results), 1)
+        self.assertIn("@bob", results[0]["title"])
+
+    def test_null_tweets_returns_empty_list(self):
+        results = self._run_with_payload({"tweets": None})
+        self.assertEqual(results, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consolidates **20 independent retriever-hardening fixes** from @Bartok9, cherry-picked clean onto `main` with authorship preserved (`git cherry-pick -x`). Every fix guards a retriever against malformed / missing / null result fields so a single bad item no longer crashes or silently drops all results.

**Verified:** all 20 fixes' bundled tests + offline baseline pass — **79 passed**. Every touched module compile-checks clean.

Supersedes and closes these PRs (each with its own test):
- #1837 Serper — return `[]` not `None` · #1838 PubMedCentral — return `[]` not `None`
- #1844 BoChaSearch — handle errors/missing keys · #1845 XquikSearch — null author/tweets/text
- #1864 Bing · #1865 SerpApi · #1866 fastCRW (skip url-less, don't drop all) · #1869 Tavily
- #1870 CustomRetriever — always return a list · #1871 Google CSE — malformed content items
- #1872 Exa — null url/id/text · #1876 DuckDuckGo — normalize to href/body
- #1877 Searx · #1878 GroundRoute · #1879 OpenAlex — malformed payloads
- #1856 SearchAPIRetriever — guard None `raw_content` · #1833 Semantic Scholar — preserve camelCase sort
- #1827 header retriever lists — strip whitespace · #1831 Google — URL-encode query params
- #1890 skip redundant Tavily-MCP when direct Tavily active (fixes #1875)

_Note: #1852 (SearchApi) and the CRW/BoCha duplicates #1903/#1904 were held back for author rework — see triage summary._

🤖 Generated with [Claude Code](https://claude.com/claude-code)