### PR TITLE
fix(curator): recover fenced LLM JSON instead of dropping curation

### DIFF
--- a/gpt_researcher/skills/curator.py
+++ b/gpt_researcher/skills/curator.py
@@ -4,8 +4,10 @@ This module provides the SourceCurator class that evaluates and ranks
 research sources based on relevance, credibility, and reliability.
 """
 
-import json
 from typing import Dict, List, Optional
+
+import json_repair
+from langchain_core.utils.json import parse_json_markdown
 
 from ..actions import stream_output
 from ..config.config import Config
@@ -71,7 +73,20 @@ class SourceCurator:
                 cost_callback=self.researcher.add_costs,
             )
 
-            curated_sources = json.loads(response)
+            # LLMs frequently wrap the JSON in ```json fences or add prose
+            # despite the prompt's instructions, which plain json.loads cannot
+            # parse. Recover the payload the same way the rest of the codebase
+            # does (see actions/query_processing.py, multi_agents/agents/utils/
+            # llms.py) so a well-formed-but-fenced response is not discarded.
+            curated_sources = parse_json_markdown(response, parser=json_repair.loads)
+            # json_repair never raises: on unusable output it returns "" or a
+            # dict rather than a list. Guard so such a result still falls back
+            # to the uncurated sources below instead of emptying the context.
+            if not isinstance(curated_sources, list):
+                raise ValueError(
+                    f"expected a JSON list of sources, got "
+                    f"{type(curated_sources).__name__}"
+                )
             print(f"\n\nFinal Curated sources {len(source_data)} sources: {curated_sources}")
 
             if self.researcher.verbose:

--- a/tests/test_source_curator_json_parsing.py
+++ b/tests/test_source_curator_json_parsing.py
@@ -1,0 +1,90 @@
+"""Regression: SourceCurator must recover fenced/malformed LLM JSON.
+
+Models routinely wrap their JSON in ```json fences despite the curator
+prompt's "no markdown" instruction. Plain ``json.loads`` raises on that
+output, which sent ``curate_sources`` down its except-branch and silently
+returned the *full uncurated* source set — defeating the curation the user
+opted into via ``cfg.curate_sources``. The parser now matches the rest of
+the codebase (``parse_json_markdown`` + ``json_repair``), so a
+well-formed-but-fenced response is parsed instead of discarded.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gpt_researcher.skills.curator import SourceCurator
+
+
+def _fake_researcher():
+    """Minimal researcher stub exercising only what curate_sources reads."""
+    return SimpleNamespace(
+        verbose=False,
+        websocket=None,
+        role="system role",
+        query="market share of EVs",
+        cfg=SimpleNamespace(
+            smart_llm_model="openai:gpt-x",
+            smart_llm_provider="openai",
+            llm_kwargs={},
+        ),
+        prompt_family=SimpleNamespace(curate_sources=lambda *a, **k: "curate prompt"),
+        add_costs=lambda *a, **k: None,
+    )
+
+
+SOURCES = [
+    {"Title": "A", "Content": "a", "Source": "https://a.example"},
+    {"Title": "B", "Content": "b", "Source": "https://b.example"},
+    {"Title": "C", "Content": "c", "Source": "https://c.example"},
+]
+
+
+@pytest.mark.asyncio
+async def test_markdown_fenced_response_is_parsed_not_dropped(monkeypatch):
+    fenced = (
+        "```json\n"
+        '[{"Title": "A", "Content": "a", "Source": "https://a.example"}]\n'
+        "```"
+    )
+    monkeypatch.setattr(
+        "gpt_researcher.skills.curator.create_chat_completion",
+        AsyncMock(return_value=fenced),
+    )
+
+    result = await SourceCurator(_fake_researcher()).curate_sources(SOURCES)
+
+    # Curation succeeded: the single ranked source, NOT the 3 uncurated ones.
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0]["Source"] == "https://a.example"
+    assert result is not SOURCES
+
+
+@pytest.mark.asyncio
+async def test_clean_unfenced_response_still_parses(monkeypatch):
+    clean = '[{"Title": "B", "Content": "b", "Source": "https://b.example"}]'
+    monkeypatch.setattr(
+        "gpt_researcher.skills.curator.create_chat_completion",
+        AsyncMock(return_value=clean),
+    )
+
+    result = await SourceCurator(_fake_researcher()).curate_sources(SOURCES)
+
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0]["Source"] == "https://b.example"
+
+
+@pytest.mark.asyncio
+async def test_non_list_response_falls_back_to_uncurated(monkeypatch):
+    # A non-list result (json_repair returns "" / a dict for unusable output
+    # instead of raising) must NOT be treated as a curation result — the
+    # existing safety net that returns the uncurated sources must still fire.
+    monkeypatch.setattr(
+        "gpt_researcher.skills.curator.create_chat_completion",
+        AsyncMock(return_value='{"not": "a list"}'),
+    )
+
+    result = await SourceCurator(_fake_researcher()).curate_sources(SOURCES)
+
+    assert result is SOURCES


### PR DESCRIPTION
Fixes #1953.

### Problem

`SourceCurator.curate_sources` parses the model response with plain `json.loads`:

```python
curated_sources = json.loads(response)
```

Models routinely wrap the array in ` ```json ` fences or add a prose preamble despite the prompt's "no markdown" instruction. `json.loads` raises on that, so the call drops into the `except` branch and returns the **full, uncurated** source set — with only a `🚫 Source verification failed` log line that misattributes the failure to the sources/model rather than the parser. With `CURATE_SOURCES=True`, the feature silently no-ops on ordinary model output (and can be broken on *every* call for less instruction-compliant/local models).

### Why this is a gap, not intentional

The rest of the codebase already parses LLM JSON robustly with the shipped `json-repair` dependency:

- `actions/query_processing.py` → `json_repair.loads(response)`
- `skills/deep_research.py` → `json_repair.loads(...)`
- `multi_agents/agents/utils/llms.py` → `parse_json_markdown(response, parser=json_repair.loads)`
- `actions/agent_creator.py` explicitly falls back to `json_repair` "to recover…from malformed JSON responses"

The curator is the lone LLM-JSON call site using bare `json.loads` with no recovery.

### Fix

Parse the response the same way `multi_agents` already does. No new dependency (both `json_repair` and `parse_json_markdown` are already used in-repo).

The existing "fall back to uncurated sources" safety net is preserved with an explicit list-type guard: unlike `json.loads`, `json_repair` never raises — on unusable output it returns `""` or a `dict`. Without the guard, such a result would slip past the `except` branch and empty the report context. Rejecting a non-list result keeps the graceful degradation intact.

### Tests

Adds `tests/test_source_curator_json_parsing.py` covering three cases: a markdown-fenced response is now parsed to the ranked source (not the uncurated set); clean output still parses; and a non-list response falls back to the uncurated sources.

### Risk

Minimal — one parse call swapped, strictly more permissive than before, so no previously-passing input regresses.
