### PR TITLE
fix(bocha): skip non-dict and href-less search hits

### DIFF
--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -56,15 +56,23 @@ class BoChaSearch():
         results = (
             ((json_response or {}).get("data") or {}).get("webPages") or {}
         ).get("value") or []
+        if not isinstance(results, list):
+            return []
+
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
+            if not isinstance(result, dict):
+                continue
+            href = result.get("url") or ""
+            if not href:
+                continue
             search_results.append(
                 {
-                    "title": result.get("name", ""),
-                    "href": result.get("url", ""),
-                    "body": result.get("snippet", ""),
+                    "title": result.get("name") or "",
+                    "href": href,
+                    "body": result.get("snippet") or "",
                 }
             )
 

--- a/tests/test_bocha_malformed_results.py
+++ b/tests/test_bocha_malformed_results.py
@@ -1,0 +1,36 @@
+"""BoChaSearch must skip non-dict / href-less organic hits."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.bocha.bocha import BoChaSearch
+
+
+def _search(payload):
+    with patch.dict("os.environ", {"BOCHA_API_KEY": "k"}):
+        r = BoChaSearch("q")
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = payload
+    with patch("gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp):
+        return r.search(max_results=5)
+
+
+def test_bocha_skips_non_dict_and_missing_url():
+    out = _search(
+        {
+            "data": {
+                "webPages": {
+                    "value": [
+                        {"name": "Good", "url": "https://ok.example", "snippet": "s"},
+                        "x",
+                        {"name": "NoURL", "snippet": "s"},
+                    ]
+                }
+            }
+        }
+    )
+    assert out == [{"title": "Good", "href": "https://ok.example", "body": "s"}]
+
+
+def test_bocha_non_list_value_returns_empty():
+    assert _search({"data": {"webPages": {"value": {"not": "list"}}}}) == []


### PR DESCRIPTION
## Summary

- BoChaSearch skips non-dict organic rows and results without a URL instead of AttributeError/empty-href entries.
- Non-list webPages.value returns [].

## Motivation

The walk for data.webPages.value was defensive, but the row loop assumed every element was a mapping and always emitted href even when blank. Partial API rows can break the shared retriever contract for consumer code that expects real URLs.

## Verification

- .venv/bin/python -m pytest tests/test_bocha_malformed_results.py -v — 2 passed

## Real behavior proof

tests/test_bocha_malformed_results.py both PASSED.
