### PR TITLE
fix(bing): skip non-dict results and empty URLs

### DIFF
--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -79,17 +79,25 @@ class BingSearch():
             self.logger.warning(f"No search results found for query: {self.query}")
             return []
 
-        # Normalize the results to match the format of the other search APIs
+        # Normalize the results to match the format of the other search APIs.
+        # Skip non-dict rows (API drift / error stubs) and empty URLs rather
+        # than AttributeError/'NoneType' crashes mid-research.
         search_response = []
+        if not isinstance(results, list):
+            return []
         for result in results:
-            url = result.get("url", "")
+            if not isinstance(result, dict):
+                continue
+            url = result.get("url") or ""
+            if not url:
+                continue
             # skip youtube results
             if "youtube.com" in url:
                 continue
             search_response.append({
-                "title": result.get("name", ""),
+                "title": result.get("name") or "",
                 "href": url,
-                "body": result.get("snippet", ""),
+                "body": result.get("snippet") or "",
             })
 
         return search_response

--- a/tests/test_bing_retriever_malformed.py
+++ b/tests/test_bing_retriever_malformed.py
@@ -1,8 +1,8 @@
 """Regression tests for BingSearch result normalization.
 
-Without the fix, a single result missing an expected key (``url``/``name``/
-``snippet``) raises a KeyError that aborts the whole ``search()`` call, and a
-response without a ``webPages`` block raises a KeyError instead of returning [].
+Without the fix, a single non-dict or null result raises AttributeError that
+aborts the whole ``search()`` call, and a response without a ``webPages``
+block should return [].
 """
 import importlib.util
 import json
@@ -45,6 +45,27 @@ def test_bing_skips_results_missing_keys():
     assert results[0] == {"title": "A", "href": "https://a.example", "body": "sa"}
     assert results[1]["body"] == ""
     assert results[2]["title"] == ""
+
+
+@patch.dict(os.environ, {"BING_API_KEY": "test-key"})
+def test_bing_skips_non_dict_and_empty_url():
+    payload = {
+        "webPages": {
+            "value": [
+                "not-a-dict",
+                None,
+                {"name": "No URL"},
+                {"name": "Ok", "url": "https://ok.example", "snippet": "body"},
+                {"name": "YT", "url": "https://youtube.com/watch?v=1"},
+            ]
+        }
+    }
+    with patch.object(_bing.requests, "get", return_value=_FakeResp(payload)):
+        results = BingSearch("q").search()
+
+    assert results == [
+        {"title": "Ok", "href": "https://ok.example", "body": "body"},
+    ]
 
 
 @patch.dict(os.environ, {"BING_API_KEY": "test-key"})


### PR DESCRIPTION
## Summary

- BingSearch.search() assumed every webPages.value entry was a dict with a usable url.
- Null/string/incomplete rows are skipped; missing title/snippet default to empty string so one bad result cannot abort the research run.

## Motivation

Sibling retrievers already guard with isinstance(result, dict) before .get(). Bing did not, so a single non-dict value raised AttributeError mid-loop.

## Verification

```
python3 -m pytest tests/test_bing_retriever_malformed.py -v
# 3 passed
```

## Test plan

- [x] Unit tests cover missing keys, non-dict/null rows, empty webPages
- [ ] CI green
