### PR TITLE
fix(publisher): use stripped output dir everywhere

### DIFF
--- a/multi_agents/ag2/agents/orchestrator.py
+++ b/multi_agents/ag2/agents/orchestrator.py
@@ -35,7 +35,7 @@ class ChiefEditorAgent:
 
     def _create_output_directory(self) -> str:
         output_dir = "./outputs/" + sanitize_filename(
-            f"run_{self.task_id}_{self.task.get('query')[0:40]}"
+            f"run_{self.task_id}_{self.task.get('query')[0:40].strip()}"
         )
         os.makedirs(output_dir, exist_ok=True)
         return output_dir

--- a/multi_agents/agents/orchestrator.py
+++ b/multi_agents/agents/orchestrator.py
@@ -41,7 +41,7 @@ class ChiefEditorAgent:
     def _create_output_directory(self):
         output_dir = "./outputs/" + \
             sanitize_filename(
-                f"run_{self.task_id}_{self.task.get('query')[0:40]}")
+                f"run_{self.task_id}_{self.task.get('query')[0:40].strip()}")
 
         os.makedirs(output_dir, exist_ok=True)
         return output_dir

--- a/multi_agents/agents/publisher.py
+++ b/multi_agents/agents/publisher.py
@@ -10,7 +10,7 @@ class PublisherAgent:
     def __init__(self, output_dir: str, websocket=None, stream_output=None, headers=None):
         self.websocket = websocket
         self.stream_output = stream_output
-        self.output_dir = output_dir.strip()
+        self.output_dir = output_dir
         self.headers = headers or {}
         
     async def publish_research_report(self, research_state: dict, publish_formats: dict):


### PR DESCRIPTION
Because the multi-agent publisher stripping the output directory string, a space in the 40th position of the task string will result in the publisher trying to write to a directory that does not exist. 

This PR makes sure that these kind of spaces are already stripped when the output directory name is generated, avoiding this issue to arise at all.

This fixes #641 and fixes #717 and was tested locally to confirm the fix.