### PR TITLE
fix(searchapi): guard non-dict organic_results rows

### DIFF
--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -61,22 +61,30 @@ class SearchApiSearch():
             response = requests.get(encoded_url, headers=headers, timeout=20)
             if response.status_code == 200:
                 search_results = response.json()
-                if search_results:
-                    results = search_results["organic_results"]
-                    results_processed = 0
-                    for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
-                        if results_processed >= max_results:
-                            break
-                        search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
-                        }
-                        search_response.append(search_result)
-                        results_processed += 1
+                if not isinstance(search_results, dict):
+                    return []
+                results = search_results.get("organic_results") or []
+                if not isinstance(results, list):
+                    return []
+                results_processed = 0
+                for result in results:
+                    if not isinstance(result, dict):
+                        continue
+                    # Prefer KeyError-safe getters so partial API rows (rate-
+                    # limit stubs, A/B experiment payloads) cannot abort the
+                    # entire result list.
+                    link = result.get("link") or ""
+                    if not link or "youtube.com" in link:
+                        continue
+                    if results_processed >= max_results:
+                        break
+                    search_result = {
+                        "title": result.get("title") or "",
+                        "href": link,
+                        "body": result.get("snippet") or "",
+                    }
+                    search_response.append(search_result)
+                    results_processed += 1
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []

--- a/tests/test_searchapi_organic_guards.py
+++ b/tests/test_searchapi_organic_guards.py
@@ -1,0 +1,107 @@
+"""SearchApi organic_results must tolerate partial / non-dict payloads.
+
+Bare ``search_results["organic_results"]`` and ``result["link"]`` raise on
+error-rate-limit stubs, list envelopes, and rows missing title/snippet.
+Downstream research expects a list of {title, href, body} dicts, not a crash.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "searchapi" / "searchapi.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+    requests_mod.get = MagicMock()
+    sys.modules["requests"] = requests_mod
+
+    for key in list(sys.modules):
+        if "searchapi.searchapi" in key or key.endswith("searchapi_testmod"):
+            sys.modules.pop(key, None)
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.searchapi.searchapi_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    with patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"}, clear=False):
+        spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+class SearchApiOrganicGuards(unittest.TestCase):
+    def test_skips_non_dict_rows_and_missing_links(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "organic_results": [
+                {"title": "A", "link": "https://a.example", "snippet": "sa"},
+                "bad-row",
+                {"title": "No link"},
+                None,
+                {
+                    "title": "B",
+                    "link": "https://www.youtube.com/watch?v=1",
+                    "snippet": "yt",
+                },
+                {"link": "https://b.example"},  # missing title/snippet OK
+            ]
+        }
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"}):
+            out = mod.SearchApiSearch("q").search(max_results=10)
+        self.assertEqual(
+            out,
+            [
+                {
+                    "title": "A",
+                    "href": "https://a.example",
+                    "body": "sa",
+                },
+                {
+                    "title": "",
+                    "href": "https://b.example",
+                    "body": "",
+                },
+            ],
+        )
+
+    def test_non_dict_json_returns_empty(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = ["not", "a", "dict"]
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"}):
+            self.assertEqual(mod.SearchApiSearch("q").search(), [])
+
+    def test_missing_organic_results_key_returns_empty(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"error": "rate limited"}
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"}):
+            self.assertEqual(mod.SearchApiSearch("q").search(), [])
+
+    def test_organic_results_non_list_returns_empty(self):
+        mod, requests_mod = _load()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"organic_results": {"oops": True}}
+        requests_mod.get.return_value = resp
+        with patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test-key"}):
+            self.assertEqual(mod.SearchApiSearch("q").search(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Harden SearchApiSearch.search so partial or malformed SearchApi JSON no longer crashes the result walk with KeyError TypeError.

## Motivation

organic_results was accessed with bare indexing and each row used required keys for link title snippet. Error stubs list envelopes non-dict rows and rows missing link aborted the entire search path.

## Changes

- Require JSON object payload and list organic_results
- Skip non-dict rows and empty links
- Use get for title and snippet

## Real behavior proof

python3 -m pytest tests/test_searchapi_organic_guards.py -q
4 passed

## Test plan

- Unit tests cover non-dict rows missing organic key non-list organic non-dict JSON top-level
- Author Bartok9