### PR TITLE
fix(mcp): recover fenced tool-selection JSON via json_repair

### DIFF
--- a/gpt_researcher/mcp/tool_selector.py
+++ b/gpt_researcher/mcp/tool_selector.py
@@ -6,6 +6,8 @@ Handles intelligent tool selection using LLM analysis.
 import asyncio
 import json
 import logging
+
+import json_repair
 from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -80,32 +82,28 @@ class MCPToolSelector:
             response_preview = response[:500] + "..." if len(response) > 500 else response
             logger.debug(f"LLM tool selection response: {response_preview}")
             
-            # Parse LLM response
+            # Parse LLM response — json_repair handles fences/preambles (same as deep_research)
             try:
-                selection_result = json.loads(response)
-            except json.JSONDecodeError:
-                # Try to extract JSON from response
-                import re
-                json_match = re.search(r"\{.*\}", response, re.DOTALL)
-                if json_match:
-                    try:
-                        selection_result = json.loads(json_match.group(0))
-                    except json.JSONDecodeError:
-                        logger.warning("Could not parse extracted JSON, using fallback")
-                        return self._fallback_tool_selection(all_tools, max_tools)
-                else:
-                    logger.warning("No JSON found in LLM response, using fallback")
-                    return self._fallback_tool_selection(all_tools, max_tools)
-            
+                selection_result = json_repair.loads(response)
+            except Exception:
+                logger.warning("Could not parse LLM tool selection JSON, using fallback")
+                return self._fallback_tool_selection(all_tools, max_tools)
+
+            if not isinstance(selection_result, dict):
+                logger.warning("Tool selection response was not a JSON object, using fallback")
+                return self._fallback_tool_selection(all_tools, max_tools)
+
             selected_tools = []
-            
+
             # Process selected tools
-            for tool_selection in selection_result.get("selected_tools", []):
+            for tool_selection in selection_result.get("selected_tools", []) or []:
+                if not isinstance(tool_selection, dict):
+                    continue
                 tool_index = tool_selection.get("index")
                 tool_name = tool_selection.get("name", "")
                 reason = tool_selection.get("reason", "")
                 relevance_score = tool_selection.get("relevance_score", 0)
-                
+
                 if tool_index is not None and 0 <= tool_index < len(all_tools):
                     selected_tools.append(all_tools[tool_index])
                     logger.info(f"Selected tool '{tool_name}' (score: {relevance_score}): {reason}")

--- a/tests/test_mcp_tool_selector_json_repair.py
+++ b/tests/test_mcp_tool_selector_json_repair.py
@@ -1,0 +1,76 @@
+"""MCP tool selector should recover fenced LLM JSON via json_repair."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gpt_researcher.mcp.tool_selector import MCPToolSelector
+
+
+class _Tool:
+    def __init__(self, name, description="d"):
+        self.name = name
+        self.description = description
+
+
+@pytest.mark.asyncio
+async def test_select_recovers_fenced_json(monkeypatch):
+    selector = MCPToolSelector(cfg=SimpleNamespace())
+    tools = [_Tool("a"), _Tool("b"), _Tool("c")]
+
+    async def fake_llm(prompt):
+        return (
+            'Pick these:\n```json\n'
+            '{"selected_tools":[{"index":1,"name":"b","reason":"yes","relevance_score":9}],'
+            '"selection_reasoning":"best"}\n```'
+        )
+
+    monkeypatch.setattr(selector, "_call_llm_for_tool_selection", fake_llm)
+    # avoid prompt import path churn if select builds prompt first
+    monkeypatch.setattr(
+        "gpt_researcher.prompts.PromptFamily.generate_mcp_tool_selection_prompt",
+        staticmethod(lambda *a, **k: "prompt"),
+        raising=False,
+    )
+    # patch where imported inside method
+    import gpt_researcher.mcp.tool_selector as mod
+
+    class PF:
+        @staticmethod
+        def generate_mcp_tool_selection_prompt(*a, **k):
+            return "prompt"
+
+    monkeypatch.setattr(mod, "PromptFamily", PF, raising=False)
+
+    # The method does: from ..prompts import PromptFamily inside try path
+    import gpt_researcher.prompts as prompts_mod
+
+    monkeypatch.setattr(
+        prompts_mod.PromptFamily,
+        "generate_mcp_tool_selection_prompt",
+        staticmethod(lambda *a, **k: "prompt"),
+    )
+
+    selected = await selector.select_relevant_tools("q", tools, max_tools=2)
+    assert [t.name for t in selected] == ["b"]
+
+
+@pytest.mark.asyncio
+async def test_select_skips_non_dict_tool_rows(monkeypatch):
+    selector = MCPToolSelector(cfg=SimpleNamespace())
+    tools = [_Tool("a"), _Tool("b")]
+
+    async def fake_llm(prompt):
+        return '{"selected_tools":[null, {"index":0,"name":"a","reason":"r","relevance_score":1}],"selection_reasoning":"x"}'
+
+    monkeypatch.setattr(selector, "_call_llm_for_tool_selection", fake_llm)
+    import gpt_researcher.prompts as prompts_mod
+
+    monkeypatch.setattr(
+        prompts_mod.PromptFamily,
+        "generate_mcp_tool_selection_prompt",
+        staticmethod(lambda *a, **k: "prompt"),
+    )
+
+    selected = await selector.select_relevant_tools("q", tools, max_tools=2)
+    assert [t.name for t in selected] == ["a"]


### PR DESCRIPTION
## Summary

- `MCPToolSelector.select_relevant_tools` parsed the LLM reply with bare `json.loads` + a brittle `{...}` regex extract.
- Fenced / preambled JSON failed parse and dropped into `_fallback_tool_selection`, ignoring the model’s ranking.
- Use `json_repair.loads` (existing hard dep) and skip non-dict `selected_tools` rows.

## Motivation

Same silent-degrade class as image planning and deep_research JSON paths. When MCP tool selection is enabled, a fence should not erase the LLM ranking.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_mcp_tool_selector_json_repair.py -q
2 passed
```

## Real behavior proof

```text
>>> import json
>>> json.loads('Pick:\n```json\n{"selected_tools":[{"index":1}]}\n```')
JSONDecodeError
>>> import json_repair
>>> json_repair.loads('Pick:\n```json\n{"selected_tools":[{"index":1}]}\n```')
{'selected_tools': [{'index': 1}]}
```
