### PR TITLE
fix(custom): skip non-dict custom retriever items

### DIFF
--- a/gpt_researcher/retrievers/custom/custom.py
+++ b/gpt_researcher/retrievers/custom/custom.py
@@ -68,4 +68,21 @@ class CustomRetriever:
                 f"{type(payload).__name__}"
             )
             return []
-        return payload
+
+        # Contract is list[{url, raw_content}]. Downstream reads .get on
+        # each item; filter non-dicts and rows without a usable URL so a
+        # single malformed edge cannot crash the research pipeline.
+        cleaned: List[Dict[str, Any]] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            url = item.get("url") or item.get("href") or ""
+            if not url:
+                continue
+            cleaned.append(
+                {
+                    "url": url,
+                    "raw_content": item.get("raw_content") or item.get("body") or "",
+                }
+            )
+        return cleaned

--- a/tests/test_custom_retriever_guard.py
+++ b/tests/test_custom_retriever_guard.py
@@ -1,10 +1,24 @@
-"""CustomRetriever.search must always return a list, never None."""
+"""CustomRetriever.search must always return a clean list of dict results."""
 
 from __future__ import annotations
 
+import importlib.util
+import pathlib
 from unittest.mock import MagicMock, patch
 
-from gpt_researcher.retrievers.custom.custom import CustomRetriever
+import requests
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "custom"
+    / "custom.py"
+)
+_spec = importlib.util.spec_from_file_location("_custom_under_test", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+CustomRetriever = _mod.CustomRetriever
 
 
 def _make(endpoint="https://example.test/search"):
@@ -15,12 +29,8 @@ def _make(endpoint="https://example.test/search"):
 def test_custom_returns_empty_list_on_http_error():
     c = _make()
     resp = MagicMock()
-    resp.raise_for_status.side_effect = Exception("boom")
-    # Use requests.RequestException path
-    import requests
-
     resp.raise_for_status.side_effect = requests.HTTPError("boom")
-    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+    with patch.object(_mod.requests, "get", return_value=resp):
         out = c.search()
     assert out == []
 
@@ -30,7 +40,7 @@ def test_custom_returns_empty_list_on_null_json():
     resp = MagicMock()
     resp.raise_for_status.return_value = None
     resp.json.return_value = None
-    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+    with patch.object(_mod.requests, "get", return_value=resp):
         out = c.search()
     assert out == []
 
@@ -40,7 +50,7 @@ def test_custom_returns_empty_list_on_non_list_json():
     resp = MagicMock()
     resp.raise_for_status.return_value = None
     resp.json.return_value = {"url": "x"}
-    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp):
+    with patch.object(_mod.requests, "get", return_value=resp):
         out = c.search()
     assert out == []
 
@@ -51,8 +61,27 @@ def test_custom_returns_list_payload():
     resp = MagicMock()
     resp.raise_for_status.return_value = None
     resp.json.return_value = payload
-    with patch("gpt_researcher.retrievers.custom.custom.requests.get", return_value=resp) as get:
+    with patch.object(_mod.requests, "get", return_value=resp) as get:
         out = c.search()
     assert out == payload
-    # timeout is passed so the retriever cannot hang forever
     assert get.call_args.kwargs.get("timeout") == 20
+
+
+def test_custom_skips_non_dict_and_url_less_items():
+    c = _make()
+    payload = [
+        "not-a-dict",
+        None,
+        {"raw_content": "no url"},
+        {"url": "https://ok.example", "raw_content": "body"},
+        {"href": "https://alt.example", "body": "alt body"},
+    ]
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    with patch.object(_mod.requests, "get", return_value=resp):
+        out = c.search()
+    assert out == [
+        {"url": "https://ok.example", "raw_content": "body"},
+        {"url": "https://alt.example", "raw_content": "alt body"},
+    ]


### PR DESCRIPTION
## Summary

- CustomRetriever already returns [] for HTTP/JSON/non-list failures.
- Also filter individual list elements: skip non-dict/null rows and items without url/href; normalize raw_content from body when needed.

## Motivation

Downstream code does result.get(...) on custom search hits. A list like [null, "x", {good}] used to pass validation as a list and crash later. Surface only dict hits with a usable URL.

## Verification

```
python3 -m pytest tests/test_custom_retriever_guard.py -v
# 5 passed
```

## Test plan

- [x] Local unit tests
- [ ] CI green
