### PR TITLE
fix(costs): tolerate None content in estimate_llm_cost

### DIFF
--- a/gpt_researcher/utils/costs.py
+++ b/gpt_researcher/utils/costs.py
@@ -72,6 +72,16 @@ def estimate_llm_cost(input_content: str, output_content: str) -> float:
     Returns:
         The estimated cost in USD.
     """
+    # Callbacks and stream paths may pass None before content is available.
+    # tiktoken.encode(None) raises TypeError and abort sq col of the caller.
+    if input_content is None:
+        input_content = ""
+    if output_content is None:
+        output_content = ""
+    if not isinstance(input_content, str):
+        input_content = str(input_content)
+    if not isinstance(output_content, str):
+        output_content = str(output_content)
     encoding = tiktoken.get_encoding(ENCODING_MODEL)
     input_tokens = encoding.encode(input_content)
     output_tokens = encoding.encode(output_content)

--- a/tests/test_estimate_llm_cost_none.py
+++ b/tests/test_estimate_llm_cost_none.py
@@ -1,0 +1,29 @@
+"""estimate_llm_cost must tolerate None/non-str arguments."""
+import importlib.util
+import pathlib
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "utils"
+    / "costs.py"
+)
+_spec = importlib.util.spec_from_file_location("_costs_ut", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_none_inputs_return_zeroish():
+    assert _mod.estimate_llm_cost(None, None) == 0.0
+
+
+def test_mixed_none_does_not_raise():
+    cost = _mod.estimate_llm_cost("hello world", None)
+    assert isinstance(cost, float)
+    assert cost > 0
+
+
+def test_non_str_coerced():
+    cost = _mod.estimate_llm_cost(12345, ["a", "b"])
+    assert isinstance(cost, float)
+    assert cost > 0


### PR DESCRIPTION
## Summary

Coerce `None`/non-string arguments in `estimate_llm_cost` so stream and callback paths do not fail inside `tiktoken.encode`.

## Motivation

Cost callbacks sometimes fire with missing text. bare encode raised TypeError.

## Real behavior proof

```
$ python3 -m pytest tests/test_estimate_llm_cost_none.py -v
3 passed
```

## Test plan

- [x] None/None → 0.0
- [x] Mixed None does not raise
- [x] Non-str coerced