### PR TITLE
fix(openalex): tolerate non-dict OA/primary locations

### DIFF
--- a/gpt_researcher/retrievers/openalex/openalex.py
+++ b/gpt_researcher/retrievers/openalex/openalex.py
@@ -97,12 +97,16 @@ class OpenAlexSearch:
         Prefer the open-access PDF URL, then the landing page URL from
         primary_location, then the OpenAlex work URL as fallback.
         """
-        oa_location = result.get("best_oa_location") or {}
+        oa_location = result.get("best_oa_location")
+        if not isinstance(oa_location, dict):
+            oa_location = {}
         pdf_url = oa_location.get("pdf_url")
         if pdf_url:
             return pdf_url
 
-        primary = result.get("primary_location") or {}
+        primary = result.get("primary_location")
+        if not isinstance(primary, dict):
+            primary = {}
         landing = primary.get("landing_page_url")
         if landing:
             return landing

--- a/tests/test_openalex_malformed_results.py
+++ b/tests/test_openalex_malformed_results.py
@@ -71,3 +71,25 @@ class OpenAlexMalformedTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+    def test_list_best_oa_location_falls_back_to_id(self):
+        """OpenAlex can return a non-dict location envelope; never AttributeError."""
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [
+                {
+                    "title": "Odd OA",
+                    "id": "https://openalex.org/W3",
+                    "abstract_inverted_index": None,
+                    "best_oa_location": [{"pdf_url": "https://example.com/x.pdf"}],
+                    "primary_location": "not-a-dict",
+                },
+            ]
+        }
+        requests_mod.get.return_value = resp
+        out = mod.OpenAlexSearch("q").search()
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["href"], "https://openalex.org/W3")


### PR DESCRIPTION
## Summary

- `_pick_href` assumed `best_oa_location` / `primary_location` were always dicts.
- Non-dict envelopes (list/string) raised `AttributeError` while normalizing a search hit and dropped the work.
- Require dict locations; otherwise fall through to the OpenAlex work `id`.

## Motivation

Defensive hardening for partial OpenAlex payloads. Truthy non-dict values defeat the existing `or {}` pattern (`[{...}] or {}` stays a list).

## Verification

Direct load of `openalex.py`:
```
_pick_href({..., best_oa_location: [{}], primary_location: "x"}) -> work id
```