### PR TITLE
docs(skill): fix drift in .claude reference docs (retrievers, multi-agents, api)

### DIFF
--- a/.claude/references/api-reference.md
+++ b/.claude/references/api-reference.md
@@ -32,11 +32,16 @@ Base URL: `http://localhost:8000`
 
 ```json
 {
-    "report": "# Research Report\n\n...",
     "research_id": "task_1234567890_query",
-    "costs": 0.05,
-    "pdf_path": "outputs/task_123.pdf",
-    "docx_path": "outputs/task_123.docx"
+    "research_information": {
+        "source_urls": ["..."],
+        "research_costs": 0.05,
+        "visited_urls": ["..."],
+        "research_images": ["..."]
+    },
+    "report": "# Research Report\n\n...",
+    "docx_path": "outputs/task_123.docx",
+    "pdf_path": "outputs/task_123.pdf"
 }
 ```
 
@@ -67,16 +72,10 @@ Base URL: `http://localhost:8000`
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
+| GET | `/files/` | List uploaded documents |
 | POST | `/upload/` | Upload document |
-| DELETE | `/delete/{filename}` | Delete file |
+| DELETE | `/files/{filename}` | Delete file |
 | GET | `/outputs/{filename}` | Get output file |
-
-### Configuration
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/getConfig` | Get current config |
-| POST | `/setConfig` | Update config |
 
 ---
 

--- a/.claude/references/multi-agents.md
+++ b/.claude/references/multi-agents.md
@@ -21,11 +21,11 @@ LangGraph-based system inspired by [STORM paper](https://arxiv.org/abs/2402.1420
 | Agent | File | Role |
 |-------|------|------|
 | Human | - | Oversees and provides feedback |
-| Chief Editor | `agents/editor.py` | Master coordinator via LangGraph |
+| Chief Editor | `agents/orchestrator.py` | Master coordinator via LangGraph |
 | Researcher | Uses GPTResearcher | Deep research on topics |
 | Editor | `agents/editor.py` | Plans outline and structure |
 | Reviewer | `agents/reviewer.py` | Validates research correctness |
-| Revisor | `agents/revisor.py` | Revises based on feedback |
+| Reviser | `agents/reviser.py` | Revises based on feedback |
 | Writer | `agents/writer.py` | Compiles final report |
 | Publisher | `agents/publisher.py` | Exports to PDF, DOCX, Markdown |
 
@@ -39,7 +39,7 @@ LangGraph-based system inspired by [STORM paper](https://arxiv.org/abs/2402.1420
 3. For each outline topic (parallel):
    a. Researcher → In-depth subtopic research
    b. Reviewer → Validates draft
-   c. Revisor → Revises until satisfactory
+   c. Reviser → Revises until satisfactory
 4. Writer → Compiles final report
 5. Publisher → Exports to multiple formats
 ```
@@ -67,7 +67,7 @@ report_type = "multi_agents"
 ### Directly in Python
 
 ```python
-from multi_agents import run_research_task
+from multi_agents.main import run_research_task
 
 report = await run_research_task(
     query="Comprehensive analysis of market trends",

--- a/.claude/references/retrievers.md
+++ b/.claude/references/retrievers.md
@@ -15,17 +15,27 @@
 |-----------|-------|-----------------|
 | Tavily | `TavilySearch` | `TAVILY_API_KEY` |
 | Google | `GoogleSearch` | `GOOGLE_API_KEY`, `GOOGLE_CX_KEY` |
-| DuckDuckGo | `Duckduckgo` | None |
 | Bing | `BingSearch` | `BING_API_KEY` |
+| Brave | `BraveSearch` | `BRAVE_API_KEY` |
+| DuckDuckGo | `Duckduckgo` | None |
+| SearX | `SearxSearch` | `SEARX_URL` |
 | Serper | `SerperSearch` | `SERPER_API_KEY` |
 | SerpAPI | `SerpApiSearch` | `SERPAPI_API_KEY` |
 | SearchAPI | `SearchApiSearch` | `SEARCHAPI_API_KEY` |
 | Exa | `ExaSearch` | `EXA_API_KEY` |
+| GroundRoute | `GroundRouteSearch` | `GROUNDROUTE_API_KEY` |
+| fastCRW | `CRWRetriever` | `CRW_API_KEY` |
+| BoCha | `BoChaSearch` | `BOCHA_API_KEY` |
+| Xquik | `XquikSearch` | `XQUIK_API_KEY` |
+| GetXAPI (X/Twitter) | `GetXAPISearch` | `GETXAPI_API_KEY` |
 | arXiv | `ArxivSearch` | None |
 | Semantic Scholar | `SemanticScholarSearch` | None |
 | PubMed Central | `PubMedCentralSearch` | None |
+| OpenAlex | `OpenAlexSearch` | `OPENALEX_API_KEY`, `OPENALEX_EMAIL` |
 | MCP | `MCPRetriever` | Per-server |
 | Custom | `CustomRetriever` | User-defined |
+
+> The authoritative list is the `match` statement in `gpt_researcher/actions/retriever.py` (`get_retriever`).
 
 ---
 
@@ -48,18 +58,17 @@ def get_retriever(retriever: str):
             return MCPRetriever
         # ... etc
 
-def get_retrievers(retriever_names: str, headers: dict = None) -> list:
+def get_retrievers(headers: dict[str, str], cfg) -> list:
     """
-    Get multiple retrievers from comma-separated string.
-    
+    Resolve which retriever(s) to use, in priority order:
+    headers["retrievers"] / headers["retriever"] → cfg.retrievers / cfg.retriever
+    → default (TavilySearch). Accepts a comma-separated string or a list.
+
     Usage: RETRIEVER=tavily,google,mcp
     """
-    retrievers = []
-    for name in retriever_names.split(","):
-        retriever_class = get_retriever(name.strip())
-        if retriever_class:
-            retrievers.append(retriever_class)
-    return retrievers
+    # ... resolve names from headers/cfg (see actions/retriever.py) ...
+    # Invalid names fall back to get_default_retriever():
+    return [get_retriever(r) or get_default_retriever() for r in retriever_names]
 ```
 
 ---


### PR DESCRIPTION
Audited the Claude skill (`.claude/SKILL.md` + `.claude/references/*.md`) against the current codebase and fixed verified drift. The skill itself and most references were accurate — these three had concrete errors.

**retrievers.md**
- Listed only 13 of the **21** registered retrievers → now complete: adds Brave, SearX, GroundRoute, fastCRW, BoCha, Xquik, OpenAlex, and **GetXAPI** (with correct env vars)
- Fixed the stale `get_retrievers()` example signature → real `(headers, cfg)` form with default-fallback behavior

**multi-agents.md**
- `ChiefEditorAgent` is in `agents/orchestrator.py`, not `editor.py`
- `Reviser` / `agents/reviser.py` (was mislabeled `Revisor` / `revisor.py`)
- `from multi_agents.main import run_research_task` (the bare `from multi_agents import` fails — it isn't re-exported)

**api-reference.md**
- `/report` response nests `research_information.research_costs` (removed the non-existent top-level `costs`)
- `DELETE /files/{filename}` (was `/delete/{filename}`) + added `GET /files/`
- Removed non-existent `/getConfig` & `/setConfig` endpoints

Verified each against the code (`retriever.py`, `multi_agents/agents/*`, `backend/server/app.py`). No `multi_agents_ag2` references exist in any doc, so the ag2 move (#1912) needs no doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)