### PR TITLE
Scraper robustness: 6 fixes (title/PDF-detection/temp-file/dimensions) (supersedes #1824…#1842)

### DIFF
--- a/gpt_researcher/document/online_document.py
+++ b/gpt_researcher/document/online_document.py
@@ -88,4 +88,8 @@ class OnlineDocumentLoader:
 
     @staticmethod
     def _get_extension(url: str) -> str:
-        return os.path.splitext(url.split("?")[0])[1]
+        # Lower-case the extension so loader lookup (whose keys are lower-case,
+        # e.g. "pdf"/"docx") matches URLs that use upper-case extensions like
+        # "report.PDF" or "doc.DOCX". The leading "?" split drops query strings
+        # (signed CDN/S3 URLs) before extracting the suffix.
+        return os.path.splitext(url.split("?")[0])[1].lower()

--- a/gpt_researcher/scraper/browser/browser.py
+++ b/gpt_researcher/scraper/browser/browser.py
@@ -15,7 +15,20 @@ from typing import Iterable, cast
 from .processing.scrape_skills import (scrape_pdf_with_pymupdf,
                                        scrape_pdf_with_arxiv)
 
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
+
+
+def _is_pdf_url(url: str) -> bool:
+    """Return True when ``url`` points at a PDF.
+
+    Inspects only the path component so query strings / fragments don't hide
+    the extension (signed CDN/S3 links like ``https://host/doc.pdf?sig=...``
+    are extremely common), and matches case-insensitively because ``.PDF`` is
+    a perfectly valid suffix.
+    """
+    if not url:
+        return False
+    return urlparse(url).path.lower().endswith(".pdf")
 
 from ..utils import get_relevant_images, extract_title, get_text_from_soup, clean_soup
 
@@ -204,7 +217,7 @@ class BrowserScraper:
 
         self._scroll_to_bottom()
 
-        if self.url.endswith(".pdf"):
+        if _is_pdf_url(self.url):
             text = scrape_pdf_with_pymupdf(self.url)
             return text, [], ""
         elif "arxiv" in self.url:

--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -57,10 +57,16 @@ class PyMuPDFScraper:
                     for chunk in response.iter_content(chunk_size=8192):
                         temp_file.write(chunk)  # Write the downloaded content to the temporary file
 
-                loader = PyMuPDFLoader(temp_filename)
-                doc = loader.load()
-
-                os.remove(temp_filename)
+                # Always clean up the downloaded temp file, even if loading fails
+                # (PyMuPDFLoader.load() can raise on a malformed/partial PDF).
+                try:
+                    loader = PyMuPDFLoader(temp_filename)
+                    doc = loader.load()
+                finally:
+                    try:
+                        os.remove(temp_filename)
+                    except OSError:
+                        pass
             else:
                 loader = PyMuPDFLoader(self.link)
                 doc = loader.load()

--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -9,6 +9,7 @@ import importlib
 import logging
 import subprocess
 import sys
+from urllib.parse import urlparse
 
 import requests
 from colorama import Fore, init
@@ -198,7 +199,11 @@ class Scraper:
 
         scraper_key = None
 
-        if link.endswith(".pdf"):
+        # Inspect only the path component so query strings / fragments don't
+        # hide the extension (e.g. signed CDN/S3 links like "…/doc.pdf?sig=…").
+        # Match case-insensitively because ".PDF" is a perfectly valid suffix.
+        path = urlparse(link).path
+        if path.lower().endswith(".pdf"):
             scraper_key = "pdf"
         elif "arxiv.org" in link:
             scraper_key = "arxiv"

--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -67,8 +67,17 @@ def parse_dimension(value: str) -> int:
         return None
 
 def extract_title(soup: BeautifulSoup) -> str:
-    """Extract the title from the BeautifulSoup object"""
-    return soup.title.string if soup.title else ""
+    """Extract the title text from the BeautifulSoup object.
+
+    Always returns a string. An empty ``<title></title>`` yields ``""`` (not
+    ``None``), and a title containing nested markup (e.g.
+    ``<title><span>x</span></title>``) yields its text content rather than the
+    raw inner HTML.
+    """
+    title_tag = soup.title
+    if not title_tag:
+        return ""
+    return title_tag.get_text(strip=True)
 
 def get_image_hash(image_url: str) -> str:
     """Calculate a simple hash based on the image filename and essential query parameters"""

--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -63,7 +63,9 @@ def parse_dimension(value: str) -> int:
         # Convert to float first to handle decimal values like '409.12'
         return int(float(value))
     except (ValueError, TypeError) as e:
-        print(f"Error parsing dimension value {value}: {e}")
+        # Non-numeric dimensions (e.g. '100%', 'auto', '50em') are common and
+        # expected on real pages; log at debug level instead of spamming stdout.
+        logging.debug("Could not parse dimension value %r: %s", value, e)
         return None
 
 def extract_title(soup: BeautifulSoup) -> str:

--- a/tests/test_browser_pdf_detection.py
+++ b/tests/test_browser_pdf_detection.py
@@ -1,0 +1,41 @@
+"""Regression tests for PDF URL detection in the BrowserScraper.
+
+The scrape path used ``self.url.endswith(".pdf")``, which:
+  * missed query strings / fragments (signed CDN/S3 links such as
+    ``https://host/doc.pdf?sig=...`` are extremely common), and
+  * was case-sensitive, so ``.PDF`` was not recognized.
+
+These tests pin the corrected behavior via the ``_is_pdf_url`` helper.
+"""
+
+from gpt_researcher.scraper.browser.browser import _is_pdf_url
+
+
+def test_plain_pdf_url_detected():
+    assert _is_pdf_url("https://example.com/file.pdf") is True
+
+
+def test_pdf_with_query_string_detected():
+    # Signed CDN / S3 links carry the signature as a query string.
+    assert _is_pdf_url("https://cdn.example.com/doc.pdf?sig=abc123&exp=999") is True
+
+
+def test_pdf_with_fragment_detected():
+    assert _is_pdf_url("https://example.com/doc.pdf#page=2") is True
+
+
+def test_uppercase_extension_detected():
+    assert _is_pdf_url("https://example.com/REPORT.PDF") is True
+
+
+def test_non_pdf_url_not_detected():
+    assert _is_pdf_url("https://example.com/article.html") is False
+
+
+def test_pdf_substring_in_query_not_detected():
+    # A ".pdf" appearing only in a query param must NOT trigger PDF handling.
+    assert _is_pdf_url("https://example.com/view?file=report.pdf") is False
+
+
+def test_empty_url_not_detected():
+    assert _is_pdf_url("") is False

--- a/tests/test_online_document_extension.py
+++ b/tests/test_online_document_extension.py
@@ -1,0 +1,24 @@
+"""Regression test for OnlineDocumentLoader._get_extension case handling."""
+
+from gpt_researcher.document.online_document import OnlineDocumentLoader
+
+
+def test_get_extension_lowercases_uppercase_suffix():
+    # Loader dict keys are lower-case ("pdf", "docx"); an upper-case URL
+    # extension must be normalised so the right loader is selected instead
+    # of silently falling through to the unsupported branch.
+    assert OnlineDocumentLoader._get_extension("https://x.com/report.PDF") == ".pdf"
+    assert OnlineDocumentLoader._get_extension("https://x.com/doc.DOCX") == ".docx"
+
+
+def test_get_extension_strips_query_string():
+    # Signed CDN/S3 URLs carry a query string after the real extension.
+    assert (
+        OnlineDocumentLoader._get_extension("https://x.com/report.PDF?sig=abc&t=1")
+        == ".pdf"
+    )
+    assert OnlineDocumentLoader._get_extension("https://x.com/a.pdf") == ".pdf"
+
+
+def test_get_extension_no_extension():
+    assert OnlineDocumentLoader._get_extension("https://x.com/page") == ""

--- a/tests/test_parse_dimension.py
+++ b/tests/test_parse_dimension.py
@@ -1,0 +1,48 @@
+"""Tests for image dimension parsing.
+
+`parse_dimension` is called for every `<img>` width/height attribute during
+scraping. Non-numeric values like '100%', 'auto', and '50em' are common and
+valid HTML, but used to print an error line to stdout for each one, polluting
+application output. It should parse numeric/px values and silently (debug-log)
+return None for the rest.
+"""
+
+import logging
+import unittest
+
+from gpt_researcher.scraper.utils import parse_dimension
+
+
+class TestParseDimension(unittest.TestCase):
+    def test_plain_integer(self):
+        self.assertEqual(parse_dimension("100"), 100)
+
+    def test_px_suffix(self):
+        self.assertEqual(parse_dimension("10px"), 10)
+
+    def test_decimal_value(self):
+        self.assertEqual(parse_dimension("409.12"), 409)
+
+    def test_non_numeric_returns_none(self):
+        for value in ("100%", "auto", "", "50em"):
+            self.assertIsNone(parse_dimension(value))
+
+    def test_non_numeric_does_not_write_to_stdout(self):
+        # Regression: these used to print(...) one line per malformed value.
+        import contextlib
+        import io
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            for value in ("100%", "auto", "50em"):
+                parse_dimension(value)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_non_numeric_logs_at_debug(self):
+        with self.assertLogs(level=logging.DEBUG) as captured:
+            parse_dimension("100%")
+        self.assertTrue(any("100%" in m for m in captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pymupdf_tempfile_cleanup.py
+++ b/tests/test_pymupdf_tempfile_cleanup.py
@@ -1,0 +1,50 @@
+"""Regression test: PyMuPDFScraper must not leak its downloaded temp file.
+
+When scraping a remote PDF, the scraper downloads it to a
+``NamedTemporaryFile(delete=False, suffix=".pdf")`` and then loads it with
+``PyMuPDFLoader``. The old code called ``os.remove(temp_filename)`` only on the
+success path, so a parse failure (malformed/partial PDF -> ``PyMuPDFLoader.load``
+raises) left the temp file behind on disk every time. The exception is then
+swallowed by the broad ``except``, so the leak was silent.
+"""
+
+import os
+import glob
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.scraper.pymupdf.pymupdf import PyMuPDFScraper
+
+
+class _FakeResponse:
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size=8192):
+        yield b"%PDF-1.4 not-a-real-pdf"
+
+
+def _temp_pdfs() -> set:
+    return set(glob.glob(os.path.join(tempfile.gettempdir(), "*.pdf")))
+
+
+def test_tempfile_removed_when_loader_raises():
+    scraper = PyMuPDFScraper("https://example.com/broken.pdf")
+
+    before = _temp_pdfs()
+
+    with patch(
+        "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
+        return_value=_FakeResponse(),
+    ), patch(
+        "gpt_researcher.scraper.pymupdf.pymupdf.PyMuPDFLoader"
+    ) as mock_loader:
+        mock_loader.return_value.load.side_effect = RuntimeError("corrupt PDF")
+
+        content, images, title = scraper.scrape()
+
+    # Broad except still yields the empty-result contract...
+    assert (content, images, title) == ("", [], "")
+    # ...but no new *.pdf temp file is left behind.
+    leaked = _temp_pdfs() - before
+    assert not leaked, f"PyMuPDFScraper leaked temp file(s): {leaked}"

--- a/tests/test_scraper_extract_title.py
+++ b/tests/test_scraper_extract_title.py
@@ -1,0 +1,41 @@
+"""Tests for scraper title extraction.
+
+`extract_title` is annotated `-> str` and its result flows into image alt-text
+and document metadata across every scraper backend. A `<title></title>` with no
+text node made `soup.title.string` return `None`, breaking the string contract
+and propagating `None` downstream.
+"""
+
+import unittest
+
+from bs4 import BeautifulSoup
+
+from gpt_researcher.scraper.utils import extract_title
+
+
+def _title(html: str) -> str:
+    return extract_title(BeautifulSoup(html, "html.parser"))
+
+
+class TestExtractTitle(unittest.TestCase):
+    def test_simple_title(self):
+        self.assertEqual(_title("<title>Hello</title>"), "Hello")
+
+    def test_empty_title_returns_empty_string_not_none(self):
+        result = _title("<title></title>")
+        self.assertIsNotNone(result)
+        self.assertEqual(result, "")
+
+    def test_no_title_tag(self):
+        self.assertEqual(_title("<html><body>x</body></html>"), "")
+
+    def test_title_is_whitespace_stripped(self):
+        self.assertEqual(_title("<title>   spaced   </title>"), "spaced")
+
+    def test_always_returns_str(self):
+        for html in ("<title>Hello</title>", "<title></title>", "<html></html>"):
+            self.assertIsInstance(_title(html), str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scraper_get_scraper.py
+++ b/tests/test_scraper_get_scraper.py
@@ -1,0 +1,58 @@
+"""Regression tests for PDF detection in Scraper.get_scraper.
+
+PDF links were detected with ``link.endswith(".pdf")``, which:
+  * missed query strings / fragments (signed CDN/S3 links such as
+    ``https://host/doc.pdf?sig=...`` are extremely common), and
+  * was case-sensitive, so ``.PDF`` was not recognized.
+
+In both cases a real PDF was routed to the configured HTML scraper
+(e.g. BeautifulSoup) instead of PyMuPDFScraper, producing garbage or
+empty content. These tests pin correct routing.
+"""
+
+import unittest
+
+from gpt_researcher.scraper.scraper import Scraper
+from gpt_researcher.scraper import PyMuPDFScraper, BeautifulSoupScraper
+
+
+def _scraper():
+    # worker_pool is unused by get_scraper; default scraper is "bs".
+    return Scraper(urls=["https://example.com"], user_agent="ua", scraper="bs", worker_pool=None)
+
+
+class GetScraperPdfDetectionTests(unittest.TestCase):
+    def test_plain_pdf_url_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/doc.pdf"), PyMuPDFScraper)
+
+    def test_pdf_with_query_string_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(
+            s.get_scraper("https://example.com/doc.pdf?sig=abc123&exp=999"),
+            PyMuPDFScraper,
+        )
+
+    def test_pdf_with_fragment_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/doc.pdf#page=2"), PyMuPDFScraper)
+
+    def test_uppercase_pdf_extension_uses_pymupdf(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/REPORT.PDF"), PyMuPDFScraper)
+
+    def test_non_pdf_url_uses_default_scraper(self):
+        s = _scraper()
+        self.assertIs(s.get_scraper("https://example.com/article"), BeautifulSoupScraper)
+
+    def test_pdf_substring_in_query_is_not_treated_as_pdf(self):
+        # "pdf" only in the query, not the path extension -> NOT a pdf.
+        s = _scraper()
+        self.assertIs(
+            s.get_scraper("https://example.com/article?format=pdf"),
+            BeautifulSoupScraper,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consolidates **6 scraper-robustness fixes** from @Bartok9, cherry-picked clean onto `main` with authorship preserved. **Verified: tests pass**, all modules compile-check clean, and the combined integration branch (this + the other 4 batch PRs) passes a live end-to-end research run.

Supersedes and closes:
- #1824 `extract_title` — return empty string for empty `<title>` tags
- #1825 image dimensions — debug-log instead of printing on non-numeric values
- #1828 scraper — detect PDF links with query strings / uppercase extensions
- #1832 BrowserScraper — same PDF-link detection
- #1842 PyMuPDF — remove temp file even when PDF loading fails
- #1836 OnlineDocumentLoader — normalise URL extension case

_Held back: #1839 (guard ArxivScraper against empty results) — conflicts with #1906's arxiv Client-API rewrite of the same file; needs author rebase onto the new arxiv code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)