### PR TITLE
fix(serper): guard non-dict JSON search payloads

### DIFF
--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -112,7 +112,7 @@ class SerperSearch():
             search_results = json.loads(resp.text)
         except Exception:
             return []
-        if search_results is None:
+        if search_results is None or not isinstance(search_results, dict):
             return []
 
         results = search_results.get("organic") or []

--- a/tests/test_serper_non_dict_payload.py
+++ b/tests/test_serper_non_dict_payload.py
@@ -1,0 +1,55 @@
+"""SerperSearch must tolerate non-dict JSON payloads without AttributeError.
+
+A 200 body that parses to a list/str used to crash on ``.get("organic")``.
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+from unittest.mock import MagicMock, patch
+
+_SERPER_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "serper"
+    / "serper.py"
+)
+_spec = importlib.util.spec_from_file_location("_serper_under_test", _SERPER_PATH)
+_serper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_serper)
+SerperSearch = _serper.SerperSearch
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self.text = payload if isinstance(payload, str) else json.dumps(payload)
+
+
+@patch.dict(os.environ, {"SERPER_API_KEY": "test-key"})
+def test_search_returns_list_when_json_is_list():
+    with patch.object(_serper.requests, "request", return_value=_FakeResp([{"link": "https://x"}])):
+        out = SerperSearch("q").search()
+    assert out == []
+
+
+@patch.dict(os.environ, {"SERPER_API_KEY": "test-key"})
+def test_search_returns_list_when_json_is_string():
+    with patch.object(_serper.requests, "request", return_value=_FakeResp('"surprise"')):
+        out = SerperSearch("q").search()
+    assert out == []
+
+
+@patch.dict(os.environ, {"SERPER_API_KEY": "test-key"})
+def test_search_still_parses_organic_dicts():
+    payload = {
+        "organic": [
+            {"title": "T", "link": "https://ex.com", "snippet": "S"},
+            "skip-me",
+            {"link": ""},
+        ]
+    }
+    with patch.object(_serper.requests, "request", return_value=_FakeResp(payload)):
+        out = SerperSearch("q").search()
+    assert out == [{"title": "T", "href": "https://ex.com", "body": "S"}]


### PR DESCRIPTION
## Summary
- Treat non-dict Serper JSON bodies (list/str/number) as empty results instead of calling `.get("organic")`.
- Keep existing empty-list behavior for null/unparseable bodies and skip non-dict organic rows.

## Motivation
`search()` always builds results via `search_results.get("organic")`. A 200 response that still `json.loads` to a list/string raises `AttributeError`, which aborts the whole research run instead of degrading to no Serper hits.

## Verification
Without fix (simulated): AttributeError 'list' object has no attribute 'get'
With fix: `python3 -m pytest tests/test_serper_non_dict_payload.py -q` → 3 passed

## Real behavior proof
- Payload `[1]` → `[]` (no crash)
- Normal `{"organic":[...]}` still returns normalized href/title/body rows

## Test plan
- [x] pytest tests/test_serper_non_dict_payload.py
- [ ] CI green on this PR
