### PR TITLE
fix(scraper): guard process_scraped_data against partial items

### DIFF
--- a/gpt_researcher/actions/web_scraping.py
+++ b/gpt_researcher/actions/web_scraping.py
@@ -35,8 +35,11 @@ async def scrape_urls(
         scraper = Scraper(urls, user_agent, cfg.scraper, worker_pool=worker_pool)
         scraped_data = await scraper.run()
         for item in scraped_data:
-            if 'image_urls' in item:
-                images.extend(item['image_urls'])
+            if not isinstance(item, dict):
+                continue
+            image_urls = item.get("image_urls")
+            if image_urls:
+                images.extend(image_urls)
     except Exception as e:
         print(f"{Fore.RED}Error in scrape_urls: {e}{Style.RESET_ALL}")
     finally:
@@ -95,12 +98,17 @@ async def process_scraped_data(scraped_data: list[dict[str, Any]], config: Confi
     """
     processed_data = []
     for item in scraped_data:
-        if item['status'] == 'success':
-            main_content = await extract_main_content(item['content'])
+        if not isinstance(item, dict):
+            continue
+        # Partial scraper payloads historically used strict key access and
+        # crashed mid-batch; skip/or re-emit guards keep the rest of the run.
+        status = item.get("status")
+        if status == "success":
+            main_content = await extract_main_content(item.get("content") or "")
             processed_data.append({
-                'url': item['url'],
-                'content': main_content,
-                'status': 'success'
+                "url": item.get("url") or "",
+                "content": main_content,
+                "status": "success",
             })
         else:
             processed_data.append(item)

--- a/tests/test_process_scraped_data_guards.py
+++ b/tests/test_process_scraped_data_guards.py
@@ -1,0 +1,77 @@
+"""process_scraped_data must not KeyError on partial scrape dicts.
+
+Strict item['status'] / item['content'] / item['url'] access aborted
+post-processing the rest of the batch when one entry was partial.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _mod(name: str):
+    m = types.ModuleType(name)
+    sys.modules[name] = m
+    return m
+
+
+sys.modules.setdefault(
+    "colorama",
+    types.SimpleNamespace(
+        Fore=types.SimpleNamespace(RED=""),
+        Style=types.SimpleNamespace(RESET_ALL=""),
+    ),
+)
+_mod("gpt_researcher")
+_mod("gpt_researcher.utils")
+_workers = _mod("gpt_researcher.utils.workers")
+_workers.WorkerPool = object
+_logger = _mod("gpt_researcher.utils.logger")
+_logger.get_formatted_logger = lambda: MagicMock()
+_scraper = _mod("gpt_researcher.scraper")
+_scraper.Scraper = object
+_mod("gpt_researcher.config")
+_cfgm = _mod("gpt_researcher.config.config")
+_cfgm.Config = object
+_mod("gpt_researcher.actions")
+
+web_path = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "actions"
+    / "web_scraping.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "gpt_researcher.actions.web_scraping",
+    web_path,
+)
+ws = importlib.util.module_from_spec(spec)
+sys.modules["gpt_researcher.actions.web_scraping"] = ws
+ws.__package__ = "gpt_researcher.actions"
+spec.loader.exec_module(ws)
+
+
+def test_process_scraped_data_success_and_partial():
+    data = [
+        {"status": "success", "url": "https://a.example", "content": "<p>hi</p>"},
+        {"status": "error", "url": "https://b.example", "error": "x"},
+        "not-a-dict",
+        {"status": "success"},  # missing url/content
+    ]
+
+    out = asyncio.run(ws.process_scraped_data(data, config=None))
+    assert out[0]["status"] == "success"
+    assert out[0]["url"] == "https://a.example"
+    assert out[0]["content"] == "<p>hi</p>"
+    assert out[1]["status"] == "error"
+    assert out[2] == {"url": "", "content": "", "status": "success"}
+
+
+def test_process_scraped_data_missing_status_not_success():
+    data = [{"url": "https://c.example", "content": "x"}]
+    out = asyncio.run(ws.process_scraped_data(data, config=None))
+    assert out == data


### PR DESCRIPTION
## Summary

- `process_scraped_data` uses safe dict access for status/content/url.
- Non-dict scrape entries are skipped; image_urls aggregation no longer assumes every item is a dict.

## Motivation

Post-scrape processing used strict key access. A single partial item without `status`/`content`/`url` raised KeyError mid-list and aborted processing of remaining successful scrapes.

## Verification

- `python -m pytest tests/test_process_scraped_data_guards.py -v` — **2 passed**
- Did NOT change: success path content extraction for well-formed items; non-success items still re-emitted as-is

## Real behavior proof

```
tests/test_process_scraped_data_guards.py::test_process_scraped_data_success_and_partial PASSED
tests/test_process_scraped_data_guards.py::test_process_scraped_data_missing_status_not_success PASSED
```
