### PR TITLE
fix: detect and recover extensionless PDFs routed to the wrong scraper

### DIFF
--- a/gpt_researcher/scraper/scraper.py
+++ b/gpt_researcher/scraper/scraper.py
@@ -27,6 +27,29 @@ from . import (
     WebBaseLoaderScraper,
 )
 
+# get_scraper() picks a backend from the URL's suffix, but PDFs served from
+# institutional repositories (DSpace/EPrints-style download endpoints) are
+# routed by content type, not a file extension -- e.g.
+# "scholarspace.manoa.hawaii.edu/bitstreams/<uuid>/download" has none. Those
+# fall through to a text/HTML scraper, which has no way to decode the PDF
+# body and returns its raw bytes (FlateDecode streams, xref tables, /Annot
+# objects) as if it were the page's real text -- silently: no exception, a
+# normal-looking content_length, just unusable content.
+#
+# These tokens are PDF's own internal structural syntax; they essentially
+# never occur, even coincidentally, in real prose. Two independent hits is
+# enough to be confident this is raw PDF, not text that happens to contain
+# one of these words in isolation.
+_PDF_STRUCTURE_MARKERS = ("endobj", "endstream", "/FlateDecode", "xref", "trailer")
+_MIN_PDF_MARKER_HITS = 2
+
+
+def _looks_like_unextracted_pdf(text: str) -> bool:
+    if text.startswith("%PDF-"):
+        return True
+    hits = sum(1 for marker in _PDF_STRUCTURE_MARKERS if marker in text)
+    return hits >= _MIN_PDF_MARKER_HITS
+
 
 class Scraper:
     """
@@ -158,6 +181,23 @@ class Scraper:
                         "title": title,
                     }
 
+                if _looks_like_unextracted_pdf(content) and Scraper is not PyMuPDFScraper:
+                    self.logger.warning(
+                        f"{link} looks like unextracted PDF binary via {scraper_name} "
+                        f"(no .pdf suffix, so get_scraper() didn't route it to "
+                        f"PyMuPDFScraper) -- retrying with PyMuPDFScraper"
+                    )
+                    retried = await self._retry_as_pdf(link, session)
+                    if retried is not None:
+                        return retried
+                    self.logger.warning(f"PyMuPDFScraper retry also failed for {link}")
+                    return {
+                        "url": link,
+                        "raw_content": None,
+                        "image_urls": [],
+                        "title": title,
+                    }
+
                 return {
                     "url": link,
                     "raw_content": content,
@@ -168,6 +208,29 @@ class Scraper:
             except Exception as e:
                 self.logger.error(f"Error processing {link}: {str(e)}")
                 return {"url": link, "raw_content": None, "image_urls": [], "title": ""}
+
+    async def _retry_as_pdf(self, link, session):
+        """Re-fetch link with PyMuPDFScraper after the scraper get_scraper()
+        originally picked returned unextracted PDF binary.
+
+        Returns the normal extract_data_from_url result dict on success, or
+        None if the retry also failed to produce usable content (so the
+        caller falls back to treating this as an ordinary fetch failure
+        instead of passing binary through).
+        """
+        scraper = PyMuPDFScraper(link, session)
+        content, image_urls, title = await asyncio.get_running_loop().run_in_executor(
+            self.worker_pool.executor, scraper.scrape
+        )
+        if not content or len(content) < 100:
+            return None
+        self.logger.info(f"PyMuPDFScraper retry recovered {len(content)} characters for {link}")
+        return {
+            "url": link,
+            "raw_content": content,
+            "image_urls": image_urls,
+            "title": title,
+        }
 
     def get_scraper(self, link):
         """

--- a/tests/test_scraper_pdf_retry.py
+++ b/tests/test_scraper_pdf_retry.py
@@ -1,0 +1,174 @@
+"""Regression tests for extensionless-PDF detection and retry.
+
+PDFs served from institutional repository download endpoints (DSpace/
+EPrints-style, e.g. "scholarspace.manoa.hawaii.edu/bitstreams/<uuid>/
+download") have no ".pdf" suffix, so Scraper.get_scraper() routes them to
+a text/HTML backend instead of PyMuPDFScraper. That backend has no way to
+decode the PDF body and returns its raw bytes (FlateDecode streams, xref
+tables, /Annot objects) as if it were real page text -- silently: no
+exception, a normal-looking content_length, unusable content.
+
+_looks_like_unextracted_pdf is unit-tested directly; the retry path is
+exercised through extract_data_from_url with both the originally-dispatched
+backend and PyMuPDFScraper replaced by stubs, to confirm the method
+actually retries and recovers, or falls back to a fetch-failure shape if
+the retry also fails.
+"""
+
+import unittest
+
+from gpt_researcher.scraper.scraper import Scraper, _looks_like_unextracted_pdf
+
+
+class LooksLikeUnextractedPdfTests(unittest.TestCase):
+    def test_pdf_magic_bytes_detected(self):
+        self.assertTrue(_looks_like_unextracted_pdf("%PDF-1.4\n%\xe2\xe3\xcf\xd3\n" + "x" * 200))
+
+    def test_structural_tokens_detected(self):
+        text = (
+            "\xff\xd8V Kg-\xcd\xa5 ... endstream\nendobj\n"
+            "38 0 obj\n<< /Type /Annot /BS 3782 0 R /AP 3783 0 R >>\nendobj\n"
+            "xref\n0001355793 00000 n trailer\n"
+        )
+        self.assertTrue(_looks_like_unextracted_pdf(text))
+
+    def test_single_incidental_token_not_flagged(self):
+        # A single overlapping word (e.g. an article that happens to
+        # mention a "trailer") must not alone trigger this -- it requires
+        # at least two independent structural markers.
+        text = "The movie trailer was released online ahead of the premiere. " * 10
+        self.assertFalse(_looks_like_unextracted_pdf(text))
+
+    def test_normal_prose_not_flagged(self):
+        text = "This is a normal article about Catala, a domain-specific language for tax law."
+        self.assertFalse(_looks_like_unextracted_pdf(text))
+
+
+class _NullLogger:
+    def warning(self, *a, **k):
+        pass
+
+    def info(self, *a, **k):
+        pass
+
+
+class _FakeWorkerPool:
+    class _NullThrottle:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    def throttle(self):
+        return self._NullThrottle()
+
+    @property
+    def executor(self):
+        return None
+
+
+class ExtractDataFromUrlPdfRetryTests(unittest.IsolatedAsyncioTestCase):
+    """Drives the real extract_data_from_url/_retry_as_pdf path, with
+    get_scraper() and the module-level PyMuPDFScraper name replaced by
+    stubs -- no real network or PDF parsing involved."""
+
+    PDF_GARBAGE = (
+        "\xff\xd8V Kg-\xcd\xa5 ... endstream\nendobj\n"
+        "38 0 obj\n<< /Type /Annot /BS 3782 0 R /AP 3783 0 R >>\nendobj\n"
+        "xref\n0001355793 00000 n trailer\n"
+    ) * 5
+
+    def _scraper(self):
+        return Scraper(urls=["https://example.com"], user_agent="ua", scraper="bs", worker_pool=_FakeWorkerPool())
+
+    async def test_retries_and_recovers_via_pymupdf(self):
+        scraper = self._scraper()
+        scraper.logger = _NullLogger()
+
+        wrong_backend = type(
+            "WrongBackend",
+            (),
+            {
+                "__init__": lambda self, link, session: None,
+                "scrape": lambda self: (ExtractDataFromUrlPdfRetryTests.PDF_GARBAGE, [], ""),
+            },
+        )
+        clean_pdf_text = "This is the real, cleanly-extracted PDF text. " * 10
+        pymupdf_stub = type(
+            "PyMuPDFStub",
+            (),
+            {
+                "__init__": lambda self, link, session: None,
+                "scrape": lambda self: (clean_pdf_text, [], "Recovered Title"),
+            },
+        )
+
+        scraper.get_scraper = lambda link: wrong_backend
+
+        import gpt_researcher.scraper.scraper as scraper_module
+
+        original_pymupdf = scraper_module.PyMuPDFScraper
+        scraper_module.PyMuPDFScraper = pymupdf_stub
+        try:
+            result = await scraper.extract_data_from_url("https://repo.example.edu/bitstream/x/download", scraper.session)
+        finally:
+            scraper_module.PyMuPDFScraper = original_pymupdf
+
+        self.assertEqual(result["raw_content"], clean_pdf_text)
+        self.assertEqual(result["title"], "Recovered Title")
+
+    async def test_retry_failure_falls_back_to_fetch_failure_shape(self):
+        scraper = self._scraper()
+        scraper.logger = _NullLogger()
+
+        wrong_backend = type(
+            "WrongBackend",
+            (),
+            {
+                "__init__": lambda self, link, session: None,
+                "scrape": lambda self: (ExtractDataFromUrlPdfRetryTests.PDF_GARBAGE, [], ""),
+            },
+        )
+        pymupdf_stub_fails = type(
+            "PyMuPDFStubFails",
+            (),
+            {
+                "__init__": lambda self, link, session: None,
+                "scrape": lambda self: ("", [], ""),
+            },
+        )
+
+        scraper.get_scraper = lambda link: wrong_backend
+
+        import gpt_researcher.scraper.scraper as scraper_module
+
+        original_pymupdf = scraper_module.PyMuPDFScraper
+        scraper_module.PyMuPDFScraper = pymupdf_stub_fails
+        try:
+            result = await scraper.extract_data_from_url("https://repo.example.edu/bitstream/x/download", scraper.session)
+        finally:
+            scraper_module.PyMuPDFScraper = original_pymupdf
+
+        self.assertIsNone(result["raw_content"])
+
+    async def test_legitimate_content_not_retried(self):
+        scraper = self._scraper()
+        scraper.logger = _NullLogger()
+
+        good_backend = type(
+            "GoodBackend",
+            (),
+            {
+                "__init__": lambda self, link, session: None,
+                "scrape": lambda self: ("A normal article with real prose content. " * 10, [], "Title"),
+            },
+        )
+        scraper.get_scraper = lambda link: good_backend
+
+        result = await scraper.extract_data_from_url("https://example.com/article", scraper.session)
+        self.assertIn("normal article", result["raw_content"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Scraper.get_scraper()` picks a backend from the URL's suffix, but PDFs served from institutional repository download endpoints (DSpace/EPrints-style, e.g. `scholarspace.manoa.hawaii.edu/bitstreams/<uuid>/download`) have no `.pdf` suffix. Those fall through to a text/HTML scraper, which has no way to decode the PDF body and returns its raw bytes (FlateDecode streams, xref tables, `/Annot` objects) as if it were the page's real text — silently: no exception, a normal-looking `content_length`, just unusable content passed on to synthesis.

This matters specifically because institutional repositories are where a lot of the highest-value open-access primaries live for research/regulatory queries — theses, preprints, university-hosted studies — so this bug hits exactly the sources that matter most, while working correctly for publisher PDFs that do end in `.pdf`.

## Fix

After a scrape completes, check whether the content looks like unextracted PDF binary — starts with `%PDF-`, or contains at least two independent PDF structural tokens (`endobj`/`endstream`/`/FlateDecode`/`xref`/`trailer` — syntax that essentially never occurs, even coincidentally, in real prose). If so, and the originally-dispatched backend wasn't already `PyMuPDFScraper`, retry the same URL directly with `PyMuPDFScraper`. Recovering real content this way is a better outcome than discarding the source outright.

## Verification against the real, reported-broken URL (not just synthetic test data)

Fetched `https://scholarspace.manoa.hawaii.edu/bitstreams/5b99bd69-e789-4864-9cd8-4fe3d912b55a/download` and ran it through the same `BeautifulSoup` → `clean_soup` → `get_text_from_soup` path `Scraper` actually uses:

- Reproduces the exact reported symptom: **1,346,436** "extracted" characters of raw PDF binary — matches the `content_length` in the bug report byte-for-byte.
- Detection correctly fires on this real content.
- Running the same file through `PyMuPDFLoader` (what the retry path uses) recovers **61,260** characters of clean, readable text — the actual paper ("Detection of Contradictions and Inconsistencies in Regulatory Documents using Prompt-Engineering").

## Test plan

`tests/test_scraper_pdf_retry.py`:
- Unit tests for the detection helper, including a false-positive guard (a single incidental word like "trailer" appearing in ordinary prose must not alone trigger it — two independent structural tokens are required).
- Integration-style tests driving the full `extract_data_from_url` retry path with both the originally-dispatched backend and `PyMuPDFScraper` replaced by stubs: successful recovery, retry-also-fails (falls back to a normal fetch-failure shape rather than passing binary through), and the already-correct-backend case (no retry loop).
- Ran alongside the existing scraper suite (`test_scraper_extract_title.py`, `test_scraper_get_scraper.py`, `test_arxiv_scraper.py`): 20 passed, no regressions.