### PR TITLE
fix(exa): return empty results on search API failures

### DIFF
--- a/gpt_researcher/retrievers/exa/exa.py
+++ b/gpt_researcher/retrievers/exa/exa.py
@@ -51,17 +51,24 @@ class ExaSearch:
         Returns:
             A list of search results.
         """
-        results = self.client.search(
-            self.query,
-            type=search_type,
-            use_autoprompt=use_autoprompt,
-            num_results=max_results,
-            include_domains=self.query_domains,
-            **filters
-        )
+        try:
+            results = self.client.search(
+                self.query,
+                type=search_type,
+                use_autoprompt=use_autoprompt,
+                num_results=max_results,
+                include_domains=self.query_domains,
+                **filters
+            )
+        except Exception as e:
+            print(f"Error: {e}. Failed fetching sources from Exa. Empty response.")
+            return []
 
         search_response = []
-        for result in results.results or []:
+        rows = getattr(results, "results", None) or []
+        if not isinstance(rows, list):
+            return []
+        for result in rows:
             href = getattr(result, "url", None)
             if not href:
                 continue

--- a/tests/test_exa_search_errors.py
+++ b/tests/test_exa_search_errors.py
@@ -1,0 +1,53 @@
+"""ExaSearch.search must return [] on API failures, not raise."""
+
+from types import SimpleNamespace
+
+from gpt_researcher.retrievers.exa.exa import ExaSearch
+
+
+def test_search_swallows_client_errors(monkeypatch):
+    searcher = ExaSearch.__new__(ExaSearch)
+    searcher.query = "q"
+    searcher.query_domains = None
+
+    class Boom:
+        def search(self, *a, **k):
+            raise RuntimeError("api down")
+
+    searcher.client = Boom()
+    assert searcher.search() == []
+
+
+def test_search_tolerates_missing_results_list():
+    searcher = ExaSearch.__new__(ExaSearch)
+    searcher.query = "q"
+    searcher.query_domains = None
+
+    class Ok:
+        def search(self, *a, **k):
+            return SimpleNamespace(results=None)
+
+    searcher.client = Ok()
+    assert searcher.search() == []
+
+
+def test_search_normalizes_hits():
+    searcher = ExaSearch.__new__(ExaSearch)
+    searcher.query = "q"
+    searcher.query_domains = None
+
+    class Ok:
+        def search(self, *a, **k):
+            return SimpleNamespace(
+                results=[
+                    SimpleNamespace(url="https://a.example", text="body", summary=None),
+                    SimpleNamespace(url=None, text="x", summary=None),
+                    SimpleNamespace(url="https://b.example", text=None, summary="sum"),
+                ]
+            )
+
+    searcher.client = Ok()
+    assert searcher.search() == [
+        {"href": "https://a.example", "body": "body"},
+        {"href": "https://b.example", "body": "sum"},
+    ]


### PR DESCRIPTION
## Summary

- `ExaSearch.search` let `client.search` exceptions bubble and assumed `results.results` was iterable.
- One Exa failure could abort the whole retriever loop path depending on callers.
- Catch exceptions → `[]`; tolerate missing/non-list `results`.

## Verification

```text
$ .venv/bin/python -m pytest tests/test_exa_search_errors.py -q
3 passed
```
