### PR TITLE
Reconcile master→main: GetXAPI retriever, Claude 4.x temp fix, MiniMax M3, curate_sources fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ OPENAI_API_KEY=
 TAVILY_API_KEY=
 BRAVE_API_KEY=
 XQUIK_API_KEY=
+GETXAPI_API_KEY=
 DOC_PATH=./my-docs
 
 # NEXT_PUBLIC_GPTR_API_URL=http://0.0.0.0:8000  # Defaults to localhost:8000 if not set

--- a/docs/docs/gpt-researcher/llms/llms.md
+++ b/docs/docs/gpt-researcher/llms/llms.md
@@ -387,24 +387,23 @@ EMBEDDING="aimlapi:text-embedding-3-small"
 
 ## MiniMax
 
-[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. The latest MiniMax-M2.7 features improved reasoning and competitive pricing.
+[MiniMax](https://www.minimaxi.com) offers powerful large language models with an OpenAI-compatible API. The latest MiniMax-M3 features a 512K context window, up to 128K output, and image input support.
 
 Sign up at [minimaxi.com](https://www.minimaxi.com) to get an API key, then set the following environment variables:
 
 ```env
 MINIMAX_API_KEY=[Your Key]
-FAST_LLM=minimax:MiniMax-M2.7-highspeed
-SMART_LLM=minimax:MiniMax-M2.7
-STRATEGIC_LLM=minimax:MiniMax-M2.7
+FAST_LLM=minimax:MiniMax-M3
+SMART_LLM=minimax:MiniMax-M3
+STRATEGIC_LLM=minimax:MiniMax-M3
 
 EMBEDDING=minimax:embo-01
 ```
 
 Available models:
-- `MiniMax-M2.7` — latest flagship model with improved reasoning
-- `MiniMax-M2.7-highspeed` — optimized for speed
-- `MiniMax-M2.5` — 204K context, general-purpose model
-- `MiniMax-M2.5-highspeed` — 204K context, optimized for speed
+- `MiniMax-M3` — flagship model with 512K context, 128K max output, image input support (default)
+- `MiniMax-M2.7` — previous-generation model
+- `MiniMax-M2.7-highspeed` — previous-generation low-latency variant
 
 ## Avian
 

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -33,6 +33,7 @@ def get_retriever(retriever: str):
         - custom: Custom user-defined retriever
         - mcp: Model Context Protocol retriever
         - xquik: Xquik X/Twitter search
+        - getxapi: GetXAPI X/Twitter search
     """
     match retriever:
         case "google":
@@ -115,6 +116,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import OpenAlexSearch
 
             return OpenAlexSearch
+        case "getxapi":
+            from gpt_researcher.retrievers import GetXAPISearch
+
+            return GetXAPISearch
 
         case _:
             return None

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -62,6 +62,15 @@ NO_SUPPORT_TEMPERATURE_MODELS = [
     "gpt-5.4-pro",
     "gpt-5.5",
     "gpt-5.5-pro",
+    # Claude 4.x family: Anthropic deprecates temperature on these models
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
 ]
 
 SUPPORT_REASONING_EFFORT_MODELS = [

--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -245,7 +245,11 @@ Use this context to inform and refine your search queries. The context provides 
 
         dynamic_example = ", ".join([f'"query {i+1}"' for i in range(max_iterations)])
 
-        return f"""Write {max_iterations} google search queries to search online that form an objective opinion from the following task: "{task}"
+        return f"""Write {max_iterations} search queries to research the following task: "{task}"
+
+Each query must be a plain natural language phrase. Do not use search operator syntax
+such as site:, filetype:, inurl:, intitle:, OR, AND, or NOT — these operators are
+not universally supported and will return empty results on many search backends.
 
 Assume the current date is {datetime.now(timezone.utc).strftime('%B %d, %Y')} if required.
 

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -14,6 +14,7 @@ from .tavily.tavily_search import TavilySearch
 from .groundroute.groundroute import GroundRouteSearch
 from .exa.exa import ExaSearch
 from .crw.crw import CRWRetriever
+from .getxapi.getxapi import GetXAPISearch
 from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
@@ -36,6 +37,7 @@ __all__ = [
     "PubMedCentralSearch",
     "ExaSearch",
     "CRWRetriever",
+    "GetXAPISearch",
     "MCPRetriever",
     "BoChaSearch",
     "XquikSearch",

--- a/gpt_researcher/retrievers/getxapi/getxapi.py
+++ b/gpt_researcher/retrievers/getxapi/getxapi.py
@@ -1,0 +1,91 @@
+"""GetXAPI X/Twitter retriever for GPT Researcher."""
+
+import json
+import os
+import urllib.parse
+import urllib.request
+
+
+class GetXAPISearch:
+    """
+    GetXAPI X/Twitter search retriever.
+
+    Searches tweets via the GetXAPI REST API and returns results in the
+    standard {title, href, body} format used by all GPT Researcher retrievers.
+
+    Set GETXAPI_API_KEY in your environment. Get one at https://getxapi.com
+    """
+
+    def __init__(self, query, query_domains=None, **kwargs):
+        self.query = query
+        self.query_domains = query_domains
+        self.api_key = self.get_api_key()
+
+    def get_api_key(self):
+        try:
+            api_key = os.environ["GETXAPI_API_KEY"]
+        except KeyError:
+            raise Exception(
+                "GetXAPI API key not found. Please set the GETXAPI_API_KEY "
+                "environment variable. Get a key at https://getxapi.com"
+            )
+        return api_key
+
+    def search(self, max_results=10):
+        """
+        Search X/Twitter via GetXAPI advanced search.
+
+        Returns:
+            list: Search results as [{title, href, body}, ...]
+        """
+        print(f"Searching X/Twitter with query: {self.query}...")
+
+        try:
+            results = self._search_tweets(max_results)
+            return results
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching X/Twitter sources. Resulting in empty response.")
+            return []
+
+    def _search_tweets(self, max_results):
+        params = urllib.parse.urlencode({"q": self.query})
+        url = f"https://api.getxapi.com/twitter/tweet/advanced_search?{params}"
+
+        req = urllib.request.Request(url, headers={
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "User-Agent": "gpt-researcher/1.0",
+        })
+
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        tweets = data.get("tweets") or data.get("data") or []
+        search_results = []
+
+        for tweet in tweets[:max_results]:
+            author = tweet.get("author") or {}
+            username = (
+                author.get("userName")
+                or author.get("username")
+                or author.get("screen_name")
+                or tweet.get("username")
+                or "unknown"
+            )
+            text = tweet.get("text") or tweet.get("full_text") or ""
+            tweet_id = tweet.get("id") or tweet.get("id_str") or ""
+
+            likes = tweet.get("likeCount") or tweet.get("favorite_count") or 0
+            retweets = tweet.get("retweetCount") or tweet.get("retweet_count") or 0
+            replies = tweet.get("replyCount") or tweet.get("reply_count") or 0
+            views = tweet.get("viewCount") or tweet.get("view_count") or 0
+
+            truncated = text[:80] + ("..." if len(text) > 80 else "")
+
+            search_results.append({
+                "title": f"@{username}: {truncated}",
+                "href": f"https://x.com/{username}/status/{tweet_id}",
+                "body": f"{text}\n\n[likes:{likes} retweets:{retweets} replies:{replies} views:{views}]",
+            })
+
+        return search_results

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -76,6 +76,7 @@ VALID_RETRIEVERS = [
     "pubmed_central",
     "exa",
     "crw",
+    "getxapi",
     "mcp",
     "xquik",
     "openalex",

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -487,7 +487,14 @@ Return ONLY a JSON object using this exact schema:
             all_visited_urls.update(result['visited_urls'])
             all_citations.update(result['citations'])
             if result['context']:
-                all_context.append(result['context'])
+                # Use extend, not append: when CURATE_SOURCES=True, result['context'] is
+                # a List[dict]. append() nests it as a single item, which causes
+                # "\n".join() to crash later with "expected str instance, dict found".
+                ctx = result['context']
+                if isinstance(ctx, list):
+                    all_context.extend(ctx)
+                else:
+                    all_context.append(ctx)
             if result['sources']:
                 all_sources.extend(result['sources'])
 
@@ -588,7 +595,12 @@ Return ONLY a JSON object using this exact schema:
         final_context = trim_context_to_word_limit(context_with_citations)
         
         # Set enhanced context and visited URLs
-        self.researcher.context = "\n".join(final_context)
+        self.researcher.context = "\n".join(
+            item if isinstance(item, str)
+            else item.get("Content", str(item)) if isinstance(item, dict)
+            else str(item)
+            for item in final_context
+        )
         self.researcher.visited_urls = results['visited_urls']
 
         # Set research sources

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -208,7 +208,21 @@ class ResearchConductor:
         self.researcher.context = research_data
         if self.researcher.cfg.curate_sources:
             self.logger.info("Curating sources")
-            self.researcher.context = await self.researcher.source_curator.curate_sources(research_data)
+            curated = await self.researcher.source_curator.curate_sources(research_data)
+            # curate_sources() returns List[dict] with Title/Content/Source keys.
+            # Normalize to str so downstream code that expects researcher.context
+            # to be a string (e.g. "\n".join, .split(), len()) doesn't crash.
+            if isinstance(curated, list):
+                self.researcher.context = "\n\n".join(
+                    "Title: {title}\nContent: {content}\nSource: {source}".format(
+                        title=s.get("Title", ""),
+                        content=s.get("Content", ""),
+                        source=s.get("Source", ""),
+                    ) if isinstance(s, dict) else str(s)
+                    for s in curated
+                )
+            else:
+                self.researcher.context = curated
 
         if self.researcher.verbose:
             await stream_output(


### PR DESCRIPTION
Reconciles the `main`/`master` trunk fork. `master` diverged from `main` on 2026-04-16 and accumulated real work that never reached `main` (now the default branch). This brings the **6 valuable `master`-only commits** onto `main`, cherry-picked with authorship preserved; two required manual conflict resolution against #1861's rewrites (details below).

**Brought over:**
- **Add GetXAPI retriever** for X/Twitter search (new `retrievers/getxapi/`) — registered alongside existing retrievers
- **Add Claude 4.x family to `NO_SUPPORT_TEMPERATURE_MODELS`** — ⚠️ this was a **live bug on `main`**: reasoning-model temperature rejection wasn't applied to Claude 4.x. Merged as a union with main's GPT-5 entries.
- **MiniMax M3** default model upgrade
- **CURATE_SOURCES `List[dict]`** handling in deep research + **normalize `curate_sources()` return type**
- **Retriever-agnostic search-query prompt** (prohibit operator syntax)

**Skipped** (chore/junk, not carried over): a "Safety commit", a version bump, and a `.python-version` removal.

**Verified:** getxapi registers and resolves via `get_retriever`, Claude 4.x + GPT-5 both present in the temp guard, all modules compile, baseline unit suite passes (43), and a live end-to-end research run succeeds (8 sources).

After this merges, `master` can be retired and its remaining PRs retargeted to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)