### PR TITLE
fix(searchapi): tolerate missing keys on organic results

### DIFF
--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -61,22 +61,33 @@ class SearchApiSearch():
             response = requests.get(encoded_url, headers=headers, timeout=20)
             if response.status_code == 200:
                 search_results = response.json()
-                if search_results:
-                    results = search_results["organic_results"]
-                    results_processed = 0
-                    for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
-                        if results_processed >= max_results:
-                            break
-                        search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
-                        }
-                        search_response.append(search_result)
-                        results_processed += 1
+                if not isinstance(search_results, dict):
+                    return []
+                # Missing or null organic_results must not KeyError the whole call.
+                results = search_results.get("organic_results") or []
+                if not isinstance(results, list):
+                    return []
+                results_processed = 0
+                for result in results:
+                    if not isinstance(result, dict):
+                        continue
+                    if results_processed >= max_results:
+                        break
+                    link = result.get("link") or result.get("url") or ""
+                    # A result without a link is unusable; skip rather than
+                    # KeyError on result["link"] and drop the rest of the page.
+                    if not link:
+                        continue
+                    # skip youtube results
+                    if "youtube.com" in link:
+                        continue
+                    search_result = {
+                        "title": result.get("title") or "",
+                        "href": link,
+                        "body": result.get("snippet") or result.get("body") or "",
+                    }
+                    search_response.append(search_result)
+                    results_processed += 1
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_searchapi_malformed_results.py
+++ b/tests/test_searchapi_malformed_results.py
@@ -1,0 +1,76 @@
+"""Regression tests for SearchApiSearch result normalization.
+
+Without the fix, a response missing ``organic_results`` raises a KeyError,
+and a single result missing ``title``/``link``/``snippet`` raises a KeyError
+that aborts the whole ``search()`` call via the broad except — dropping every
+other valid hit on the page.
+"""
+import importlib.util
+import os
+import pathlib
+from unittest.mock import patch
+
+_SEARCHAPI_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher" / "retrievers" / "searchapi" / "searchapi.py"
+)
+_spec = importlib.util.spec_from_file_location("_searchapi_under_test", _SEARCHAPI_PATH)
+_searchapi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_searchapi)
+SearchApiSearch = _searchapi.SearchApiSearch
+
+
+class _FakeResp:
+    def __init__(self, payload, status_code=200):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+@patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"})
+def test_searchapi_skips_results_missing_keys():
+    payload = {
+        "organic_results": [
+            {"title": "A", "link": "https://a.example", "snippet": "sa"},
+            {"title": "B", "link": "https://b.example"},  # missing snippet
+            {"link": "https://c.example"},  # missing title + snippet
+            {"title": "D", "snippet": "sd"},  # missing link -> skipped
+            "not-a-dict",
+        ]
+    }
+    with patch.object(_searchapi.requests, "get", return_value=_FakeResp(payload)):
+        results = SearchApiSearch("q").search()
+
+    assert len(results) == 3
+    assert results[0] == {"title": "A", "href": "https://a.example", "body": "sa"}
+    assert results[1] == {"title": "B", "href": "https://b.example", "body": ""}
+    assert results[2] == {"title": "", "href": "https://c.example", "body": ""}
+
+
+@patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"})
+def test_searchapi_no_organic_results_returns_empty():
+    with patch.object(_searchapi.requests, "get", return_value=_FakeResp({})):
+        assert SearchApiSearch("q").search() == []
+
+
+@patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"})
+def test_searchapi_null_organic_results_returns_empty():
+    with patch.object(
+        _searchapi.requests, "get", return_value=_FakeResp({"organic_results": None})
+    ):
+        assert SearchApiSearch("q").search() == []
+
+
+@patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"})
+def test_searchapi_skips_youtube_links():
+    payload = {
+        "organic_results": [
+            {"title": "YT", "link": "https://www.youtube.com/watch?v=x", "snippet": "v"},
+            {"title": "OK", "link": "https://ok.example", "snippet": "body"},
+        ]
+    }
+    with patch.object(_searchapi.requests, "get", return_value=_FakeResp(payload)):
+        results = SearchApiSearch("q").search()
+    assert results == [{"title": "OK", "href": "https://ok.example", "body": "body"}]


### PR DESCRIPTION
## Summary

- SearchApi retriever no longer KeyErrors on missing/null organic_results or partial organic hits missing title/link/snippet.
- One malformed hit can no longer abort the whole page of search results (same hardening pattern as SerpApi/Serper).

## Motivation

Sibling retrievers (serpapi, serper) already normalize API payloads with .get() so a single incomplete organic result does not throw KeyError and discard every other hit via the broad except. SearchApiSearch still indexed with strict key access on organic_results / title / link / snippet.

An error payload without organic_results, JSON null list, or a hit missing snippet/title raised KeyError, which the surrounding except Exception caught — returning [] even when other hits on the same response were valid.

## Verification

- python -m pytest tests/test_searchapi_malformed_results.py -v — 4 passed, 0 failed
- Fail-without-fix: bare result["link"] / ["organic_results"] KeyError under the same payloads
- Did NOT change: auth header path, engine defaults, max_results semantics beyond validity of list length

## Real behavior proof

```
tests/test_searchapi_malformed_results.py::test_searchapi_skips_results_missing_keys PASSED
tests/test_searchapi_malformed_results.py::test_searchapi_no_organic_results_returns_empty PASSED
tests/test_searchapi_malformed_results.py::test_searchapi_null_organic_results_returns_empty PASSED
tests/test_searchapi_malformed_results.py::test_searchapi_skips_youtube_links PASSED
```
