### PR TITLE
fix: scraper ingests anti-bot challenge pages as content, word-list dumps dominate context

### DIFF
--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -31,19 +31,27 @@ from . import (
 # These pages return HTTP 200 with real (often large) HTML bodies, so
 # neither an exception nor the short-content check below catches them --
 # without this, a block/challenge page is ingested as if it were the
-# article's real content. Not exhaustive; add more as new blockers are
-# observed in practice.
+# article's real content. Each marker is anchored specifically enough to
+# avoid colliding with ordinary prose (e.g. "researchgate - temporarily
+# unavailable", not the bare phrase "temporarily unavailable", which a
+# legitimate article about an unrelated outage could plausibly contain).
+# Not exhaustive; add more as new blockers are observed in practice.
 _BLOCK_PAGE_MARKERS = (
     "anubis uses a proof-of-work scheme",  # HAL and other Anubis-fronted sites
     "making sure you're not a bot",
     "checking your browser before accessing",
     "enable javascript and cookies to continue",
-    "temporarily unavailable",  # ResearchGate's specific wording
+    "researchgate - temporarily unavailable",  # ResearchGate's specific wording
     "please verify you are a human",
     "attention required! | cloudflare",
     "sorry, you have been blocked",
-    "just a moment...",
 )
+
+# Block pages are the entire response body -- a "please wait" message, not
+# a real article -- so they're always short and always appear at the very
+# start of the content. Checking only a prefix avoids lower-casing and
+# scanning multi-megabyte legitimate documents on every scrape.
+_BLOCK_PAGE_CHECK_PREFIX_LEN = 5_000
 
 # Word-list/vocab dumps (plain lists of unrelated words, no prose) scrape
 # cleanly and can dominate a report's context, since they lexically match
@@ -52,20 +60,24 @@ _BLOCK_PAGE_MARKERS = (
 # writing has a period every ~100-200 characters). Size alone isn't used as
 # a signal -- long legitimate documents exist -- only the near-total absence
 # of sentence structure combined with real size is checked, to keep the
-# false-positive rate on real content low.
+# false-positive rate on real content low. Includes CJK fullwidth sentence
+# terminators (。！？) alongside the Latin ones, so long-form Chinese/
+# Japanese/Korean prose -- which never uses "." "!" "?" -- isn't
+# misclassified as a word list purely for lacking ASCII punctuation.
 _MIN_LENGTH_FOR_WORDLIST_CHECK = 200_000
 _MAX_SENTENCE_DENSITY = 1 / 5000  # at most 1 sentence-ending mark per 5000 chars
+_SENTENCE_ENDING_CHARS = frozenset(".!?。！？")
 
 
 def _looks_like_block_page(text: str) -> bool:
-    lowered = text.lower()
-    return any(marker in lowered for marker in _BLOCK_PAGE_MARKERS)
+    prefix = text[:_BLOCK_PAGE_CHECK_PREFIX_LEN].lower()
+    return any(marker in prefix for marker in _BLOCK_PAGE_MARKERS)
 
 
 def _looks_like_word_list(text: str) -> bool:
     if len(text) < _MIN_LENGTH_FOR_WORDLIST_CHECK:
         return False
-    sentence_endings = text.count(".") + text.count("!") + text.count("?")
+    sentence_endings = sum(1 for ch in text if ch in _SENTENCE_ENDING_CHARS)
     return (sentence_endings / len(text)) < _MAX_SENTENCE_DENSITY
 
 
@@ -172,54 +184,21 @@ class Scraper:
                         self.worker_pool.executor, scraper.scrape
                     )
 
-                if len(content) < 100:
-                    self.logger.warning(f"Content too short or empty for {link}")
-                    return {
-                        "url": link,
-                        "raw_content": None,
-                        "image_urls": [],
-                        "title": title,
-                    }
+                if not content or len(content) < 100:
+                    return self._reject(link, title, "Content too short or empty")
 
                 # Log results
                 self.logger.info(f"\nTitle: {title}")
-                self.logger.info(
-                    f"Content length: {len(content) if content else 0} characters"
-                )
+                self.logger.info(f"Content length: {len(content)} characters")
                 self.logger.info(f"Number of images: {len(image_urls)}")
                 self.logger.info(f"URL: {link}")
                 self.logger.info("=" * 50)
 
-                if not content or len(content) < 100:
-                    self.logger.warning(f"Content too short or empty for {link}")
-                    return {
-                        "url": link,
-                        "raw_content": None,
-                        "image_urls": [],
-                        "title": title,
-                    }
-
                 if _looks_like_block_page(content):
-                    self.logger.warning(
-                        f"Anti-bot/challenge page detected for {link}, treating as fetch failure"
-                    )
-                    return {
-                        "url": link,
-                        "raw_content": None,
-                        "image_urls": [],
-                        "title": title,
-                    }
+                    return self._reject(link, title, "Anti-bot/challenge page detected")
 
                 if _looks_like_word_list(content):
-                    self.logger.warning(
-                        f"Word-list-like content detected for {link}, treating as fetch failure"
-                    )
-                    return {
-                        "url": link,
-                        "raw_content": None,
-                        "image_urls": [],
-                        "title": title,
-                    }
+                    return self._reject(link, title, "Word-list-like content detected")
 
                 return {
                     "url": link,
@@ -231,6 +210,13 @@ class Scraper:
             except Exception as e:
                 self.logger.error(f"Error processing {link}: {str(e)}")
                 return {"url": link, "raw_content": None, "image_urls": [], "title": ""}
+
+    def _reject(self, link, title, reason):
+        """Treat a fetched-but-unusable page as a scrape failure, in the same
+        shape a raised exception or too-short content already returns --
+        downstream code (Scraper.run) drops any raw_content: None entry."""
+        self.logger.warning(f"{reason} for {link}, treating as fetch failure")
+        return {"url": link, "raw_content": None, "image_urls": [], "title": title}
 
     def get_scraper(self, link):
         """

--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -27,6 +27,47 @@ from . import (
     WebBaseLoaderScraper,
 )
 
+# Known anti-bot/challenge-page markers, case-insensitive substring match.
+# These pages return HTTP 200 with real (often large) HTML bodies, so
+# neither an exception nor the short-content check below catches them --
+# without this, a block/challenge page is ingested as if it were the
+# article's real content. Not exhaustive; add more as new blockers are
+# observed in practice.
+_BLOCK_PAGE_MARKERS = (
+    "anubis uses a proof-of-work scheme",  # HAL and other Anubis-fronted sites
+    "making sure you're not a bot",
+    "checking your browser before accessing",
+    "enable javascript and cookies to continue",
+    "temporarily unavailable",  # ResearchGate's specific wording
+    "please verify you are a human",
+    "attention required! | cloudflare",
+    "sorry, you have been blocked",
+    "just a moment...",
+)
+
+# Word-list/vocab dumps (plain lists of unrelated words, no prose) scrape
+# cleanly and can dominate a report's context, since they lexically match
+# almost any query. They have essentially zero sentence-ending punctuation
+# relative to their size, unlike any real prose (even dense technical
+# writing has a period every ~100-200 characters). Size alone isn't used as
+# a signal -- long legitimate documents exist -- only the near-total absence
+# of sentence structure combined with real size is checked, to keep the
+# false-positive rate on real content low.
+_MIN_LENGTH_FOR_WORDLIST_CHECK = 200_000
+_MAX_SENTENCE_DENSITY = 1 / 5000  # at most 1 sentence-ending mark per 5000 chars
+
+
+def _looks_like_block_page(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _BLOCK_PAGE_MARKERS)
+
+
+def _looks_like_word_list(text: str) -> bool:
+    if len(text) < _MIN_LENGTH_FOR_WORDLIST_CHECK:
+        return False
+    sentence_endings = text.count(".") + text.count("!") + text.count("?")
+    return (sentence_endings / len(text)) < _MAX_SENTENCE_DENSITY
+
 
 class Scraper:
     """
@@ -151,6 +192,28 @@ class Scraper:
 
                 if not content or len(content) < 100:
                     self.logger.warning(f"Content too short or empty for {link}")
+                    return {
+                        "url": link,
+                        "raw_content": None,
+                        "image_urls": [],
+                        "title": title,
+                    }
+
+                if _looks_like_block_page(content):
+                    self.logger.warning(
+                        f"Anti-bot/challenge page detected for {link}, treating as fetch failure"
+                    )
+                    return {
+                        "url": link,
+                        "raw_content": None,
+                        "image_urls": [],
+                        "title": title,
+                    }
+
+                if _looks_like_word_list(content):
+                    self.logger.warning(
+                        f"Word-list-like content detected for {link}, treating as fetch failure"
+                    )
                     return {
                         "url": link,
                         "raw_content": None,

--- a/tests/test_scraper_content_quality.py
+++ b/tests/test_scraper_content_quality.py
@@ -51,6 +51,34 @@ class LooksLikeBlockPageTests(unittest.TestCase):
         text = "MAKING SURE YOU'RE NOT A BOT! " * 5
         self.assertTrue(_looks_like_block_page(text))
 
+    def test_generic_phrases_do_not_false_positive_on_ordinary_news(self):
+        # Regression: markers must be anchored to their actual source wording,
+        # not bare generic phrases a real article can plausibly contain.
+        text = (
+            "Regional water utility says services will be temporarily "
+            'unavailable in the downtown area starting Monday for scheduled '
+            'maintenance. "Just a moment, please," the utility spokesperson '
+            "said, noting repairs should finish by evening."
+        ) * 5
+        self.assertFalse(_looks_like_block_page(text))
+
+    def test_marker_beyond_prefix_window_not_detected(self):
+        # Block pages are checked via a size-bounded prefix (they're always
+        # short); a marker string appearing far into a large legitimate
+        # document (e.g. quoting or discussing an anti-bot system) must not
+        # retroactively flag the whole thing.
+        padding = "Ordinary article content discussing web scraping history. " * 200
+        self.assertGreater(len(padding), 5_000)
+        text = padding + "This page happens to mention: anubis uses a proof-of-work scheme."
+        self.assertFalse(_looks_like_block_page(text))
+
+    def test_marker_within_prefix_window_still_detected(self):
+        # Same marker as above, but within the checked prefix -- must still
+        # be caught (confirms the prefix limit didn't disable detection
+        # entirely).
+        text = "anubis uses a proof-of-work scheme. " + ("Padding. " * 10)
+        self.assertTrue(_looks_like_block_page(text))
+
 
 class LooksLikeWordListTests(unittest.TestCase):
     def test_synthetic_word_list_detected(self):
@@ -74,6 +102,16 @@ class LooksLikeWordListTests(unittest.TestCase):
         # Even a short string with zero punctuation must not be flagged --
         # the size threshold guards against false positives on short pages.
         self.assertFalse(_looks_like_word_list("soa tenses kea ashdown 890 autographs"))
+
+    def test_legitimate_cjk_prose_not_detected(self):
+        # Regression: CJK prose uses fullwidth sentence terminators (。！？),
+        # never ASCII ".", "!", "?" -- counting only ASCII punctuation would
+        # misclassify any long-form Chinese/Japanese/Korean article as a
+        # word list purely for lacking Latin punctuation.
+        sentence = "GPT研究员通过将查询分解为子问题、检索来源并综合成引用报告来进行自主网络研究。"
+        text = sentence * 6000
+        self.assertGreater(len(text), 200_000)
+        self.assertFalse(_looks_like_word_list(text))
 
 
 class ExtractDataFromUrlContentQualityTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_scraper_content_quality.py
+++ b/tests/test_scraper_content_quality.py
@@ -1,0 +1,141 @@
+"""Regression tests for Scraper's anti-bot/word-list content-quality checks.
+
+Authoritative sources were found by search but returned anti-bot/challenge
+pages when scraped (Anubis proof-of-work challenges, Cloudflare,
+ResearchGate's "Temporarily Unavailable") -- and those challenge pages were
+then ingested as if they were the article's real content, since they return
+HTTP 200 with a real (often large) body, so neither an exception nor the
+existing len(content) < 100 check catches them. Separately, raw
+word-list/vocabulary-dump .txt files (plain lists of unrelated words, no
+prose) scrape cleanly and then dominate the returned context, since they
+lexically match almost any query.
+
+_looks_like_block_page/_looks_like_word_list are unit-tested directly; the
+full extract_data_from_url path is exercised with a scraper backend
+replaced by a canned stub, to confirm the method actually treats a match as
+a fetch failure (raw_content: None), the same shape it already returns for
+too-short content.
+"""
+
+import random
+import unittest
+
+from gpt_researcher.scraper.scraper import (
+    Scraper,
+    _looks_like_block_page,
+    _looks_like_word_list,
+)
+
+
+class LooksLikeBlockPageTests(unittest.TestCase):
+    def test_anubis_challenge_detected(self):
+        text = (
+            "Making sure you're not a bot!  Checking your browser. "
+            "Anubis uses a Proof-of-Work scheme "
+        ) * 20
+        self.assertTrue(_looks_like_block_page(text))
+
+    def test_researchgate_unavailable_detected(self):
+        text = "ResearchGate - Temporarily Unavailable. We're sorry for the inconvenience." * 10
+        self.assertTrue(_looks_like_block_page(text))
+
+    def test_cloudflare_detected(self):
+        text = "Attention Required! | Cloudflare\nSorry, you have been blocked."
+        self.assertTrue(_looks_like_block_page(text))
+
+    def test_normal_article_not_detected(self):
+        text = "This is a normal article about Catala, a domain-specific language for tax law."
+        self.assertFalse(_looks_like_block_page(text))
+
+    def test_case_insensitive(self):
+        text = "MAKING SURE YOU'RE NOT A BOT! " * 5
+        self.assertTrue(_looks_like_block_page(text))
+
+
+class LooksLikeWordListTests(unittest.TestCase):
+    def test_synthetic_word_list_detected(self):
+        random.seed(42)
+        words = ["".join(random.choices("abcdefghijklmnop", k=random.randint(3, 9))) for _ in range(180_000)]
+        text = " ".join(words)
+        self.assertGreater(len(text), 1_000_000)
+        self.assertTrue(_looks_like_word_list(text))
+
+    def test_legitimate_long_prose_not_detected(self):
+        sentence = (
+            "GPT Researcher conducts autonomous web research by decomposing a "
+            "query into sub-questions, retrieving sources, and synthesizing a "
+            "cited report. "
+        )
+        text = sentence * 3000
+        self.assertGreater(len(text), 200_000)
+        self.assertFalse(_looks_like_word_list(text))
+
+    def test_short_content_never_flagged(self):
+        # Even a short string with zero punctuation must not be flagged --
+        # the size threshold guards against false positives on short pages.
+        self.assertFalse(_looks_like_word_list("soa tenses kea ashdown 890 autographs"))
+
+
+class ExtractDataFromUrlContentQualityTests(unittest.IsolatedAsyncioTestCase):
+    class _StubBackend:
+        """Stands in for a real scraper backend (BeautifulSoupScraper, etc.)."""
+
+        def __init__(self, link, session):
+            pass
+
+        def scrape(self):
+            return self._canned_content, [], "Stub Title"
+
+    async def _extract_with_canned_content(self, canned_content: str) -> dict:
+        scraper = Scraper(urls=["https://example.com"], user_agent="ua", scraper="bs", worker_pool=_FakeWorkerPool())
+        stub_cls = type(
+            "StubBackend",
+            (self._StubBackend,),
+            {"_canned_content": canned_content},
+        )
+        scraper.get_scraper = lambda link: stub_cls
+        return await scraper.extract_data_from_url("https://example.com/x", scraper.session)
+
+    async def test_anti_bot_page_treated_as_fetch_failure(self):
+        text = (
+            "Making sure you're not a bot!  Checking your browser. "
+            "Anubis uses a Proof-of-Work scheme "
+        ) * 20
+        result = await self._extract_with_canned_content(text)
+        self.assertIsNone(result["raw_content"])
+
+    async def test_word_list_treated_as_fetch_failure(self):
+        random.seed(42)
+        words = ["".join(random.choices("abcdefghijklmnop", k=random.randint(3, 9))) for _ in range(180_000)]
+        text = " ".join(words)
+        result = await self._extract_with_canned_content(text)
+        self.assertIsNone(result["raw_content"])
+
+    async def test_legitimate_content_preserved(self):
+        text = "This is a normal article about Catala, a domain-specific language for tax law. " * 5
+        result = await self._extract_with_canned_content(text)
+        self.assertEqual(result["raw_content"], text)
+
+
+class _FakeWorkerPool:
+    """Minimal stand-in: extract_data_from_url only uses throttle()/executor,
+    and the stub backend's scrape() runs synchronously and fast enough that
+    the real ThreadPoolExecutor isn't needed."""
+
+    class _NullThrottle:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    def throttle(self):
+        return self._NullThrottle()
+
+    @property
+    def executor(self):
+        return None
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two related content-quality problems found running this against real research queries in production, both returning HTTP 200 with a real (often large) body, so neither `Scraper.extract_data_from_url`'s `except Exception` path nor its existing `len(content) < 100` check catches either:

1. **Authoritative sources are correctly found by search, then return anti-bot/challenge pages when scraped** -- e.g. Anubis proof-of-work challenges (`inria.hal.science` and other Anubis-fronted sites), Cloudflare ("Attention Required!"), ResearchGate's "Temporarily Unavailable". Those challenge pages are then ingested as if they were the article's real content -- in one case, the report's citation for a specific paper was grounded entirely in Anubis's own challenge-page prose, not the paper.
2. **Raw word-list/vocabulary-dump `.txt` files scrape cleanly and then dominate the returned context** -- e.g. `cs.princeton.edu/.../words-333333.txt` (4.96M chars), `downloads.cs.stanford.edu/nlp/data/jiwei/data/vocab_wiki.txt` (1.68M chars). These lexically match almost any query, so they rank on everything; in one run, a single vocab dump contributed more chunks to the returned context than any legitimate source.

## Fix

After a scrape completes, `raw_content` is nulled out (the same shape the function already returns for too-short content) when it matches either check:

- **Block-page detection**: a small set of known anti-bot/challenge-page markers (Anubis, Cloudflare, ResearchGate, generic "verify you are human" phrasing), case-insensitive substring match.
- **Word-list detection**: large content (>200K chars) with near-zero sentence-ending punctuation density. Size alone isn't used as the signal -- legitimate long documents exist -- only the near-total absence of sentence structure combined with real size, which is what actually distinguishes a word-list dump from any real prose (even dense technical writing has a period every ~100-200 characters; a plain word list has essentially none).

Downstream code already drops `raw_content=None` entries (`Scraper.run`'s filter, and `_search_relevant_source_urls`'s classification), so both cases are then treated exactly like "this URL failed to scrape," and gpt-researcher tries another source instead of treating either as real content.

## Test plan

`tests/test_scraper_content_quality.py`:
- Unit tests for the two detection helpers directly, including false-positive checks against long legitimate prose (>200K chars, but full of periods) and short normal content -- both must survive untouched.
- An integration-style test driving the full `extract_data_from_url` path with a stubbed scraper backend, confirming the method-level contract (not just the helper functions in isolation).
- Ran alongside the existing scraper test suite (`test_scraper_extract_title.py`, `test_scraper_get_scraper.py`, `test_arxiv_scraper.py`): 13 passed, no regressions.

(Note: verifying this locally required #1943 -- the currently-published release doesn't import at all -- applied on top; this PR's diff itself doesn't touch that file.)