### PR TITLE
fix(pubmed): guard non-dict esearchresult and non-list idlist

### DIFF
--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -61,8 +61,17 @@ class PubMedCentralSearch:
             response = requests.get(self.base_search_url, params=search_params)
             response.raise_for_status()
             data = response.json()
-            
-            id_list = data.get('esearchresult', {}).get('idlist', [])
+            if not isinstance(data, dict):
+                return []
+
+            # Error / unexpected envelopes may set esearchresult to null,
+            # a list, or omit idlist. Only treat a real list as success.
+            esearch = data.get("esearchresult")
+            if not isinstance(esearch, dict):
+                return []
+            id_list = esearch.get("idlist") or []
+            if not isinstance(id_list, list):
+                return []
             print(f"Found {len(id_list)} articles with full text available")
             return id_list
             

--- a/tests/test_pubmed_central_returns_list.py
+++ b/tests/test_pubmed_central_returns_list.py
@@ -29,3 +29,37 @@ def test_search_returns_list_when_empty_article_ids():
     with patch.object(PubMedCentralSearch, "_search_articles", return_value=[]):
         out = s.search()
     assert out == []
+
+
+def test_search_articles_malformed_esearchresult_returns_empty_list():
+    s = PubMedCentralSearch("cancer")
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"esearchresult": None}
+
+    with patch(
+        "gpt_researcher.retrievers.pubmed_central.pubmed_central.requests.get",
+        return_value=Resp(),
+    ):
+        out = s._search_articles(max_results=5)
+    assert out == []
+
+
+def test_search_articles_non_list_idlist_returns_empty_list():
+    s = PubMedCentralSearch("cancer")
+    class Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"esearchresult": {"idlist": "1,2,3"}}
+
+    with patch(
+        "gpt_researcher.retrievers.pubmed_central.pubmed_central.requests.get",
+        return_value=Resp(),
+    ):
+        out = s._search_articles(max_results=5)
+    assert out == []


### PR DESCRIPTION
## Summary

- `_search_articles` chained `.get` on `esearchresult` assuming a dict.
- Null/list envelopes raised AttributeError; non-list `idlist` broke `len`/iteration.
- Restrict to dict + list shapes; otherwise return `[]`.

## Motivation

NCBI error JSON is not always the happy-path shape. Fail closed to an empty id list rather than crashing lookup.

## Verification

Direct module load:
- `esearchresult: null` → `[]`
- `idlist: "1,2,3"` → `[]`