### PR TITLE
fix(brave): guard non-dict web/results payloads

### DIFF
--- a/gpt_researcher/retrievers/brave/brave.py
+++ b/gpt_researcher/retrievers/brave/brave.py
@@ -62,7 +62,14 @@ class BraveSearch:
             response = requests.get(url, headers=headers, params=params, timeout=20)
             response.raise_for_status()
             search_results = response.json()
-            results = search_results.get("web", {}).get("results", [])
+            if not isinstance(search_results, dict):
+                return []
+            web = search_results.get("web") or {}
+            if not isinstance(web, dict):
+                return []
+            results = web.get("results") or []
+            if not isinstance(results, list):
+                return []
         except Exception as e:
             self.logger.error(
                 f"Error fetching Brave search results: {e}. Resulting in empty response."
@@ -73,13 +80,15 @@ class BraveSearch:
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
+            if not isinstance(result, dict):
+                continue
             url = result.get("url")
             if not url:
                 continue
             search_result = {
-                "title": result.get("title", ""),
+                "title": result.get("title") or "",
                 "href": url,
-                "body": result.get("description", ""),
+                "body": result.get("description") or "",
             }
             search_results.append(search_result)
 

--- a/tests/test_brave_malformed_results.py
+++ b/tests/test_brave_malformed_results.py
@@ -1,0 +1,38 @@
+"""BraveSearch must tolerate non-dict web/results payloads."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.brave.brave import BraveSearch
+
+
+def _search(payload):
+    with patch.dict("os.environ", {"BRAVE_API_KEY": "k"}):
+        r = BraveSearch("q")
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = payload
+    with patch("gpt_researcher.retrievers.brave.brave.requests.get", return_value=resp):
+        return r.search(max_results=5)
+
+
+def test_brave_skips_non_dict_rows():
+    out = _search(
+        {
+            "web": {
+                "results": [
+                    {"title": "G", "url": "https://ok.example", "description": "d"},
+                    "bad",
+                    {"title": "n", "description": "d"},
+                ]
+            }
+        }
+    )
+    assert out == [{"title": "G", "href": "https://ok.example", "body": "d"}]
+
+
+def test_brave_null_web_returns_empty():
+    assert _search({"web": None}) == []
+
+
+def test_brave_non_list_results_returns_empty():
+    assert _search({"web": {"results": {"x": 1}}}) == []


### PR DESCRIPTION
## Summary

- BraveSearch treats non-dict JSON, null web, or non-list results as empty rather than AttributeError.
- Skips non-dict organic rows.

## Verification

- .venv/bin/python -m pytest tests/test_brave_malformed_results.py -v — 3 passed

## Real behavior proof

All three malformed-payload tests PASSED.
