### PR TITLE
fix(serpapi): skip non-dict organic_results rows

### DIFF
--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -64,11 +64,15 @@ class SerpApiSearch():
                     # or a query that matched nothing) has no "organic_results"
                     # key; default to [] instead of raising KeyError.
                     results = search_results.get("organic_results") or []
+                    if not isinstance(results, list):
+                        results = []
                     results_processed = 0
                     for result in results:
                         if results_processed >= max_results:
                             break
-                        link = result.get("link")
+                        if not isinstance(result, dict):
+                            continue
+                        link = result.get("link") or ""
                         # A result without a link is unusable; skip it rather
                         # than emitting an entry with href=None.
                         if not link:
@@ -77,9 +81,9 @@ class SerpApiSearch():
                         if "youtube.com" in link:
                             continue
                         search_result = {
-                            "title": result.get("title", ""),
+                            "title": result.get("title") or "",
                             "href": link,
-                            "body": result.get("snippet", ""),
+                            "body": result.get("snippet") or "",
                         }
                         search_response.append(search_result)
                         results_processed += 1

--- a/tests/test_serpapi_malformed_results.py
+++ b/tests/test_serpapi_malformed_results.py
@@ -1,0 +1,57 @@
+"""SerpApiSearch organic_results must tolerate non-dict / incomplete rows."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+from unittest.mock import MagicMock, patch
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "serpapi"
+    / "serpapi.py"
+)
+_spec = importlib.util.spec_from_file_location("_serpapi_under_test", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+SerpApiSearch = _mod.SerpApiSearch
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+def test_serpapi_skips_non_dict_and_empty_link():
+    payload = {
+        "organic_results": [
+            "not-a-dict",
+            None,
+            {"title": "No link"},
+            {
+                "title": "Ok",
+                "link": "https://ok.example",
+                "snippet": "body",
+            },
+            {
+                "title": "YT",
+                "link": "https://youtube.com/watch?v=1",
+                "snippet": "y",
+            },
+        ]
+    }
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    with patch.object(_mod.requests, "get", return_value=resp):
+        out = SerpApiSearch("q").search(max_results=10)
+
+    assert out == [
+        {"title": "Ok", "href": "https://ok.example", "body": "body"},
+    ]
+
+
+@patch.dict(os.environ, {"SERPAPI_API_KEY": "test-key"})
+def test_serpapi_non_list_organic_returns_empty():
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"organic_results": {"oops": True}}
+    with patch.object(_mod.requests, "get", return_value=resp):
+        assert SerpApiSearch("q").search() == []


### PR DESCRIPTION
## Summary

- SerpApi already defaults missing organic_results to [] and skips empty links.
- Also skip non-dict rows, coerce organic_results when not a list, and default title/snippet with or "".

## Motivation

A single non-dict organic result raised AttributeError mid-search; matches Bing/BoCha/Google guards.

## Verification

```
python3 -m pytest tests/test_serpapi_malformed_results.py -v
# 2 passed
```

## Test plan

- [x] Local unit tests
- [ ] CI green
