### PR TITLE
fix(tavily): guard non-dict API responses in search()

### DIFF
--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -128,8 +128,12 @@ class TavilySearch:
                 topic=self.topic,
                 include_domains=include_domains,
             )
+            # API/proxy glitches can yield a list or scalar JSON body; only dict
+            # responses have a top-level "results" key we understand.
+            if not isinstance(results, dict):
+                raise Exception("No results found with Tavily API search.")
             sources = results.get("results", [])
-            if not sources:
+            if not isinstance(sources, list) or not sources:
                 raise Exception("No results found with Tavily API search.")
             # Return the results. Guard each source against missing/None
             # fields so a single malformed hit does not drop the whole page.

--- a/tests/test_tavily_non_dict_response.py
+++ b/tests/test_tavily_non_dict_response.py
@@ -1,0 +1,46 @@
+"""TavilySearch.search must not AttributeError on non-dict API JSON."""
+
+import importlib.util
+import pathlib
+from unittest.mock import patch
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "tavily"
+    / "tavily_search.py"
+)
+_spec = importlib.util.spec_from_file_location("_tavily_under_test", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+TavilySearch = _mod.TavilySearch
+
+
+def test_search_returns_empty_when_api_json_is_list():
+    s = TavilySearch("q", headers={"tavily_api_key": "k"})
+    with patch.object(s, "_search", return_value=[{"url": "https://x"}]):
+        assert s.search() == []
+
+
+def test_search_returns_empty_when_results_not_list():
+    s = TavilySearch("q", headers={"tavily_api_key": "k"})
+    with patch.object(s, "_search", return_value={"results": {"url": "https://x"}}):
+        assert s.search() == []
+
+
+def test_search_normalizes_dict_hits():
+    s = TavilySearch("q", headers={"tavily_api_key": "k"})
+    payload = {
+        "results": [
+            {"url": "https://a.example", "content": "body-a"},
+            "skip",
+            {"content": "no-url"},
+            {"url": "https://b.example", "snippet": "body-b"},
+        ]
+    }
+    with patch.object(s, "_search", return_value=payload):
+        assert s.search() == [
+            {"href": "https://a.example", "body": "body-a"},
+            {"href": "https://b.example", "body": "body-b"},
+        ]


### PR DESCRIPTION
## Summary
- Require Tavily `_search` payloads to be a dict with a list `results` before iterating.
- Non-dict JSON or a non-list `results` degrades to `[]` via the existing exception handler.

## Motivation
After a successful HTTP call, `search()` did `results.get("results", [])`. List/scalar JSON bodies raise `AttributeError` and treat the failure path inconsistently with other retrievers.

## Verification
`python3 -m pytest tests/test_tavily_non_dict_response.py -q` → 3 passed

## Test plan
- [x] unit tests for list payload, non-list results, happy path
- [ ] CI green
