### PR TITLE
fix(config): coerce list/dict env JSON via json_repair

### DIFF
--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -6,6 +6,7 @@ retrievers, and various operational parameters.
 """
 
 import json
+import json_repair
 import os
 import warnings
 from typing import Any, Dict, List, Type, Union, get_args, get_origin
@@ -283,10 +284,24 @@ class Config:
             return float(env_value)
         elif type_hint in (str, Any):
             return env_value
-        elif origin is list or origin is List:
-            return json.loads(env_value)
+        elif type_hint is list or origin is list or origin is List:
+            # Env values are often hand-edited (trailing commas, single quotes).
+            # Bare `list` has get_origin(None); typing.List[...] has origin list.
+            try:
+                value = json_repair.loads(env_value)
+            except Exception as exc:
+                raise ValueError(f"Cannot convert {env_value} to list") from exc
+            if not isinstance(value, list):
+                raise ValueError(f"Cannot convert {env_value} to list")
+            return value
         elif type_hint is dict:
-            return json.loads(env_value)
+            try:
+                value = json_repair.loads(env_value)
+            except Exception as exc:
+                raise ValueError(f"Cannot convert {env_value} to dict") from exc
+            if not isinstance(value, dict):
+                raise ValueError(f"Cannot convert {env_value} to dict")
+            return value
         else:
             raise ValueError(f"Unsupported type {type_hint} for key {key}")
 

--- a/tests/test_convert_env_value_json_repair.py
+++ b/tests/test_convert_env_value_json_repair.py
@@ -1,0 +1,32 @@
+"""List/dict env coercion should tolerate near-JSON via json_repair."""
+
+import pytest
+
+from gpt_researcher.config.config import Config
+
+
+def test_list_env_trailing_comma():
+    assert Config.convert_env_value("DOMAINS", '["a.com", "b.com",]', list) == [
+        "a.com",
+        "b.com",
+    ]
+
+
+def test_dict_env_trailing_comma():
+    assert Config.convert_env_value("META", '{"k": "v",}', dict) == {"k": "v"}
+
+
+def test_list_env_rejects_non_list():
+    with pytest.raises(ValueError):
+        Config.convert_env_value("DOMAINS", '{"not":"a-list"}', list)
+
+
+def test_dict_env_rejects_non_dict():
+    with pytest.raises(ValueError):
+        Config.convert_env_value("META", '["not-a-dict"]', dict)
+
+
+def test_list_env_with_typing_list():
+    from typing import List
+
+    assert Config.convert_env_value("DOMAINS", '["a",]', List[str]) == ["a"]


### PR DESCRIPTION
## Summary

- `Config.convert_env_value` used bare `json.loads` for `list` / `dict` env values.
- Hand-edited env (trailing commas, minor JSON glitches) raised at import/startup.
- Parse with `json_repair.loads` and reject wrong container types with `ValueError`.

## Motivation

Operators often put `RETRIEVER` domain lists and MCP/JSON knobs in `.env` by hand. A trailing comma should not take down the process when `json-repair` is already a core dependency.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_convert_env_value_json_repair.py tests/test_convert_env_value_optional.py -q
6 passed
```

## Real behavior proof

```text
>>> import json
>>> json.loads('["a.com", "b.com",]')
JSONDecodeError
>>> import json_repair
>>> json_repair.loads('["a.com", "b.com",]')
['a.com', 'b.com']
```
