### PR TITLE
fix(query_processing): add missing typing imports

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,3 +1,5 @@
+from typing import Any, List
+
 import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts


### PR DESCRIPTION
This was needed on my end to make the multi agent ag2 backend run. Not sure why nobody else has this problem. This was using python 3.13.