### PR TITLE
fix(actions): move imports above _normalize_sub_queries to fix NameError on startup

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,6 +1,11 @@
 import json_repair
+import logging
+from typing import Any, List, Dict
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
+from ..utils.llm import create_chat_completion
+from ..prompts import PromptFamily
+from ..config import Config
 
 
 def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
@@ -32,11 +37,6 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     if not queries and fallback_query.strip():
         return [fallback_query.strip()]
     return queries
-from ..utils.llm import create_chat_completion
-from ..prompts import PromptFamily
-from typing import Any, List, Dict
-from ..config import Config
-import logging
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## What

Moves the import block in `gpt_researcher/actions/query_processing.py` to the top of the file.

## Why

bcc1eac0 added `_normalize_sub_queries` at the top of the file, above the imports.
Its `Any`/`List` annotations are evaluated at definition time, so importing the module raises:

```
NameError: name 'Any' is not defined. Did you mean: 'any'?
```

This breaks server startup (`python -m uvicorn main:app`) on a fresh clone of `main`, i.e. the README quick-start path.

No behavior change - imports are just moved above the function that uses them.

## Verified

- `python -c "from backend.server.app import app"` imports cleanly
- Server starts and serves the frontend on `localhost:8000`
