### PR TITLE
fix(crw): skip non-dict sources in search results

### DIFF
--- a/gpt_researcher/retrievers/crw/crw.py
+++ b/gpt_researcher/retrievers/crw/crw.py
@@ -108,18 +108,23 @@ class CRWRetriever:
             # Search the query
             results = self._search(self.query, max_results=max_results)
             sources = results.get("data") or []
-            if not sources:
+            if not isinstance(sources, list) or not sources:
                 raise Exception("No results found with fastCRW API search.")
             # Return the results. A source missing "url" is unusable, so skip it
             # rather than raising a KeyError that discards the whole result set.
-            search_response = [
-                {
-                    "href": obj["url"],
-                    "body": obj.get("markdown") or obj.get("description", ""),
-                }
-                for obj in sources
-                if obj.get("url")
-            ]
+            search_response = []
+            for obj in sources:
+                if not isinstance(obj, dict):
+                    continue
+                href = obj.get("url") or ""
+                if not href:
+                    continue
+                search_response.append(
+                    {
+                        "href": href,
+                        "body": obj.get("markdown") or obj.get("description") or "",
+                    }
+                )
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_crw_malformed_results.py
+++ b/tests/test_crw_malformed_results.py
@@ -1,0 +1,32 @@
+"""CRWRetriever must skip non-dict sources."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.crw.crw import CRWRetriever
+
+
+def _search(envelope):
+    r = CRWRetriever("q", headers={"crw_api_key": "k"})
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = envelope
+    with patch("gpt_researcher.retrievers.crw.crw.requests.post", return_value=resp):
+        return r.search(max_results=5)
+
+
+def test_crw_skips_non_dict_sources():
+    out = _search(
+        {
+            "success": True,
+            "data": [
+                {"url": "https://ok.example", "description": "d"},
+                "x",
+                {"description": "no url"},
+            ],
+        }
+    )
+    assert out == [{"href": "https://ok.example", "body": "d"}]
+
+
+def test_crw_non_list_data_returns_empty():
+    assert _search({"success": True, "data": {"url": "x"}}) == []


### PR DESCRIPTION
## Summary

- CRWRetriever skips non-dict source rows and requires data to be a list.
- Avoids AttributeError on obj.get when API mixes types into data.

## Verification

- .venv/bin/python -m pytest tests/test_crw_malformed_results.py -v — 2 passed

## Real behavior proof

Both crw malformed-result tests PASSED.
