### PR TITLE
fix: NameError on import in query_processing.py (package currently unusable as published)

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,6 +1,12 @@
 import json_repair
+import logging
+from typing import Any, Dict, List
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
+
+from ..config import Config
+from ..prompts import PromptFamily
+from ..utils.llm import create_chat_completion
 
 
 def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
@@ -32,11 +38,6 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     if not queries and fallback_query.strip():
         return [fallback_query.strip()]
     return queries
-from ..utils.llm import create_chat_completion
-from ..prompts import PromptFamily
-from typing import Any, List, Dict
-from ..config import Config
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,27 @@
+"""Regression test: the package must be importable.
+
+gpt_researcher/actions/query_processing.py previously used `Any` in a
+function annotation before importing it from `typing`, which crashed the
+whole package on import under Python versions without PEP 649/749 lazy
+annotation evaluation (i.e. everything before 3.14) -- including the
+currently-published 0.16.0 release. See PR #1943.
+
+tests/test_sub_query_normalization.py already exercises this same import
+path indirectly (it imports _normalize_sub_queries from this module), but
+only as a side effect of testing something else. This makes "the package
+imports" an explicit, named invariant instead.
+"""
+
+import unittest
+
+
+class TestPackageImports(unittest.TestCase):
+    def test_gpt_researcher_imports(self):
+        import gpt_researcher  # noqa: F401
+
+    def test_query_processing_imports(self):
+        import gpt_researcher.actions.query_processing  # noqa: F401
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`gpt_researcher/actions/query_processing.py` currently fails to import at all: `from typing import Any, List, Dict` sits at line 37, but `_normalize_sub_queries` (introduced in bcc1eac0, 2026-06-27) uses `Any` in its signature annotation at line 6 -- evaluated eagerly at module load time since this file has no `from __future__ import annotations`.

**This breaks every import of `gpt_researcher`**, including via a plain `pip install gpt-researcher` -- confirmed the currently-published PyPI release (0.16.0) has this exact break:

```
>>> import gpt_researcher
Traceback (most recent call last):
  ...
  File ".../gpt_researcher/actions/query_processing.py", line 6, in <module>
    def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
                                       ^^^
NameError: name 'Any' is not defined. Did you mean: 'any'?
```

Confirmed `0.14.8`/`0.15.0`/`0.15.1` all import fine -- the regression is isolated to this file, introduced between those releases and today's `v3.6.0`/`0.16.0`. Not an edge case or a rare code path: the package is entirely unusable as currently published.

## Fix

Move all of this file's imports to the top, in the conventional stdlib/third-party/local order, removing the now-duplicate copies that were scattered mid-file. No behavior change -- purely import ordering.

## Test plan

- `pip install gpt-researcher==0.16.0` then `python -c "import gpt_researcher"` reproduces the crash.
- With this fix applied (editable install from this branch): `python -c "import gpt_researcher"` succeeds.
- Ran the existing scraper test suite (`tests/test_scraper_extract_title.py`, `tests/test_scraper_get_scraper.py`, `tests/test_arxiv_scraper.py`) against this branch: 13 passed, no regressions.

Given the severity (total import failure on the current release), I've opened this as a standalone, minimal PR separate from other in-progress work, so it can be reviewed and merged independently and quickly.