### PR TITLE
fix(researcher): only treat raw_content as prefetched full text

### DIFF
--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -790,7 +790,9 @@ class ResearchConductor:
                 # Separate results that already have content from those needing scraping
                 for result in search_results:
                     url = result.get("href") or result.get("url")
-                    raw_content = result.get("raw_content") or result.get("body")
+                    # Only treat genuine full-text fields as prefetched. Search
+                    # snippets live under "body" and must still be scraped (#1892).
+                    raw_content = result.get("raw_content")
                     if url and raw_content and len(raw_content) > 100:
                         # Retriever already fetched full content (e.g. PubMed Central)
                         prefetched_content.append({


### PR DESCRIPTION
## Summary
`_search_relevant_source_urls` treated any result with `body` longer than 100 characters as already-fetched full content and skipped scraping.

Almost every web retriever puts the **search snippet** in `body` (Tavily, SearXNG, DuckDuckGo, Exa). Those snippets are typically 150–400 chars, so the scraper stage became a no-op (`Scraping content from 0 URLs...`) and reports were built from snippets only.

## Change
Only treat `raw_content` as prefetched full text (PubMed Central / custom full-text retrievers). Let `body` snippets flow into the normal scrape path.

## Test plan
- [x] Classification smoke: snippet-only `body` → scrape URL; genuine `raw_content` → prefetched
- Manual: `RETRIEVER=tavily` / `searx` + `verbose=True` should log non-zero scrape counts again

Fixes #1892  
Fixes #1846
