### PR TITLE
fix: pass llm_kwargs to LLM calls in deep research skill

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -283,7 +283,8 @@ class DeepResearchSkill:
             llm_provider=self.researcher.cfg.strategic_llm_provider,
             model=self.researcher.cfg.strategic_llm_model,
             reasoning_effort=self.researcher.cfg.reasoning_effort,
-            temperature=0.4
+            temperature=0.4,
+            llm_kwargs=self.researcher.cfg.llm_kwargs
         )
 
         return parse_search_queries_response(response, num_queries)
@@ -336,7 +337,8 @@ Return ONLY a JSON object using this exact schema:
             llm_provider=self.researcher.cfg.strategic_llm_provider,
             model=self.researcher.cfg.strategic_llm_model,
             reasoning_effort=ReasoningEfforts.High.value,
-            temperature=0.4
+            temperature=0.4,
+            llm_kwargs=self.researcher.cfg.llm_kwargs
         )
 
         return parse_follow_up_questions_response(response, num_questions)
@@ -369,7 +371,8 @@ Return ONLY a JSON object using this exact schema:
             temperature=0.4,
             reasoning_effort=ReasoningEfforts.High.value,
             # Needs headroom for reasoning tokens on reasoning models
-            max_tokens=4000
+            max_tokens=4000,
+            llm_kwargs=self.researcher.cfg.llm_kwargs
         )
 
         return parse_research_results_response(response, num_learnings)


### PR DESCRIPTION
## What

`skills/deep_research.py` makes three `create_chat_completion` calls without passing `llm_kwargs`, unlike the rest of the codebase (`actions/query_processing.py`, `skills/curator.py`, `skills/image_generator.py` all pass `cfg.llm_kwargs`). As a result, anything configured via the `LLM_KWARGS` env is silently dropped — but only in deep research mode.

## Impact / how I hit it

Running gpt-researcher against a local OpenAI-compatible gateway that needs `LLM_KWARGS='{"use_responses_api":false}'`:

- **Standard research works** — the override reaches langchain-openai and calls go to `/v1/chat/completions`.
- **Deep research always fails** — langchain-openai auto-enables the Responses API for newer OpenAI model names, the dropped override can't prevent it, every strategic-LLM call hits `/v1/responses`, and the run dies after 10 retries with `Failed to get response from openai API` (client-side symptom: `'str' object has no attribute 'error'`).

Any other `llm_kwargs`-dependent deployment (custom base URLs, org headers, etc.) would degrade the same way in deep mode.

## Fix

Pass `llm_kwargs=self.researcher.cfg.llm_kwargs` at the three call sites, matching the existing convention. No behavior change when `llm_kwargs` is unset (the default `None` is ignored by `create_chat_completion`).

## Tested

Reproduced locally against an OpenAI-compatible gateway: deep research fails on every strategic-LLM call before the patch; after the patch a full deep run completes (60 sources, all LLM calls on `/v1/chat/completions`). Standard mode unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)