### PR TITLE
fix(searchapi): tolerate missing keys on organic results

### DIFF
--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -61,22 +61,31 @@ class SearchApiSearch():
             response = requests.get(encoded_url, headers=headers, timeout=20)
             if response.status_code == 200:
                 search_results = response.json()
-                if search_results:
-                    results = search_results["organic_results"]
-                    results_processed = 0
-                    for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
-                        if results_processed >= max_results:
-                            break
-                        search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
-                        }
-                        search_response.append(search_result)
-                        results_processed += 1
+                if not isinstance(search_results, dict):
+                    return []
+                # Error / empty payloads may omit organic_results or set it to null.
+                results = search_results.get("organic_results") or []
+                if not isinstance(results, list):
+                    return []
+                results_processed = 0
+                for result in results:
+                    if results_processed >= max_results:
+                        break
+                    if not isinstance(result, dict):
+                        continue
+                    link = result.get("link") or ""
+                    if not link:
+                        continue
+                    # skip youtube results
+                    if "youtube.com" in link:
+                        continue
+                    search_result = {
+                        "title": result.get("title") or "",
+                        "href": link,
+                        "body": result.get("snippet") or "",
+                    }
+                    search_response.append(search_result)
+                    results_processed += 1
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_searchapi_malformed_results.py
+++ b/tests/test_searchapi_malformed_results.py
@@ -1,0 +1,50 @@
+"""SearchApiSearch must tolerate partial / non-list organic payloads."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.searchapi.searchapi import SearchApiSearch
+
+
+def _search_with_payload(payload):
+    with patch.dict("os.environ", {"SEARCHAPI_API_KEY": "test-key"}):
+        retriever = SearchApiSearch("q")
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    with patch("gpt_researcher.retrievers.searchapi.searchapi.requests.get", return_value=resp):
+        return retriever.search(max_results=5)
+
+
+def test_searchapi_skips_results_missing_keys():
+    out = _search_with_payload(
+        {
+            "organic_results": [
+                {"title": "Good", "link": "https://ok.example", "snippet": "s"},
+                {"title": "No link"},  # missing link
+                "not-a-dict",
+            ]
+        }
+    )
+    assert out == [
+        {"title": "Good", "href": "https://ok.example", "body": "s"},
+    ]
+
+
+def test_searchapi_no_organic_results_returns_empty():
+    assert _search_with_payload({"search_metadata": {}}) == []
+
+
+def test_searchapi_null_organic_results_returns_empty():
+    assert _search_with_payload({"organic_results": None}) == []
+
+
+def test_searchapi_skips_youtube_links():
+    out = _search_with_payload(
+        {
+            "organic_results": [
+                {"title": "yt", "link": "https://www.youtube.com/watch?v=1", "snippet": "x"},
+                {"title": "Good", "link": "https://ok.example", "snippet": "s"},
+            ]
+        }
+    )
+    assert out == [{"title": "Good", "href": "https://ok.example", "body": "s"}]


### PR DESCRIPTION
## Summary

- SearchApi no longer KeyErrors on missing/null organic_results or partial organic hits.
- Same hardening pattern as SerpApi/Serper.

## Motivation

Strict key access on organic_results/title/link/snippet discarded entire result sets when one hit was partial (caught by broad except → empty list).

## Verification

- .venv/bin/python -m pytest tests/test_searchapi_malformed_results.py -v — 4 passed

## Real behavior proof

4 tests PASSED (skip missing keys, no organic_results, null organic_results, youtube filter).
