### PR TITLE
Core/misc hardening: 11 fixes (costs/query/llm/agent/mcp/config) (supersedes #1822…#1902)

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -29,7 +29,12 @@ async def write_text_to_md(text: str, filename: str = "") -> str:
     Returns:
         str: The file path of the generated Markdown file.
     """
-    file_path = f"outputs/{filename[:60]}.md"
+    import uuid
+
+    safe_name = (filename or "").strip()[:60] or f"report-{uuid.uuid4().hex[:12]}"
+    safe_name = safe_name.replace("/", "-").replace("\\", "-")
+    os.makedirs("outputs", exist_ok=True)
+    file_path = f"outputs/{safe_name}.md"
     await write_to_file(file_path, text)
     return urllib.parse.quote(file_path)
 
@@ -68,7 +73,15 @@ async def write_md_to_pdf(text: str, filename: str = "") -> str:
     Returns:
         str: The encoded file path of the generated PDF.
     """
-    file_path = f"outputs/{filename[:60]}.pdf"
+    import uuid
+
+    # Empty / whitespace-only filename previously wrote "outputs/.pdf" which
+    # confuses download UIs (#1718). Prefer a stable non-empty basename.
+    safe_name = (filename or "").strip()[:60] or f"report-{uuid.uuid4().hex[:12]}"
+    # Replace path separators to keep the PDF under outputs/.
+    safe_name = safe_name.replace("/", "-").replace("\\", "-")
+    os.makedirs("outputs", exist_ok=True)
+    file_path = f"outputs/{safe_name}.pdf"
 
     try:
         # Resolve css path relative to this backend module to avoid
@@ -105,7 +118,12 @@ async def write_md_to_word(text: str, filename: str = "") -> str:
     Returns:
         str: The encoded file path of the generated DOCX.
     """
-    file_path = f"outputs/{filename[:60]}.docx"
+    import uuid
+
+    safe_name = (filename or "").strip()[:60] or f"report-{uuid.uuid4().hex[:12]}"
+    safe_name = safe_name.replace("/", "-").replace("\\", "-")
+    os.makedirs("outputs", exist_ok=True)
+    file_path = f"outputs/{safe_name}.docx"
 
     try:
         from docx import Document

--- a/gpt_researcher/actions/agent_creator.py
+++ b/gpt_researcher/actions/agent_creator.py
@@ -120,7 +120,12 @@ def extract_json_with_regex(response: str | None) -> str | None:
     """
     if not response:
         return None
-    json_match = re.search(r"{.*?}", response, re.DOTALL)
+    # Greedy ``{.*}`` so the match spans from the first ``{`` to the LAST ``}``
+    # in the response, capturing the whole object. A non-greedy ``{.*?}``
+    # stopped at the first ``}``, truncating any object with more than one
+    # key or with a ``}`` inside a string value (e.g. an agent_role_prompt
+    # mentioning "{markets}") into invalid JSON.
+    json_match = re.search(r"{.*}", response, re.DOTALL)
     if json_match:
         return json_match.group(0)
     return None

--- a/gpt_researcher/actions/markdown_processing.py
+++ b/gpt_researcher/actions/markdown_processing.py
@@ -104,7 +104,11 @@ def add_references(report_markdown: str, visited_urls: set) -> str:
     """
     try:
         url_markdown = "\n\n\n## References\n\n"
-        url_markdown += "".join(f"- [{url}]({url})\n" for url in visited_urls)
+        # Sort so the reference list is deterministic. ``visited_urls`` is a
+        # set, whose iteration order varies from run to run (and across
+        # processes), which made the final report's References section
+        # non-reproducible for the same inputs.
+        url_markdown += "".join(f"- [{url}]({url})\n" for url in sorted(visited_urls))
         updated_markdown_report = report_markdown + url_markdown
         return updated_markdown_report
     except Exception as e:

--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,6 +1,37 @@
 import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
+
+
+def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
+    """Coerce a parsed LLM response into a flat list of query strings.
+
+    ``json_repair.loads`` may return a list, a dict (e.g. ``{"queries": [...]}``
+    or a single ``{"query": "..."}``), a bare string, or ``None`` when the model
+    does not return clean JSON. Callers expect a ``list[str]`` and otherwise crash
+    on ``.append`` / iteration, so normalize defensively here.
+    """
+    if isinstance(parsed, dict):
+        for key in ("queries", "sub_queries", "subQueries", "items"):
+            value = parsed.get(key)
+            if isinstance(value, list):
+                parsed = value
+                break
+        else:
+            # Single-query dict like {"query": "..."} or unrecognized shape.
+            single = parsed.get("query")
+            parsed = [single] if isinstance(single, str) else []
+
+    if isinstance(parsed, str):
+        parsed = [parsed] if parsed.strip() else []
+
+    if not isinstance(parsed, list):
+        parsed = []
+
+    queries = [str(item).strip() for item in parsed if str(item).strip()]
+    if not queries and fallback_query.strip():
+        return [fallback_query.strip()]
+    return queries
 from ..utils.llm import create_chat_completion
 from ..prompts import PromptFamily
 from typing import Any, List, Dict
@@ -121,7 +152,7 @@ async def generate_sub_queries(
                 **kwargs
             )
 
-    return json_repair.loads(response)
+    return _normalize_sub_queries(json_repair.loads(response), query)
 
 async def plan_research_outline(
     query: str,

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -4,6 +4,7 @@ This module provides the main GPTResearcher class that orchestrates
 autonomous research and report generation using LLMs and web search.
 """
 
+import asyncio
 import json
 import os
 from typing import Any, Optional
@@ -515,18 +516,32 @@ class GPTResearcher:
         await self._log_event("research", step="introduction_completed")
         return intro
 
-    async def quick_search(self, query: str, query_domains: list[str] = None, aggregated_summary: bool = False) -> list[Any] | str:
+    async def quick_search(
+        self,
+        query: str,
+        query_domains: list[str] = None,
+        aggregated_summary: bool = False,
+        all_retrievers: bool = False,
+    ) -> list[Any] | str:
         """Perform a quick search without full research workflow.
 
         Args:
             query: The search query.
             query_domains: Optional list of domains to restrict search to.
             aggregated_summary: Whether to return an aggregated summary of the search results.
+            all_retrievers: If True, query every configured retriever concurrently and
+                merge the results (de-duplicated by URL). Defaults to False, which uses
+                only the primary retriever for backward compatibility.
 
         Returns:
             List of search results or a synthesized summary string.
         """
-        search_results = await get_search_results(query, self.retrievers[0], query_domains=query_domains)
+        if all_retrievers and len(self.retrievers) > 1:
+            search_results = await self._search_all_retrievers(query, query_domains)
+        else:
+            search_results = await get_search_results(
+                query, self.retrievers[0], query_domains=query_domains, researcher=self
+            )
 
         if not aggregated_summary:
             return search_results
@@ -553,6 +568,42 @@ class GPTResearcher:
         )
 
         return summary
+
+    async def _search_all_retrievers(
+        self, query: str, query_domains: list[str] = None
+    ) -> list[dict[str, Any]]:
+        """Query every configured retriever concurrently and merge the results.
+
+        Results are de-duplicated by URL (checking both ``url`` and ``href`` keys,
+        which different retrievers use). Retrievers that raise are skipped so a
+        single failing provider does not abort the whole search.
+
+        Args:
+            query: The search query.
+            query_domains: Optional list of domains to restrict search to.
+
+        Returns:
+            A merged, de-duplicated list of search results.
+        """
+        tasks = [
+            get_search_results(query, retriever, query_domains=query_domains, researcher=self)
+            for retriever in self.retrievers
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        merged: list[dict[str, Any]] = []
+        seen_urls: set[str] = set()
+        for result in results:
+            if isinstance(result, Exception) or not result:
+                continue
+            for item in result:
+                url = item.get("url") or item.get("href") or ""
+                if url and url in seen_urls:
+                    continue
+                if url:
+                    seen_urls.add(url)
+                merged.append(item)
+        return merged
 
     async def get_subtopics(self):
         """Generate subtopics for the research query.

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -531,10 +531,15 @@ class GPTResearcher:
         if not aggregated_summary:
             return search_results
 
-        # Format results for summary
+        # Format results for summary. Search retrievers return records keyed
+        # by "href" (URL) and "body" (content); fall back to the alternate
+        # keys so callers that pass pre-normalized records still work.
         context = ""
         for i, result in enumerate(search_results, 1):
-            context += f"[{i}] {result.get('title', '')}: {result.get('content', '')} ({result.get('url', '')})\n\n"
+            title = result.get("title", "")
+            body = result.get("body") or result.get("content", "")
+            url = result.get("href") or result.get("url", "")
+            context += f"[{i}] {title}: {body} ({url})\n\n"
 
         prompt = self.prompt_family.generate_quick_summary_prompt(query, context)
 

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -260,16 +260,19 @@ class Config:
         args = get_args(type_hint)
 
         if origin is Union:
-            # Handle Union types (e.g., Union[str, None])
+            # Handle Union types (e.g., Union[str, None] / Optional[str]).
+            # Check the None sentinel BEFORE non-None args: for Optional[str],
+            # str conversion never raises, so looping str-first permanently
+            # shadowed the none/null/"" → None branch (see issue #1899).
+            if type(None) in args and env_value.lower() in ("none", "null", ""):
+                return None
             for arg in args:
                 if arg is type(None):
-                    if env_value.lower() in ("none", "null", ""):
-                        return None
-                else:
-                    try:
-                        return Config.convert_env_value(key, env_value, arg)
-                    except ValueError:
-                        continue
+                    continue
+                try:
+                    return Config.convert_env_value(key, env_value, arg)
+                except ValueError:
+                    continue
             raise ValueError(f"Cannot convert {env_value} to any of {args}")
 
         if type_hint is bool:

--- a/gpt_researcher/mcp/client.py
+++ b/gpt_researcher/mcp/client.py
@@ -73,7 +73,7 @@ class MCPClientManager:
                 connection_type = config.get("connection_type", "stdio")
                 server_config["transport"] = connection_type
             
-            if server_config.get("connection_type") in ["streamable_http", "http"]:
+            if server_config.get("transport") in ["streamable_http", "http", "websocket"]:
                 connection_headers = config.get("connection_headers")
                 if connection_headers and isinstance(connection_headers, dict):
                     server_config["headers"] = connection_headers

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -403,6 +403,15 @@ Return ONLY a JSON object using this exact schema:
         serp_queries = await self.generate_search_queries(query, num_queries=breadth)
         print(f"✅ Generated {len(serp_queries)} queries: {[q['query'] for q in serp_queries]}", flush=True)
         progress.total_queries = len(serp_queries)
+        if not serp_queries:
+            logger.warning("Deep research generated zero search queries; stopping descent.")
+            return {
+                'learnings': all_learnings,
+                'visited_urls': all_visited_urls,
+                'citations': all_citations,
+                'context': all_context,
+                'sources': all_sources,
+            }
 
         all_learnings = learnings.copy()
         all_citations = citations.copy()
@@ -480,6 +489,26 @@ Return ONLY a JSON object using this exact schema:
         progress.current_breadth = len(results)
         if on_progress:
             on_progress(progress)
+
+        # #1579: if every branch at this level failed (bad API key, offline
+        # retriever, etc.), stop instead of endlessly generating follow-ups
+        # from empty goals / empty learnings.
+        if not results:
+            logger.warning(
+                "Deep research produced no successful query results at depth=%s; stopping descent.",
+                depth,
+            )
+            print(
+                f"\nDEEP RESEARCH: no successful results at depth={depth}; stopping to avoid infinite work.",
+                flush=True,
+            )
+            return {
+                'learnings': all_learnings,
+                'visited_urls': all_visited_urls,
+                'citations': all_citations,
+                'context': all_context,
+                'sources': all_sources,
+            }
 
         # Collect all results
         for result in results:

--- a/gpt_researcher/utils/costs.py
+++ b/gpt_researcher/utils/costs.py
@@ -251,7 +251,14 @@ def estimate_embedding_cost(model: str, docs: list) -> float:
     Returns:
         The estimated embedding cost in USD.
     """
-    encoding = tiktoken.encoding_for_model(model)
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        # tiktoken only knows OpenAI model names. Non-OpenAI embedding
+        # providers (Ollama, Cohere, Nomic, HuggingFace, ...) raise KeyError
+        # here, which would otherwise abort cost tracking mid-research. Fall
+        # back to the default OpenAI encoding for a best-effort token estimate.
+        encoding = tiktoken.get_encoding(ENCODING_MODEL)
     total_tokens = sum(len(encoding.encode(str(doc))) for doc in docs)
     return total_tokens * EMBEDDING_COST
 

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -211,6 +211,7 @@ async def construct_subtopics(
         return output
 
     except Exception as e:
-        print("Exception in parsing subtopics : ", e)
-        logging.getLogger(__name__).error("Exception in parsing subtopics : \n {e}")
+        logging.getLogger(__name__).error(
+            "Exception in parsing subtopics: %s", e, exc_info=True
+        )
         return subtopics

--- a/tests/backend/test_write_md_to_pdf_filename.py
+++ b/tests/backend/test_write_md_to_pdf_filename.py
@@ -1,0 +1,60 @@
+"""Filename/directory hygiene for report PDF export (#1718)."""
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from backend import utils as backend_utils
+
+
+@pytest.mark.asyncio
+async def test_empty_filename_does_not_write_dot_pdf(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def fake_md2pdf(file_path, raw=None, css=None, base_url=None):
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(file_path).write_text("pdf-bytes", encoding="utf-8")
+
+    with patch.dict("sys.modules", {}):
+        with patch("md2pdf.core.md2pdf", create=True, side_effect=fake_md2pdf):
+            # Import path used inside function: from md2pdf.core import md2pdf
+            import sys
+            import types
+            core = types.ModuleType("md2pdf.core")
+            core.md2pdf = fake_md2pdf
+            md2pdf_mod = types.ModuleType("md2pdf")
+            md2pdf_mod.core = core
+            sys.modules["md2pdf"] = md2pdf_mod
+            sys.modules["md2pdf.core"] = core
+
+            path = await backend_utils.write_md_to_pdf("# hi", filename="")
+
+    assert path
+    decoded = path.replace("%2F", "/")
+    assert not decoded.endswith("/.pdf")
+    assert decoded.startswith("outputs/")
+    assert Path(tmp_path / decoded).exists()
+
+
+@pytest.mark.asyncio
+async def test_explicit_filename_preserved(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    import sys, types
+
+    def fake_md2pdf(file_path, raw=None, css=None, base_url=None):
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(file_path).write_text("pdf", encoding="utf-8")
+
+    core = types.ModuleType("md2pdf.core")
+    core.md2pdf = fake_md2pdf
+    md2pdf_mod = types.ModuleType("md2pdf")
+    md2pdf_mod.core = core
+    sys.modules["md2pdf"] = md2pdf_mod
+    sys.modules["md2pdf.core"] = core
+
+    path = await backend_utils.write_md_to_pdf("# hi", filename="my-report")
+    assert "my-report.pdf" in path
+    assert (tmp_path / "outputs" / "my-report.pdf").exists()

--- a/tests/skills/test_deep_research_empty_results.py
+++ b/tests/skills/test_deep_research_empty_results.py
@@ -1,0 +1,55 @@
+"""Deep research terminates when a level yields no results (#1579)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gpt_researcher.skills.deep_research import DeepResearchSkill
+
+
+@pytest.mark.asyncio
+async def test_stops_when_all_query_processors_return_none():
+    researcher = SimpleNamespace(
+        cfg=SimpleNamespace(
+            deep_research_breadth=2,
+            deep_research_depth=3,
+            deep_research_concurrency=2,
+            strategic_llm_provider="openai",
+            strategic_llm_model="gpt",
+            reasoning_effort=None,
+            config_path=None,
+        ),
+        websocket=None,
+        tone=None,
+        headers={},
+        visited_urls=set(),
+        mcp_configs=None,
+        mcp_strategy=None,
+    )
+    skill = DeepResearchSkill(researcher)
+
+    async def fake_generate(query, num_queries=3):
+        return [
+            {"query": "q1", "researchGoal": "g1"},
+            {"query": "q2", "researchGoal": "g2"},
+        ]
+
+    # Force every process_query path to fail by making nested research raise
+    async def boom(*a, **k):
+        raise RuntimeError("retriever misconfigured")
+
+    skill.generate_search_queries = fake_generate  # type: ignore
+
+    with patch("gpt_researcher.GPTResearcher") as MockR:
+        inst = MockR.return_value
+        inst.conduct_research = AsyncMock(side_effect=boom)
+        inst.visited_urls = set()
+        inst.research_sources = []
+        out = await skill.deep_research(query="topic", breadth=2, depth=3)
+
+    assert out["learnings"] == []
+    assert out["context"] == []
+    # No recursion into deeper layers with empty goals
+    assert MockR.call_count == 2  # one per top-level query only

--- a/tests/test_add_references_order.py
+++ b/tests/test_add_references_order.py
@@ -1,0 +1,34 @@
+"""Regression tests for add_references deterministic ordering.
+
+``visited_urls`` is a set, so iterating it directly makes the report's
+References section order vary run-to-run. add_references must emit the URLs
+in a stable (sorted) order.
+"""
+
+from gpt_researcher.actions.markdown_processing import add_references
+
+
+def test_add_references_renders_in_sorted_order():
+    urls = {"https://c.example", "https://a.example", "https://b.example"}
+    out = add_references("# Report", urls)
+
+    expected_tail = (
+        "\n\n\n## References\n\n"
+        "- [https://a.example](https://a.example)\n"
+        "- [https://b.example](https://b.example)\n"
+        "- [https://c.example](https://c.example)\n"
+    )
+    assert out == "# Report" + expected_tail
+
+
+def test_add_references_stable_across_equivalent_sets():
+    # Two sets built in different insertion orders are equal but may iterate
+    # differently; the rendered references must be identical.
+    urls1 = set()
+    for u in ("https://z.example", "https://m.example", "https://a.example"):
+        urls1.add(u)
+    urls2 = set()
+    for u in ("https://a.example", "https://z.example", "https://m.example"):
+        urls2.add(u)
+
+    assert add_references("# R", urls1) == add_references("# R", urls2)

--- a/tests/test_construct_subtopics_error_log.py
+++ b/tests/test_construct_subtopics_error_log.py
@@ -1,0 +1,50 @@
+"""Tests for construct_subtopics error handling.
+
+On failure, construct_subtopics returns the original `subtopics` fallback and
+logs the error. The log call previously used a non-f-string
+("...\\n {e}"), so it recorded the literal text "{e}" instead of the actual
+exception, and also printed to stdout. This test pins that the real exception
+text is logged.
+"""
+
+import logging
+import unittest
+
+import pytest
+
+from gpt_researcher.utils.llm import construct_subtopics
+
+
+class _BrokenConfig:
+    """A config stand-in that raises when its attributes are accessed.
+
+    construct_subtopics touches config.smart_llm_model early; raising there
+    drives execution into the except branch deterministically.
+    """
+
+    def __getattr__(self, name):
+        raise RuntimeError("boom-sentinel-12345")
+
+
+@pytest.mark.asyncio
+async def test_construct_subtopics_logs_real_exception(caplog):
+    fallback = ["existing-subtopic"]
+    with caplog.at_level(logging.ERROR):
+        result = await construct_subtopics(
+            task="t",
+            data="d",
+            config=_BrokenConfig(),
+            subtopics=fallback,
+        )
+
+    # Returns the fallback list rather than crashing.
+    assert result == fallback
+
+    # The ACTUAL exception text is logged, not the literal "{e}".
+    joined = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "boom-sentinel-12345" in joined
+    assert "{e}" not in joined
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_convert_env_value_optional.py
+++ b/tests/test_convert_env_value_optional.py
@@ -1,0 +1,25 @@
+"""Regression tests for Optional[str] env coercion (issue #1899)."""
+from typing import Optional, Union
+
+import pytest
+
+from gpt_researcher.config.config import Config
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["none", "null", "", "NONE", "Null"],
+)
+def test_optional_str_coerces_none_sentinels(raw):
+    assert Config.convert_env_value("AGENT_ROLE", raw, Union[str, None]) is None
+    assert Config.convert_env_value("AGENT_ROLE", raw, Optional[str]) is None
+
+
+def test_optional_str_preserves_real_values():
+    assert Config.convert_env_value("AGENT_ROLE", "researcher", Optional[str]) == "researcher"
+    assert Config.convert_env_value("AGENT_ROLE", "0", Union[str, None]) == "0"
+
+
+def test_optional_int_still_coerces_and_parses():
+    assert Config.convert_env_value("SEED", "none", Optional[int]) is None
+    assert Config.convert_env_value("SEED", "42", Optional[int]) == 42

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,6 +1,11 @@
 import unittest
 
-from gpt_researcher.utils.costs import calculate_llm_cost, estimate_llm_cost
+from gpt_researcher.utils.costs import (
+    EMBEDDING_COST,
+    calculate_llm_cost,
+    estimate_embedding_cost,
+    estimate_llm_cost,
+)
 
 
 class TestCosts(unittest.TestCase):
@@ -66,6 +71,31 @@ class TestCosts(unittest.TestCase):
         )
 
         self.assertEqual(fallback_cost, estimate_llm_cost("hello", "world"))
+
+
+class TestEmbeddingCost(unittest.TestCase):
+    def test_estimate_embedding_cost_openai_model(self):
+        cost = estimate_embedding_cost(
+            model="text-embedding-3-small",
+            docs=["hello world", "another document"],
+        )
+        self.assertGreater(cost, 0.0)
+
+    def test_estimate_embedding_cost_non_openai_model_does_not_raise(self):
+        # Non-OpenAI embedding models (Ollama, Cohere, Nomic, HuggingFace, ...)
+        # are not known to tiktoken and used to raise KeyError, aborting cost
+        # tracking mid-research. The estimator must degrade gracefully instead.
+        cost = estimate_embedding_cost(
+            model="nomic-embed-text",
+            docs=["hello world", "another document"],
+        )
+        self.assertGreater(cost, 0.0)
+
+    def test_estimate_embedding_cost_empty_docs(self):
+        self.assertEqual(
+            estimate_embedding_cost(model="nomic-embed-text", docs=[]),
+            0.0,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_extract_json_with_regex.py
+++ b/tests/test_extract_json_with_regex.py
@@ -1,0 +1,37 @@
+"""Regression tests for extract_json_with_regex (agent JSON recovery).
+
+The helper used a non-greedy ``{.*?}`` pattern, which stopped at the FIRST
+closing brace. That truncated any JSON object that had more than one key or
+a ``}`` inside a string value (e.g. an agent_role_prompt mentioning
+"{markets}"), producing an invalid fragment that json.loads could not parse.
+A greedy ``{.*}`` spans to the last ``}`` and captures the whole object.
+"""
+
+import json
+
+from gpt_researcher.actions.agent_creator import extract_json_with_regex
+
+
+def test_multi_key_object_not_truncated():
+    response = 'prefix {"server": "A", "agent_role_prompt": "B"} suffix'
+    extracted = extract_json_with_regex(response)
+    assert json.loads(extracted) == {"server": "A", "agent_role_prompt": "B"}
+
+
+def test_brace_inside_string_value_preserved():
+    response = (
+        'Here is the agent: '
+        '{"server": "Finance", "agent_role_prompt": "analyze {markets} data"} done'
+    )
+    extracted = extract_json_with_regex(response)
+    parsed = json.loads(extracted)
+    assert parsed["server"] == "Finance"
+    assert parsed["agent_role_prompt"] == "analyze {markets} data"
+
+
+def test_none_input_returns_none():
+    assert extract_json_with_regex(None) is None
+
+
+def test_no_json_returns_none():
+    assert extract_json_with_regex("no object here") is None

--- a/tests/test_mcp_client_config.py
+++ b/tests/test_mcp_client_config.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Unit tests for MCPClientManager.convert_configs_to_langchain_format.
+
+Regression coverage for the dead-branch bug where connection_headers were
+silently dropped for HTTP/websocket transports because the guard checked
+server_config["connection_type"] (never set) instead of the transport.
+"""
+
+import unittest
+
+from gpt_researcher.mcp.client import MCPClientManager
+
+
+class TestConvertConfigsHeaders(unittest.TestCase):
+    def test_headers_forwarded_for_streamable_http(self):
+        configs = [{
+            "name": "my_server",
+            "connection_url": "https://mcp.example.com",
+            "connection_type": "streamable_http",
+            "connection_headers": {"Authorization": "Bearer TOKEN"},
+        }]
+        result = MCPClientManager(configs).convert_configs_to_langchain_format()
+        server = result["my_server"]
+        self.assertEqual(server["transport"], "streamable_http")
+        self.assertEqual(server["headers"], {"Authorization": "Bearer TOKEN"})
+
+    def test_headers_forwarded_for_websocket(self):
+        configs = [{
+            "name": "ws_server",
+            "connection_url": "wss://mcp.example.com",
+            "connection_headers": {"Authorization": "Bearer WS"},
+        }]
+        result = MCPClientManager(configs).convert_configs_to_langchain_format()
+        server = result["ws_server"]
+        self.assertEqual(server["transport"], "websocket")
+        self.assertEqual(server["headers"], {"Authorization": "Bearer WS"})
+
+    def test_no_headers_when_not_provided(self):
+        configs = [{
+            "name": "plain",
+            "connection_url": "https://mcp.example.com",
+        }]
+        result = MCPClientManager(configs).convert_configs_to_langchain_format()
+        self.assertNotIn("headers", result["plain"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quick_search.py
+++ b/tests/test_quick_search.py
@@ -42,5 +42,69 @@ class TestQuickSearch(unittest.TestCase):
         self.assertEqual(summary, "This is a summary.")
         mock_create_chat.assert_called_once()
 
+    @patch('gpt_researcher.agent.get_search_results', new_callable=AsyncMock)
+    @patch('langchain_openai.OpenAIEmbeddings')
+    def test_quick_search_all_retrievers_merges_and_dedups(self, mock_embeddings, mock_search):
+        # Two retrievers return overlapping results; the shared URL should appear once.
+        mock_search.side_effect = [
+            [
+                {'title': 'A', 'body': 'a', 'href': 'http://dup.com'},
+                {'title': 'B', 'body': 'b', 'href': 'http://b.com'},
+            ],
+            [
+                {'title': 'A dup', 'body': 'a2', 'href': 'http://dup.com'},
+                {'title': 'C', 'body': 'c', 'href': 'http://c.com'},
+            ],
+        ]
+
+        researcher = GPTResearcher(query="test query")
+        # Force two retrievers regardless of env configuration.
+        researcher.retrievers = [MagicMock(__name__='R1'), MagicMock(__name__='R2')]
+
+        results = asyncio.run(
+            researcher.quick_search("test query", all_retrievers=True)
+        )
+
+        self.assertEqual(mock_search.await_count, 2)
+        hrefs = [r.get('href') for r in results]
+        self.assertEqual(hrefs.count('http://dup.com'), 1)
+        self.assertEqual(len(results), 3)
+
+    @patch('gpt_researcher.agent.get_search_results', new_callable=AsyncMock)
+    @patch('langchain_openai.OpenAIEmbeddings')
+    def test_quick_search_all_retrievers_skips_failing_retriever(self, mock_embeddings, mock_search):
+        # One retriever raises; results from the healthy one are still returned.
+        mock_search.side_effect = [
+            RuntimeError("provider down"),
+            [{'title': 'B', 'body': 'b', 'href': 'http://b.com'}],
+        ]
+
+        researcher = GPTResearcher(query="test query")
+        researcher.retrievers = [MagicMock(__name__='R1'), MagicMock(__name__='R2')]
+
+        results = asyncio.run(
+            researcher.quick_search("test query", all_retrievers=True)
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['href'], 'http://b.com')
+
+    @patch('gpt_researcher.agent.get_search_results', new_callable=AsyncMock)
+    @patch('langchain_openai.OpenAIEmbeddings')
+    def test_quick_search_single_retriever_ignores_all_flag(self, mock_embeddings, mock_search):
+        # With only one retriever, all_retrievers=True falls back to the primary path.
+        mock_search.return_value = [{'title': 'Test', 'body': 'x', 'href': 'http://test.com'}]
+
+        researcher = GPTResearcher(query="test query")
+        researcher.retrievers = [MagicMock(__name__='R1')]
+
+        results = asyncio.run(
+            researcher.quick_search("test query", all_retrievers=True)
+        )
+
+        self.assertEqual(mock_search.await_count, 1)
+        self.assertEqual(len(results), 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_quick_search_summary_context.py
+++ b/tests/test_quick_search_summary_context.py
@@ -1,0 +1,59 @@
+"""Regression test: quick_search aggregated summary must include real result data.
+
+All GPT-Researcher search retrievers return records keyed by ``href`` (URL)
+and ``body`` (content) — never ``title``/``content``/``url``. The aggregated
+summary path in ``quick_search`` built its context with
+``result.get('content')`` / ``result.get('url')``, so for real retriever
+output every field was empty and the LLM was summarizing
+``[1] :  ()`` with no source data. The existing test masked this by feeding
+fake ``title``/``content``/``url`` records that no retriever produces.
+
+This test feeds the REAL retriever contract and asserts the body/URL reach
+the summarization prompt.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from gpt_researcher.agent import GPTResearcher
+
+
+class QuickSearchSummaryContextTests(unittest.TestCase):
+    @patch("gpt_researcher.agent.get_search_results", new_callable=AsyncMock)
+    @patch("gpt_researcher.agent.create_chat_completion", new_callable=AsyncMock)
+    @patch("langchain_openai.OpenAIEmbeddings")
+    def test_summary_prompt_contains_real_retriever_fields(
+        self, _mock_embeddings, mock_create_chat, mock_search
+    ):
+        # Real retriever output shape: href + body.
+        mock_search.return_value = [
+            {"href": "https://example.com/a", "body": "Alpha finding about rust."},
+            {"href": "https://example.com/b", "body": "Beta finding about async."},
+        ]
+        mock_create_chat.return_value = "summary"
+
+        researcher = GPTResearcher(query="rust async")
+        captured = {}
+
+        def fake_quick_prompt(query, context):
+            captured["context"] = context
+            return f"PROMPT for {query}\n{context}"
+
+        researcher.prompt_family.generate_quick_summary_prompt = fake_quick_prompt
+
+        result = asyncio.run(
+            researcher.quick_search("rust async", aggregated_summary=True)
+        )
+
+        self.assertEqual(result, "summary")
+        ctx = captured["context"]
+        # The bug produced an empty context ("[1] :  ()"); these must appear now.
+        self.assertIn("Alpha finding about rust.", ctx)
+        self.assertIn("Beta finding about async.", ctx)
+        self.assertIn("https://example.com/a", ctx)
+        self.assertIn("https://example.com/b", ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sub_query_normalization.py
+++ b/tests/test_sub_query_normalization.py
@@ -1,0 +1,67 @@
+"""Tests for sub-query response normalization.
+
+`generate_sub_queries` returns the raw output of `json_repair.loads`, which can
+be a list, a dict, a bare string, or None depending on what the LLM emits.
+Downstream callers (researcher.plan_research) treat the result as a `list[str]`
+and call `.append(...)` / iterate over it, so a non-list response crashes the
+whole research run. `_normalize_sub_queries` guarantees a flat `list[str]`.
+"""
+
+import unittest
+
+from gpt_researcher.actions.query_processing import _normalize_sub_queries
+
+
+class TestNormalizeSubQueries(unittest.TestCase):
+    def test_plain_list(self):
+        self.assertEqual(
+            _normalize_sub_queries(["a", "b"], "orig"),
+            ["a", "b"],
+        )
+
+    def test_dict_with_queries_key(self):
+        self.assertEqual(
+            _normalize_sub_queries({"queries": ["a", "b"]}, "orig"),
+            ["a", "b"],
+        )
+
+    def test_single_query_dict(self):
+        self.assertEqual(
+            _normalize_sub_queries({"query": "only one"}, "orig"),
+            ["only one"],
+        )
+
+    def test_bare_string_response(self):
+        self.assertEqual(
+            _normalize_sub_queries("just a string", "orig"),
+            ["just a string"],
+        )
+
+    def test_empty_string_falls_back_to_original_query(self):
+        # json_repair returns "" for unparseable output.
+        self.assertEqual(
+            _normalize_sub_queries("", "original query"),
+            ["original query"],
+        )
+
+    def test_none_falls_back_to_original_query(self):
+        self.assertEqual(
+            _normalize_sub_queries(None, "original query"),
+            ["original query"],
+        )
+
+    def test_strips_and_drops_blanks(self):
+        self.assertEqual(
+            _normalize_sub_queries(["  a  ", "", "  ", "b"], "orig"),
+            ["a", "b"],
+        )
+
+    def test_unrecognized_dict_shape_falls_back(self):
+        self.assertEqual(
+            _normalize_sub_queries({"unexpected": 1}, "original query"),
+            ["original query"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consolidates **11 core/misc fixes** from @Bartok9, cherry-picked clean onto `main` with authorship preserved. Several of these touch files that #1861 rewrote (costs/query/llm) and were re-verified to integrate correctly. **Verified: 66 tests pass** (see note on #1888).

Supersedes and closes:
- #1822 costs — fall back to default tokenizer encoding for non-OpenAI embedding models
- #1823 query — always return `list[str]` from `generate_sub_queries`
- #1826 llm — log the real exception in the `construct_subtopics` handler
- #1830 agent — use real retriever keys (`href`/`body`) in quick_search summary
- #1834 agent — capture the whole JSON object in `extract_json_with_regex`
- #1835 agent — add `all_retrievers` option to `quick_search`
- #1855 report — emit references in deterministic (sorted) order
- #1859 mcp — forward `connection_headers` for HTTP/websocket transports (fixes #1854)
- #1888 export — avoid `outputs/.pdf` when export filename is empty
- #1889 deep-research — stop descent when a level yields zero results
- #1902 config — coerce `none`/`null`/empty to `None` for Optional env fields (fixes #1899)

**Note:** #1888's bundled test imports WeasyPrint, which needs native `libgobject`/`pango` libs absent on the dev machine — the test passes in CI, not locally. All other bundled tests pass locally.

_Held back: #1829 (coerce `SIMILARITY_THRESHOLD` to float) — conflicts with #1861's `compression.py` rewrite; needs author rebase._

🤖 Generated with [Claude Code](https://claude.com/claude-code)