### PR TITLE
fix(firecrawl): allow scrape when session is None

### DIFF
--- a/gpt_researcher/scraper/firecrawl/firecrawl.py
+++ b/gpt_researcher/scraper/firecrawl/firecrawl.py
@@ -66,14 +66,20 @@ class FireCrawl:
             content = response.markdown if response.markdown else ""
             title = response.metadata.title if response.metadata and response.metadata.title else ""
 
-            # Parse the HTML content of the response to create a BeautifulSoup object for the utility functions
-            response_bs = self.session.get(self.link, timeout=4)
-            soup = BeautifulSoup(
-                response_bs.content, "lxml", from_encoding=response_bs.encoding
-            )
-
-            # Get relevant images using the utility function
-            image_urls = get_relevant_images(soup, self.link)
+            # Optional image pass. Session may be None when FireCrawl is used
+            # outside Scraper; never attribute-error on session.get.
+            image_urls = []
+            if self.session is not None:
+                try:
+                    response_bs = self.session.get(self.link, timeout=4)
+                    soup = BeautifulSoup(
+                        response_bs.content,
+                        "lxml",
+                        from_encoding=response_bs.encoding,
+                    )
+                    image_urls = get_relevant_images(soup, self.link)
+                except Exception as img_err:
+                    print(f"FireCrawl image extraction skipped: {img_err}")
 
             return content, image_urls, title
 

--- a/tests/test_firecrawl_null_session.py
+++ b/tests/test_firecrawl_null_session.py
@@ -1,0 +1,68 @@
+"""FireCrawl.scrape must work when session is None (no AttributeError)."""
+
+import importlib.util
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# Optional deps not required for this unit test.
+sys.modules.setdefault("bs4", types.ModuleType("bs4"))
+sys.modules["bs4"].BeautifulSoup = MagicMock
+_fc = types.ModuleType("firecrawl")
+_fc.FirecrawlApp = MagicMock
+sys.modules.setdefault("firecrawl", _fc)
+
+root = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(root))
+
+import types as T
+
+pkg = T.ModuleType("gpt_researcher")
+pkg.__path__ = [str(root / "gpt_researcher")]
+sys.modules["gpt_researcher"] = pkg
+scraper_pkg = T.ModuleType("gpt_researcher.scraper")
+scraper_pkg.__path__ = [str(root / "gpt_researcher" / "scraper")]
+sys.modules["gpt_researcher.scraper"] = scraper_pkg
+fc_pkg = T.ModuleType("gpt_researcher.scraper.firecrawl")
+fc_pkg.__path__ = [str(root / "gpt_researcher" / "scraper" / "firecrawl")]
+sys.modules["gpt_researcher.scraper.firecrawl"] = fc_pkg
+
+utils_mod = T.ModuleType("gpt_researcher.scraper.utils")
+utils_mod.get_relevant_images = lambda soup, link: ["https://img.example/a.png"]
+sys.modules["gpt_researcher.scraper.utils"] = utils_mod
+
+_PATH = root / "gpt_researcher" / "scraper" / "firecrawl" / "firecrawl.py"
+_spec = importlib.util.spec_from_file_location(
+    "gpt_researcher.scraper.firecrawl.firecrawl", _PATH
+)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["gpt_researcher.scraper.firecrawl.firecrawl"] = _mod
+with patch.dict("os.environ", {"FIRECRAWL_API_KEY": "k"}):
+    _spec.loader.exec_module(_mod)
+
+FireCrawl = _mod.FireCrawl
+
+
+class _Meta:
+    error = None
+    status_code = 200
+    title = "Hello"
+
+
+class _Resp:
+    metadata = _Meta()
+    markdown = "x" * 150
+
+
+def test_scrape_with_session_none_returns_content():
+    app = MagicMock()
+    app.scrape.return_value = _Resp()
+    with patch.object(_mod, "FirecrawlApp", return_value=app), patch.dict(
+        "os.environ", {"FIRECRAWL_API_KEY": "k"}
+    ):
+        scraper = FireCrawl("https://example.com/page", session=None)
+        content, images, title = scraper.scrape()
+    assert content == "x" * 150
+    assert images == []
+    assert title == "Hello"

--- a/tests/test_firecrawl_null_session.py
+++ b/tests/test_firecrawl_null_session.py
@@ -6,12 +6,8 @@ import sys
 import types
 from unittest.mock import MagicMock, patch
 
-# Optional deps not required for this unit test.
 sys.modules.setdefault("bs4", types.ModuleType("bs4"))
 sys.modules["bs4"].BeautifulSoup = MagicMock
-_fc = types.ModuleType("firecrawl")
-_fc.FirecrawlApp = MagicMock
-sys.modules.setdefault("firecrawl", _fc)
 
 root = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(root))
@@ -58,11 +54,22 @@ class _Resp:
 def test_scrape_with_session_none_returns_content():
     app = MagicMock()
     app.scrape.return_value = _Resp()
-    with patch.object(_mod, "FirecrawlApp", return_value=app), patch.dict(
-        "os.environ", {"FIRECRAWL_API_KEY": "k"}
+
+    class _AppFactory:
+        def __init__(self, *a, **k):
+            pass
+
+        def scrape(self, **kwargs):
+            return app.scrape(**kwargs)
+
+    with patch.dict("os.environ", {"FIRECRAWL_API_KEY": "k"}), patch.dict(
+        sys.modules, {"firecrawl": types.SimpleNamespace(FirecrawlApp=_AppFactory)}
     ):
+        # Re-bind constructor path used inside scrape init
         scraper = FireCrawl("https://example.com/page", session=None)
+        scraper.firecrawl = app
         content, images, title = scraper.scrape()
     assert content == "x" * 150
     assert images == []
     assert title == "Hello"
+    app.scrape.assert_called_once()


### PR DESCRIPTION
## Summary
- Skip the secondary HTML/image pass when `session` is `None` instead of calling `self.session.get`.
- Swallow image-pass errors so markdown content still returns successfully.

## Motivation
`FireCrawl(link, session=None).scrape()` crashed with `AttributeError: 'NoneType' object has no attribute 'get'` after a successful Firecrawl SDK scrape whenever callers omitted the shared `requests.Session`.

## Verification
`python3 -m pytest tests/test_firecrawl_null_session.py -q` → 1 passed

## Test plan
- [x] unit test session=None happy path
- [ ] CI green
