### PR TITLE
fix: cap SearxSearch/Duckduckgo snippet length so real pages actually get scraped

### DIFF
--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -1,6 +1,23 @@
 from itertools import islice
 from ..utils import check_pkg
 
+# gpt_researcher.skills.researcher._search_relevant_source_urls() treats
+# any search result whose raw_content/body exceeds 100 characters as
+# already-fetched full text -- a heuristic meant for retrievers (e.g.
+# PubMed Central) that genuinely return full article text inline. ddgs
+# populates "body" with an ordinary search-result snippet, which routinely
+# exceeds 100 characters, so without this cap every result is wrongly
+# treated as already-fetched and the real page is never actually scraped
+# (get_source_urls() then returns [] and reports ship with zero verifiable
+# citations). Capped here, at the source, rather than patched in
+# _search_relevant_source_urls() itself, so any future upstream change to
+# that function's classification logic (bug fixes, new bookkeeping) is
+# inherited automatically. The truncated snippet is only ever used for
+# that classification decision and early-stage sub-query planning -- once
+# a URL takes the real scrape path, gpt-researcher fetches and uses the
+# actual page content, not this snippet.
+_MAX_PREFETCHED_LEN = 100
+
 
 class Duckduckgo:
     """
@@ -51,7 +68,7 @@ class Duckduckgo:
                 or result.get("description")
                 or ""
             )
-            item = {"href": href, "body": body}
+            item = {"href": href, "body": body[:_MAX_PREFETCHED_LEN]}
             title = result.get("title")
             if title:
                 item["title"] = title

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -4,6 +4,23 @@ import requests
 from typing import List, Dict
 from urllib.parse import urljoin
 
+# gpt_researcher.skills.researcher._search_relevant_source_urls() treats
+# any search result whose raw_content/body exceeds 100 characters as
+# already-fetched full text -- a heuristic meant for retrievers (e.g.
+# PubMed Central) that genuinely return full article text inline. SearxNG
+# populates "body" with an ordinary search-result snippet, which routinely
+# exceeds 100 characters, so without this cap every result is wrongly
+# treated as already-fetched and the real page is never actually scraped
+# (get_source_urls() then returns [] and reports ship with zero verifiable
+# citations). Capped here, at the source, rather than patched in
+# _search_relevant_source_urls() itself, so any future upstream change to
+# that function's classification logic (bug fixes, new bookkeeping) is
+# inherited automatically. The truncated snippet is only ever used for
+# that classification decision and early-stage sub-query planning -- once
+# a URL takes the real scrape path, gpt-researcher fetches and uses the
+# actual page content, not this snippet.
+_MAX_PREFETCHED_LEN = 100
+
 
 class SearxSearch():
     """
@@ -80,9 +97,10 @@ class SearxSearch():
             href = result.get('url') or result.get('href') or ''
             if not href:
                 continue
+            body = result.get('content') or result.get('snippet') or ''
             search_response.append({
                 "href": href,
-                "body": result.get('content') or result.get('snippet') or '',
+                "body": body[:_MAX_PREFETCHED_LEN],
             })
             if len(search_response) >= max_results:
                 break

--- a/tests/test_duckduckgo_normalize.py
+++ b/tests/test_duckduckgo_normalize.py
@@ -68,6 +68,24 @@ class DuckduckgoNormalizeTests(unittest.TestCase):
         retriever.ddg.text.return_value = None
         self.assertEqual(Duckduckgo.search(retriever), [])
 
+    def test_long_snippet_capped_to_100_chars(self):
+        # gpt_researcher.skills.researcher._search_relevant_source_urls()
+        # treats any body over 100 chars as already-fetched full text, which
+        # skips the real scrape -- see issue #17. ddgs's ordinary result
+        # snippets routinely exceed 100 chars, so this must be capped at the
+        # source or every result is wrongly treated as pre-fetched.
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        retriever = Duckduckgo.__new__(Duckduckgo)
+        retriever.query = "python"
+        retriever.query_domains = None
+        retriever.ddg = MagicMock()
+        long_snippet = "y" * 250
+        retriever.ddg.text.return_value = [{"href": "https://example.com/a", "body": long_snippet}]
+        results = Duckduckgo.search(retriever, max_results=5)
+        self.assertEqual(len(results[0]["body"]), 100)
+        self.assertEqual(results[0]["body"], long_snippet[:100])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_searx_malformed_results.py
+++ b/tests/test_searx_malformed_results.py
@@ -69,6 +69,23 @@ class SearxMalformedTests(unittest.TestCase):
         with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}):
             self.assertEqual(mod.SearxSearch("q").search(), [])
 
+    def test_long_snippet_capped_to_100_chars(self):
+        # gpt_researcher.skills.researcher._search_relevant_source_urls()
+        # treats any body over 100 chars as already-fetched full text, which
+        # skips the real scrape -- see issue #17. SearxNG's ordinary result
+        # snippets routinely exceed 100 chars, so this must be capped at the
+        # source or every result is wrongly treated as pre-fetched.
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        long_snippet = "y" * 250
+        resp.json.return_value = {"results": [{"url": "https://a.example", "content": long_snippet}]}
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}):
+            out = mod.SearxSearch("q").search(max_results=10)
+        self.assertEqual(len(out[0]["body"]), 100)
+        self.assertEqual(out[0]["body"], long_snippet[:100])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`gpt_researcher.skills.researcher._search_relevant_source_urls()` treats any search result whose `raw_content`/`body` exceeds 100 characters as already-fetched full text — a heuristic meant for retrievers (e.g. PubMed Central) that genuinely return full article text inline. `SearxSearch` and `Duckduckgo` both populate `"body"` with an ordinary search-result snippet, which routinely exceeds 100 characters, so every result from either retriever was wrongly treated as already-fetched and the real page was never actually scraped — `get_source_urls()` always returned `[]`, and report citations weren't grounded in anything actually fetched (in one observed case, a citation named the wrong CELEX number for the regulation it referenced).

## Fix

Cap `body` at 100 characters at the retriever source (`SearxSearch.search`/`Duckduckgo.search`), rather than patching `_search_relevant_source_urls()`'s classification logic itself — this way any future upstream change to that function (bug fixes, new bookkeeping) is inherited automatically rather than shadowed by a stale reimplementation. The truncated snippet is only ever used for the classification decision and early-stage sub-query planning; once a URL takes the real scrape path, gpt-researcher fetches and uses the actual page content, not this snippet.

This has been running in production (as an external monkeypatch, prior to this PR) for about two days at time of writing, with confirmed improvement: retrieval quality — including correctly finding and citing primary sources — improved markedly once this was in place.

## Test plan

- `tests/test_searx_malformed_results.py` / `tests/test_duckduckgo_normalize.py`: added a case each asserting a 250-char snippet is capped to exactly 100 chars, alongside the existing malformed-result-handling tests for both retrievers (both still pass unchanged, since their existing test snippets are all well under 100 chars).