### PR TITLE
fix(query): move typing imports above _normalize_sub_queries

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -2,6 +2,11 @@ import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
 
+from ..utils.llm import create_chat_completion
+from ..prompts import PromptFamily
+from typing import Any, List, Dict
+from ..config import Config
+import logging
 
 def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     """Coerce a parsed LLM response into a flat list of query strings.
@@ -32,11 +37,7 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     if not queries and fallback_query.strip():
         return [fallback_query.strip()]
     return queries
-from ..utils.llm import create_chat_completion
-from ..prompts import PromptFamily
-from typing import Any, List, Dict
-from ..config import Config
-import logging
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
`from typing import Any, List, Dict` (and the other module imports) were placed below `_normalize_sub_queries`, whose signature is annotated `parsed: Any` and `-> List[str]`. Python evaluates function annotations at definition time, so importing this module raised `NameError: name 'Any' is not defined`.

Move the imports to the top of the module so the annotations resolve.