### PR TITLE
fix(scraper): harden TavilyExtract against partial API payloads

### DIFF
--- a/gpt_researcher/scraper/tavily_extract/tavily_extract.py
+++ b/gpt_researcher/scraper/tavily_extract/tavily_extract.py
@@ -37,23 +37,37 @@ class TavilyExtract:
 
         try:
             response = self.tavily_client.extract(urls=self.link)
-            if response['failed_results']:
+            if not isinstance(response, dict):
                 return "", [], ""
 
-            # Parse the HTML content of the response to create a BeautifulSoup object for the utility functions
-            response_bs = self.session.get(self.link, timeout=4)
-            soup = BeautifulSoup(
-                response_bs.content, "lxml", from_encoding=response_bs.encoding
-            )
+            # failed_results may be missing, null, or a non-empty list.
+            failed = response.get("failed_results") or []
+            if failed:
+                return "", [], ""
 
-            # Since only a single link is provided to tavily_client, the results will contain only one entry.
-            content = response['results'][0]['raw_content']
+            results = response.get("results") or []
+            if not isinstance(results, list) or not results:
+                return "", [], ""
+            first = results[0]
+            if not isinstance(first, dict):
+                return "", [], ""
+            # Prefer raw_content; never KeyError if the extract payload is partial.
+            content = first.get("raw_content") or ""
+            if not content:
+                return "", [], ""
 
-            # Get relevant images using the utility function
-            image_urls = get_relevant_images(soup, self.link)
-
-            # Extract the title using the utility function
-            title = extract_title(soup)
+            # Optional HTML side-path for images/title. session may be unset
+            # (constructor default session=None) — brick that off rather than
+            # AttributeError inside the broad except.
+            image_urls = []
+            title = ""
+            if self.session is not None:
+                response_bs = self.session.get(self.link, timeout=4)
+                soup = BeautifulSoup(
+                    response_bs.content, "lxml", from_encoding=response_bs.encoding
+                )
+                image_urls = get_relevant_images(soup, self.link)
+                title = extract_title(soup) or ""
 
             return content, image_urls, title
 

--- a/tests/test_tavily_extract_malformed.py
+++ b/tests/test_tavily_extract_malformed.py
@@ -1,0 +1,118 @@
+"""TavilyExtract must tolerate partial/malformed extract API payloads.
+
+Without the fix, missing ``failed_results`` / ``results`` / ``raw_content``
+keys KeyError into the broad except and return empty — and when
+``session is None`` (constructor default) AttributeError on session.get
+discards extract content that *is* present.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+# Stub optional import-time deps so this unit test runs without bs4/tavily.
+_bs4 = types.ModuleType("bs4")
+_bs4.BeautifulSoup = MagicMock()
+sys.modules.setdefault("bs4", _bs4)
+
+_utils = types.ModuleType("gpt_researcher.scraper.utils")
+_utils.get_relevant_images = MagicMock(return_value=[])
+_utils.extract_title = MagicMock(return_value="")
+# Parent packages for relative import resolution when loading the module by path
+for name in (
+    "gpt_researcher",
+    "gpt_researcher.scraper",
+    "gpt_researcher.scraper.utils",
+):
+    sys.modules.setdefault(name, types.ModuleType(name))
+sys.modules["gpt_researcher.scraper.utils"] = _utils
+
+_fake_tavily = types.ModuleType("tavily")
+
+
+class _FakeClient:
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self._response = None
+
+    def extract(self, urls=None):
+        return self._response
+
+
+_fake_tavily.TavilyClient = _FakeClient
+sys.modules["tavily"] = _fake_tavily
+
+import importlib.util
+import pathlib
+
+_path = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "scraper"
+    / "tavily_extract"
+    / "tavily_extract.py"
+)
+_spec = importlib.util.spec_from_file_location("_tavily_extract_ut", _path)
+_mod = importlib.util.module_from_spec(_spec)
+# Provide package context for relative imports inside the module
+_mod.__package__ = "gpt_researcher.scraper.tavily_extract"
+sys.modules["_tavily_extract_ut"] = _mod
+_spec.loader.exec_module(_mod)
+TavilyExtract = _mod.TavilyExtract
+
+
+def _build(response, session=None):
+    os.environ["TAVILY_API_KEY"] = "test-key"
+    inst = TavilyExtract("https://example.com/a", session=session)
+    inst.tavily_client._response = response
+    return inst
+
+
+def test_successful_payload_returns_content_without_session():
+    inst = _build(
+        {
+            "failed_results": [],
+            "results": [{"raw_content": "hello world"}],
+        },
+        session=None,
+    )
+    content, images, title = inst.scrape()
+    assert content == "hello world"
+    assert images == []
+    assert title == ""
+
+
+def test_missing_failed_results_key_still_returns_content():
+    inst = _build({"results": [{"raw_content": "body"}]}, session=None)
+    content, _, _ = inst.scrape()
+    assert content == "body"
+
+
+def test_null_results_returns_empty():
+    inst = _build({"failed_results": [], "results": None})
+    assert inst.scrape() == ("", [], "")
+
+
+def test_empty_results_returns_empty():
+    inst = _build({"failed_results": [], "results": []})
+    assert inst.scrape() == ("", [], "")
+
+
+def test_failed_results_present_returns_empty():
+    inst = _build(
+        {
+            "failed_results": [{"url": "https://example.com/a"}],
+            "results": [{"raw_content": "should be ignored"}],
+        }
+    )
+    assert inst.scrape() == ("", [], "")
+
+
+def test_missing_raw_content_key_returns_empty():
+    inst = _build(
+        {"failed_results": [], "results": [{"url": "https://example.com/a"}]}
+    )
+    assert inst.scrape() == ("", [], "")


### PR DESCRIPTION
## Summary

- TavilyExtract no longer KeyErrors on missing `failed_results` / `results` / `raw_content`.
- `session=None` (constructor default) no longer AttributeErrors on `session.get` before returning valid extract content.

## Motivation

`scrape()` used strict dict indexing (`response['failed_results']`, `response['results'][0]['raw_content']`) and always called `self.session.get(...)`. Partial extract payloads or callers that only need text (no session) threw into the broad except and returned empty even when `raw_content` was present.

## Verification

- `python -m pytest tests/test_tavily_extract_malformed.py -v` — **6 passed**, 0 failed
- Did NOT change: Tavily client construction, failure when `failed_results` is non-empty, empty return contract on total failure

## Real behavior proof

```
tests/test_tavily_extract_malformed.py::test_successful_payload_returns_content_without_session PASSED
tests/test_tavily_extract_malformed.py::test_missing_failed_results_key_still_returns_content PASSED
tests/test_tavily_extract_malformed.py::test_null_results_returns_empty PASSED
tests/test_tavily_extract_malformed.py::test_empty_results_returns_empty PASSED
tests/test_tavily_extract_malformed.py::test_failed_results_present_returns_empty PASSED
tests/test_tavily_extract_malformed.py::test_missing_raw_content_key_returns_empty PASSED
```
