### PR TITLE
fix(scraper): keep TavilyExtract content when session is None

### DIFF
--- a/gpt_researcher/scraper/tavily_extract/tavily_extract.py
+++ b/gpt_researcher/scraper/tavily_extract/tavily_extract.py
@@ -37,23 +37,41 @@ class TavilyExtract:
 
         try:
             response = self.tavily_client.extract(urls=self.link)
-            if response['failed_results']:
+            if not isinstance(response, dict):
+                return "", [], ""
+            if response.get("failed_results"):
                 return "", [], ""
 
-            # Parse the HTML content of the response to create a BeautifulSoup object for the utility functions
-            response_bs = self.session.get(self.link, timeout=4)
-            soup = BeautifulSoup(
-                response_bs.content, "lxml", from_encoding=response_bs.encoding
-            )
+            results = response.get("results") or []
+            if not isinstance(results, list) or not results:
+                return "", [], ""
+            first = results[0]
+            if not isinstance(first, dict):
+                return "", [], ""
+            content = first.get("raw_content") or ""
 
-            # Since only a single link is provided to tavily_client, the results will contain only one entry.
-            content = response['results'][0]['raw_content']
-
-            # Get relevant images using the utility function
-            image_urls = get_relevant_images(soup, self.link)
-
-            # Extract the title using the utility function
-            title = extract_title(soup)
+            # Image/title enrichment is best-effort. Callers often construct
+            # TavilyExtract(link, session=None); a bare session.get would
+            # TypeError and (with the broad except) previously discarded the
+            # already-extracted Tavily content too. Keep content even when
+            # enrichment is unavailable.
+            image_urls = []
+            title = ""
+            if self.session is not None:
+                try:
+                    response_bs = self.session.get(self.link, timeout=4)
+                    soup = BeautifulSoup(
+                        response_bs.content,
+                        "lxml",
+                        from_encoding=response_bs.encoding,
+                    )
+                    image_urls = get_relevant_images(soup, self.link)
+                    title = extract_title(soup)
+                except Exception as enrich_err:
+                    print(
+                        "Warning: TavilyExtract image/title enrichment failed: "
+                        + str(enrich_err)
+                    )
 
             return content, image_urls, title
 

--- a/tests/test_tavily_extract_session_none.py
+++ b/tests/test_tavily_extract_session_none.py
@@ -1,0 +1,93 @@
+"""TavilyExtract keeps content when session is None; guards partial payloads."""
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _stub_bs4():
+    bs4 = types.ModuleType("bs4")
+    class BeautifulSoup:
+        def __init__(self, *a, **k):
+            pass
+    bs4.BeautifulSoup = BeautifulSoup
+    sys.modules["bs4"] = bs4
+
+ROOT = Path(__file__).resolve().parent.parent
+TE_PATH = ROOT / "gpt_researcher" / "scraper" / "tavily_extract" / "tavily_extract.py"
+UTILS_PATH = ROOT / "gpt_researcher" / "scraper" / "utils.py"
+
+
+def _load_tavily_module():
+    _stub_bs4()
+    # Minimal package graph so relative imports work without heavy agent deps.
+    pkg = types.ModuleType("gpt_researcher")
+    pkg.__path__ = [str(ROOT / "gpt_researcher")]
+    sys.modules["gpt_researcher"] = pkg
+
+    scraper_pkg = types.ModuleType("gpt_researcher.scraper")
+    scraper_pkg.__path__ = [str(ROOT / "gpt_researcher" / "scraper")]
+    sys.modules["gpt_researcher.scraper"] = scraper_pkg
+
+    u_mod = types.ModuleType("gpt_researcher.scraper.utils")
+    u_mod.get_relevant_images = lambda soup, link: [{"src": "x"}]
+    u_mod.extract_title = lambda soup: "Title"
+    sys.modules["gpt_researcher.scraper.utils"] = u_mod
+
+    te_pkg = types.ModuleType("gpt_researcher.scraper.tavily_extract")
+    te_pkg.__path__ = [str(TE_PATH.parent)]
+    sys.modules["gpt_researcher.scraper.tavily_extract"] = te_pkg
+
+    name = "gpt_researcher.scraper.tavily_extract.tavily_extract"
+    spec = importlib.util.spec_from_file_location(name, TE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    # parent package attribute for relative imports
+    mod.__package__ = "gpt_researcher.scraper.tavily_extract"
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeTavily:
+    def __init__(self, *a, **k):
+        pass
+
+    def extract(self, urls=None):
+        return {
+            "failed_results": [],
+            "results": [{"raw_content": "EXTRACTED BODY"}],
+        }
+
+
+@patch.dict(os.environ, {"TAVILY_API_KEY": "test-key"})
+def test_session_none_keeps_content():
+    fake_tavily = SimpleNamespace(TavilyClient=_FakeTavily)
+    with patch.dict(sys.modules, {"tavily": fake_tavily}):
+        mod = _load_tavily_module()
+        content, images, title = mod.TavilyExtract(
+            "https://example.com", session=None
+        ).scrape()
+    assert content == "EXTRACTED BODY"
+    assert images == []
+    assert title == ""
+
+
+@patch.dict(os.environ, {"TAVILY_API_KEY": "test-key"})
+def test_malformed_response_returns_empty():
+    class Bad:
+        def __init__(self, *a, **k):
+            pass
+
+        def extract(self, urls=None):
+            return ["not-a-dict"]
+
+    with patch.dict(sys.modules, {"tavily": SimpleNamespace(TavilyClient=Bad)}):
+        mod = _load_tavily_module()
+        scraper = object.__new__(mod.TavilyExtract)
+        scraper.link = "https://example.com"
+        scraper.session = None
+        scraper.tavily_client = Bad()
+        assert mod.TavilyExtract.scrape(scraper) == ("", [], "")


### PR DESCRIPTION
## Summary

Keep Tavily-extracted body text when `session` is `None` or image/title enrichment fails, and harden extract payload shape checks.

## Motivation

`TavilyExtract(link, session=None)` is a normal construction path. The previous code always called `self.session.get` after a successful Tavily extract; the broad `except` then returned empty content, wiping the good extract.

## Changes

- Require dict response; soft-read `results[0].raw_content`
- Only enrich images/title when `session is not None`; failures leave content intact

## Real behavior proof

```
$ python3 -m pytest tests/test_tavily_extract_session_none.py -v
2 passed
```

## Test plan

- [x] `session=None` still returns extracted body
- [x] non-dict extract response → empty triple