### PR TITLE
fix(serper): return empty results on non-dict JSON payloads

### DIFF
--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -114,6 +114,10 @@ class SerperSearch():
             return []
         if search_results is None:
             return []
+        # Error HTML/text sometimes still parses as a JSON array/string; those
+        # payloads have no ``.get`` and must not crash the research loop.
+        if not isinstance(search_results, dict):
+            return []
 
         results = search_results.get("organic") or []
         if not isinstance(results, list):

--- a/tests/test_serper_non_dict_payload.py
+++ b/tests/test_serper_non_dict_payload.py
@@ -1,0 +1,49 @@
+"""SerperSearch must tolerate non-dict JSON payloads."""
+import importlib.util
+import json
+import os
+import pathlib
+from unittest.mock import patch
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "serper"
+    / "serper.py"
+)
+_spec = importlib.util.spec_from_file_location("_serper_under_test", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+SerperSearch = _mod.SerperSearch
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self.text = json.dumps(payload) if not isinstance(payload, str) else payload
+
+
+@patch.dict(os.environ, {"SERPER_API_KEY": "test-key"})
+def test_serper_list_payload_returns_empty():
+    with patch.object(_mod.requests, "request", return_value=_FakeResp([{"link": "x"}])):
+        assert SerperSearch("q").search() == []
+
+
+@patch.dict(os.environ, {"SERPER_API_KEY": "test-key"})
+def test_serper_string_payload_returns_empty():
+    with patch.object(_mod.requests, "request", return_value=_FakeResp('"oops"')):
+        assert SerperSearch("q").search() == []
+
+
+@patch.dict(os.environ, {"SERPER_API_KEY": "test-key"})
+def test_serper_happy_path():
+    payload = {
+        "organic": [
+            {"title": "A", "link": "https://a.example", "snippet": "s"},
+            "bad-row",
+            {"title": "NoLink"},
+        ]
+    }
+    with patch.object(_mod.requests, "request", return_value=_FakeResp(payload)):
+        results = SerperSearch("q").search()
+    assert results == [{"title": "A", "href": "https://a.example", "body": "s"}]


### PR DESCRIPTION
## Summary

Harden `SerperSearch.search` so non-dict JSON payloads (arrays/strings from error or truncated bodies) return `[]` instead of crashing on `.get`.

## Motivation

`json.loads` success only means “valid JSON”, not “object with organic results”. List/string payloads caused `AttributeError` mid-research.

## Changes

- After parse, require `isinstance(search_results, dict)` before reading `organic`
- Existing per-row dict/href guards unchanged

## Real behavior proof

```
$ python3 -m pytest tests/test_serper_non_dict_payload.py -v
3 passed
```

## Test plan

- [x] List payload → `[]`
- [x] String payload → `[]`
- [x] Happy path still normalizes organic rows