### PR TITLE
fix(image_generator): recover fenced LLM JSON via json_repair

### DIFF
--- a/gpt_researcher/skills/image_generator.py
+++ b/gpt_researcher/skills/image_generator.py
@@ -8,6 +8,8 @@ import asyncio
 import json
 import logging
 import re
+
+import json_repair
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..actions.utils import stream_output
@@ -243,15 +245,12 @@ Return 2-3 visualization concepts as a JSON array:"""
                 cost_callback=self.researcher.add_costs,
             )
             
-            # Parse JSON response
-            response = response.strip()
-            # Remove markdown code blocks if present
-            if response.startswith("```"):
-                response = re.sub(r'^```(?:json)?\n?', '', response)
-                response = re.sub(r'\n?```$', '', response)
-            
-            concepts = json.loads(response)
-            
+            # Parse JSON response (models often fence/preamble JSON; match deep_research)
+            concepts = json_repair.loads(response)
+            if not isinstance(concepts, list):
+                logger.error("Image planning response was not a JSON array")
+                return []
+
             # Validate and limit to max_images
             valid_concepts = []
             for concept in concepts[:self.max_images]:
@@ -435,18 +434,20 @@ Return ONLY the JSON, no additional text."""
             List of image suggestion dictionaries.
         """
         try:
-            # Try to extract JSON from the response
-            json_match = re.search(r'\{[\s\S]*\}', response)
-            if not json_match:
-                logger.warning("No JSON found in analysis response")
+            data = json_repair.loads(response)
+            if not isinstance(data, dict):
+                logger.warning("No JSON object found in analysis response")
                 return []
-            
-            data = json.loads(json_match.group())
-            suggestions = data.get("suggestions", [])
-            
+
+            suggestions = data.get("suggestions", []) or []
+            if not isinstance(suggestions, list):
+                return []
+
             # Enrich with section data
             enriched = []
             for s in suggestions:
+                if not isinstance(s, dict):
+                    continue
                 section_num = s.get("section_number", 0) - 1  # Convert to 0-indexed
                 if 0 <= section_num < len(sections):
                     section = sections[section_num]
@@ -457,10 +458,10 @@ Return ONLY the JSON, no additional text."""
                         "reason": s.get("reason", ""),
                         "insert_after_line": section["start_line"],
                     })
-            
+
             return enriched
-            
-        except json.JSONDecodeError as e:
+
+        except Exception as e:
             logger.error(f"Failed to parse analysis JSON: {e}")
             return []
     

--- a/tests/test_image_generator_json_repair.py
+++ b/tests/test_image_generator_json_repair.py
@@ -1,0 +1,67 @@
+"""Image planning/analysis should recover fenced LLM JSON via json_repair."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gpt_researcher.skills.image_generator import ImageGenerator
+
+
+def _make_generator(max_images: int = 3) -> ImageGenerator:
+    researcher = SimpleNamespace(
+        cfg=SimpleNamespace(
+            fast_llm_model="test",
+            fast_llm_provider="openai",
+            llm_kwargs={},
+        ),
+        add_costs=lambda *_a, **_k: None,
+    )
+    gen = ImageGenerator.__new__(ImageGenerator)
+    gen.researcher = researcher
+    gen.cfg = researcher.cfg
+    gen.max_images = max_images
+    gen.image_provider = None
+    return gen
+
+
+@pytest.mark.asyncio
+async def test_plan_images_recovers_fenced_json(monkeypatch):
+    gen = _make_generator()
+
+    async def fake_chat(**kwargs):
+        return (
+            'Here you go:\n```json\n'
+            '[{"title": "Arch", "prompt": "diagram of layers"}]\n'
+            '```'
+        )
+
+    monkeypatch.setattr(
+        "gpt_researcher.skills.image_generator.create_chat_completion",
+        fake_chat,
+    )
+    concepts = await gen._plan_image_concepts("report text", "query")
+    assert concepts == [{"title": "Arch", "prompt": "diagram of layers"}]
+
+
+def test_parse_analysis_recovers_fenced_object():
+    gen = _make_generator()
+    sections = [
+        {"header": "Intro", "content": "hello world", "start_line": 1},
+    ]
+    response = (
+        'Sure.\n```json\n{"suggestions":[{"section_number":1,'
+        '"image_prompt":"p","reason":"r"}]}\n```'
+    )
+    out = gen._parse_analysis_response(response, sections)
+    assert len(out) == 1
+    assert out[0]["section_header"] == "Intro"
+    assert out[0]["image_prompt"] == "p"
+
+
+def test_parse_analysis_skips_non_dict_suggestions():
+    gen = _make_generator()
+    sections = [{"header": "H", "content": "c", "start_line": 0}]
+    response = '{"suggestions":[null, "x", {"section_number":1,"image_prompt":"ok"}]}'
+    out = gen._parse_analysis_response(response, sections)
+    assert len(out) == 1
+    assert out[0]["image_prompt"] == "ok"


### PR DESCRIPTION
## Summary

- `_plan_image_concepts` and `_parse_analysis_response` used bare `json.loads` (plus a brittle fence strip only when the response *starts* with fences).
- LLM replies that include a prose preamble or fenced JSON still failed parse and returned empty concepts/suggestions, so image generation silently no-ops.
- Switch both paths to `json_repair.loads` (already a hard dep used by `deep_research` / `query_processing`) and guard non-list/non-dict payloads.

## Motivation

Same class of failure as curator issue #1953 and the deep_research parsers: models frequently fence JSON despite "JSON only" prompts. Image generation already failed closed to `[]` on decode errors, so the feature looked configured but never drew. Aligning with `json_repair` restores the intended path without new dependencies.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_image_generator_json_repair.py -q
3 passed
```

Bare `json.loads` on fenced input raises `JSONDecodeError`; `json_repair.loads` returns the array/object (covered by tests).

## Real behavior proof

```text
>>> import json
>>> json.loads('Here you go:\n```json\n[{"title":"Arch","prompt":"diagram"}]\n```')
JSONDecodeError
>>> import json_repair
>>> json_repair.loads('Here you go:\n```json\n[{"title":"Arch","prompt":"diagram"}]\n```')
[{'title': 'Arch', 'prompt': 'diagram'}]
```
