### PR TITLE
fix(agent): guard handle_json_error on partial/non-dict payloads

### DIFF
--- a/gpt_researcher/actions/agent_creator.py
+++ b/gpt_researcher/actions/agent_creator.py
@@ -76,9 +76,10 @@ async def handle_json_error(response: str | None):
         if all parsing attempts fail.
     """
     try:
-        agent_dict = json_repair.loads(response)
-        if agent_dict.get("server") and agent_dict.get("agent_role_prompt"):
-            return agent_dict["server"], agent_dict["agent_role_prompt"]
+        agent_dict = json_repair.loads(response) if response is not None else None
+        recovered = _agent_pair_from_payload(agent_dict)
+        if recovered is not None:
+            return recovered
     except Exception as e:
         error_type = type(e).__name__
         error_msg = str(e)
@@ -93,7 +94,9 @@ async def handle_json_error(response: str | None):
     if json_string:
         try:
             json_data = json.loads(json_string)
-            return json_data["server"], json_data["agent_role_prompt"]
+            recovered = _agent_pair_from_payload(json_data)
+            if recovered is not None:
+                return recovered
         except json.JSONDecodeError as e:
             logger.warning(
                 f"Failed to decode JSON from regex extraction: {str(e)}",
@@ -105,6 +108,17 @@ async def handle_json_error(response: str | None):
         "You are an AI critical thinker research assistant. Your sole purpose is to write well written, "
         "critically acclaimed, objective and structured reports on given text."
     )
+
+
+def _agent_pair_from_payload(payload):
+    """Return (server, agent_role_prompt) only for complete dict payloads."""
+    if not isinstance(payload, dict):
+        return None
+    server = payload.get("server")
+    role = payload.get("agent_role_prompt")
+    if server and role:
+        return server, role
+    return None
 
 
 def extract_json_with_regex(response: str | None) -> str | None:

--- a/tests/test_agent_creator_json_shape.py
+++ b/tests/test_agent_creator_json_shape.py
@@ -1,0 +1,76 @@
+"""Regression: handle_json_error must not KeyError on partial agent JSON.
+
+json.loads / json_repair can return non-dicts (list, str, null) or dicts
+missing agent_role_prompt. The recovery path must fall back to the default
+agent instead of raising.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_agent_creator():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "gpt_researcher"
+        / "actions"
+        / "agent_creator.py"
+    )
+    src = path.read_text()
+    src = src.replace("from ..prompts import PromptFamily\n", "")
+    src = src.replace("from ..utils.llm import create_chat_completion\n", "")
+    mod = ModuleType("agent_creator_under_test")
+    ns = mod.__dict__
+    ns["PromptFamily"] = type("PromptFamily", (), {})
+    ns["create_chat_completion"] = None
+    exec(compile(src, str(path), "exec"), ns)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def agent_creator():
+    return _load_agent_creator()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        "not json",
+        "[]",
+        "null",
+        '"x"',
+        "123",
+        '{"server":"only-server"}',
+        '{"agent_role_prompt":"only-role"}',
+    ],
+)
+async def test_handle_json_error_falls_back_without_raise(agent_creator, response):
+    server, role = await agent_creator.handle_json_error(response)
+    assert server == "Default Agent"
+    assert "research assistant" in role
+
+
+@pytest.mark.asyncio
+async def test_handle_json_error_accepts_valid_repaired_shape(agent_creator):
+    server, role = await agent_creator.handle_json_error(
+        '{"server":"Finance Agent","agent_role_prompt":"Analyze markets"}'
+    )
+    assert server == "Finance Agent"
+    assert role == "Analyze markets"
+
+
+def test_without_fix_partial_dict_keyerrors(agent_creator):
+    """Document pre-fix failure mode on the regex path using bare json.loads semantics."""
+    import json
+
+    payload = json.loads('{"server":"only-server"}')
+    # Pre-fix path: payload["agent_role_prompt"] KeyError
+    with pytest.raises(KeyError):
+        _ = payload["server"], payload["agent_role_prompt"]


### PR DESCRIPTION
## Summary
- `handle_json_error` regex path did `json_data[\"server\"], json_data[\"agent_role_prompt\"]` without shape checks.
- Partial LLM JSON (only `server`, non-dict repair results) raised `KeyError` instead of falling back to the default agent.
- Centralize complete-dict validation and skip `json_repair.loads(None)` which thrash-logs inside json_repair.

## Motivation
Agent selection recovery should degrade to Default Agent, not crash the research pipeline.

## Test plan
- [x] `pytest tests/test_agent_creator_json_shape.py -v` (10 passed)
- [x] Demonstrated pre-fix `KeyError` on `{\"server\":\"only-server\"}`

## Real behavior proof
Partial dict path KeyError before fix; 10 tests green after fix.
