### PR TITLE
fix(bocha): skip non-dict results and empty URLs

### DIFF
--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -58,13 +58,22 @@ class BoChaSearch():
         ).get("value") or []
         search_results = []
 
-        # Normalize the results to match the format of the other search APIs
+        if not isinstance(results, list):
+            return []
+
+        # Normalize the results to match the format of the other search APIs.
+        # Skip non-dict rows / empty URLs; default missing fields to "".
         for result in results:
+            if not isinstance(result, dict):
+                continue
+            href = result.get("url") or ""
+            if not href:
+                continue
             search_results.append(
                 {
-                    "title": result.get("name", ""),
-                    "href": result.get("url", ""),
-                    "body": result.get("snippet", ""),
+                    "title": result.get("name") or "",
+                    "href": href,
+                    "body": result.get("snippet") or "",
                 }
             )
 

--- a/tests/test_bocha_error_handling.py
+++ b/tests/test_bocha_error_handling.py
@@ -1,22 +1,32 @@
 """Regression tests for BoChaSearch robustness.
 
 Unlike every sibling retriever (which returns ``[]`` and uses ``.get()`` on a
-bad/empty payload), BoChaSearch indexed ``json_response["data"]["webPages"]
-["value"]`` directly and had no error handling. A non-200 response, a body
-that doesn't decode as JSON, or a payload missing those keys crashed the whole
-research run with an unhandled ``KeyError`` / ``JSONDecodeError``.
+bad/empty payload), BoChaSearch used to index wrapper keys diectly and crash.
+Today network/JSON errors return []; this suite also guards non-dict value rows.
 """
 
+import importlib.util
 import os
+import pathlib
 from unittest.mock import MagicMock, patch
 
-import pytest
+import requests
+
+_BOCHA_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "bocha"
+    / "bocha.py"
+)
+_spec = importlib.util.spec_from_file_location("_bocha_under_test", _BOCHA_PATH)
+_bocha = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_bocha)
+BoChaSearch = _bocha.BoChaSearch
 
 
 def _make_search():
     with patch.dict(os.environ, {"BOCHA_API_KEY": "test-key"}):
-        from gpt_researcher.retrievers.bocha.bocha import BoChaSearch
-
         return BoChaSearch("test query")
 
 
@@ -26,18 +36,15 @@ def test_missing_keys_returns_empty_list():
     resp.raise_for_status.return_value = None
     resp.json.return_value = {"unexpected": "shape"}  # no data.webPages.value
 
-    with patch(
-        "gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp
-    ):
+    with patch.object(_bocha.requests, "post", return_value=resp):
         assert search.search() == []
 
 
 def test_request_exception_returns_empty_list():
-    import requests
-
     search = _make_search()
-    with patch(
-        "gpt_researcher.retrievers.bocha.bocha.requests.post",
+    with patch.object(
+        _bocha.requests,
+        "post",
         side_effect=requests.RequestException("boom"),
     ):
         assert search.search() == []
@@ -58,12 +65,35 @@ def test_valid_payload_is_normalized():
         }
     }
 
-    with patch(
-        "gpt_researcher.retrievers.bocha.bocha.requests.post", return_value=resp
-    ):
+    with patch.object(_bocha.requests, "post", return_value=resp):
         results = search.search()
 
     assert results == [
         {"title": "T", "href": "https://e.com", "body": "B"},
         {"title": "T2", "href": "https://e2.com", "body": ""},
+    ]
+
+
+def test_bocha_skips_non_dict_and_empty_url():
+    search = _make_search()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "data": {
+            "webPages": {
+                "value": [
+                    "not-a-dict",
+                    None,
+                    {"name": "No URL"},
+                    {"name": "Ok", "url": "https://ok.example", "snippet": "body"},
+                ]
+            }
+        }
+    }
+
+    with patch.object(_bocha.requests, "post", return_value=resp):
+        results = search.search()
+
+    assert results == [
+        {"title": "Ok", "href": "https://ok.example", "body": "body"},
     ]


### PR DESCRIPTION
## Summary

- BoChaSearch already resilient on network/JSON/wrapper shape, but still called .get on every webPages.value element.
- Skip non-dict/null rows and empty URLs; default missing name/snippet to empty strings.

## Motivation

Parity with Google/Serper/DuckDuckGo retrievers. One bad list element must not AttributeError the whole research loop.

## Verification

```
python3 -m pytest tests/test_bocha_error_handling.py -v
# 4 passed
```

## Test plan

- [x] Local unit tests
- [ ] CI green
