### PR TITLE
fix(scraper): guard BeautifulSoup fetch when session is None

### DIFF
--- a/gpt_researcher/scraper/beautiful_soup/beautiful_soup.py
+++ b/gpt_researcher/scraper/beautiful_soup/beautiful_soup.py
@@ -61,6 +61,10 @@ class BeautifulSoupScraper:
         Returns the response on success, or None when the page is
         unreachable, an error status, or too large to be worth parsing.
         """
+        if self.session is None:
+            logger.warning(f"No session provided for {self.link}; cannot fetch")
+            return None
+
         for attempt in (1, 2):
             try:
                 response = self.session.get(self.link, timeout=10)

--- a/tests/test_bs_session_none.py
+++ b/tests/test_bs_session_none.py
@@ -1,0 +1,54 @@
+"""BeautifulSoupScraper must not AttributeError when session is None."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "scraper" / "beautiful_soup" / "beautiful_soup.py"
+
+
+def _load():
+    # package stubs for relative imports
+    pkg = types.ModuleType("gpt_researcher")
+    pkg.__path__ = [str(ROOT / "gpt_researcher")]
+    sys.modules.setdefault("gpt_researcher", pkg)
+    sc = types.ModuleType("gpt_researcher.scraper")
+    sc.__path__ = [str(ROOT / "gpt_researcher" / "scraper")]
+    sys.modules["gpt_researcher.scraper"] = sc
+    bs_pkg = types.ModuleType("gpt_researcher.scraper.beautiful_soup")
+    bs_pkg.__path__ = [str(ROOT / "gpt_researcher" / "scraper" / "beautiful_soup")]
+    sys.modules["gpt_researcher.scraper.beautiful_soup"] = bs_pkg
+
+    utils = types.ModuleType("gpt_researcher.scraper.utils")
+    utils.get_relevant_images = lambda *a, **k: []
+    utils.extract_title = lambda soup: ""
+    utils.get_text_from_soup = lambda soup: "text"
+    utils.clean_soup = lambda soup: soup
+    sys.modules["gpt_researcher.scraper.utils"] = utils
+
+    bs4 = types.ModuleType("bs4")
+    bs4.BeautifulSoup = MagicMock
+    sys.modules["bs4"] = bs4
+
+    for key in list(sys.modules):
+        if key.endswith("bs_none_testmod"):
+            sys.modules.pop(key)
+
+    spe = importlib.util.spec_from_file_location(
+        "gpt_researcher.scraper.beautiful_soup.bs_none_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spe)
+    sys.modules[spe.name] = mod
+    spe.loader.exec_module(mod)
+    return mod
+
+
+def test_scrape_with_none_session_returns_empty():
+    mod = _load()
+    content, images, title = mod.BeautifulSoupScraper(
+        "https://example.com", session=None
+    ).scrape()
+    assert (content, images, title) == ("", [], "")


### PR DESCRIPTION
## Summary

BeautifulSoupScraper._fetch returns None when session is None instead of AttributeError on session.get.

## Real behavior proof

python3 -m pytest tests/test_bs_session_none.py -q
1 passed

## Author

Bartok9