### PR TITLE
fix(markdown): guard extractors against None/empty inputs

### DIFF
--- a/gpt_researcher/actions/markdown_processing.py
+++ b/gpt_researcher/actions/markdown_processing.py
@@ -12,6 +12,8 @@ def extract_headers(markdown_text: str) -> List[Dict]:
     Returns:
         List[Dict]: A list of dictionaries representing the header structure.
     """
+    if not isinstance(markdown_text, str) or not markdown_text:
+        return []
     headers = []
     parsed_md = markdown.markdown(markdown_text)
     lines = parsed_md.split("\n")
@@ -49,6 +51,8 @@ def extract_sections(markdown_text: str) -> List[Dict[str, str]]:
         List[Dict[str, str]]: List of sections, each section is a dictionary containing
         'section_title' and 'written_content'.
     """
+    if not isinstance(markdown_text, str) or not markdown_text:
+        return []
     sections = []
     parsed_md = markdown.markdown(markdown_text)
     
@@ -75,6 +79,9 @@ def table_of_contents(markdown_text: str) -> str:
     Returns:
         str: The generated table of contents.
     """
+    if not isinstance(markdown_text, str):
+        return ""
+
     def generate_table_of_contents(headers, indent_level=0):
         toc = ""
         for header in headers:
@@ -102,6 +109,10 @@ def add_references(report_markdown: str, visited_urls: set) -> str:
     Returns:
         str: The updated markdown report with added references.
     """
+    if not isinstance(report_markdown, str):
+        report_markdown = "" if report_markdown is None else str(report_markdown)
+    if visited_urls is None:
+        return report_markdown
     try:
         url_markdown = "\n\n\n## References\n\n"
         # Sort so the reference list is deterministic. ``visited_urls`` is a

--- a/tests/test_markdown_none_inputs.py
+++ b/tests/test_markdown_none_inputs.py
@@ -1,0 +1,37 @@
+"""Regression: markdown helpers must not crash on None/empty inputs."""
+
+from __future__ import annotations
+
+from gpt_researcher.actions.markdown_processing import (
+    add_references,
+    extract_headers,
+    extract_sections,
+    table_of_contents,
+)
+
+
+def test_extract_headers_none_and_empty():
+    assert extract_headers(None) == []
+    assert extract_headers("") == []
+
+
+def test_extract_sections_none_and_empty():
+    assert extract_sections(None) == []
+    assert extract_sections("") == []
+
+
+def test_table_of_contents_none():
+    assert table_of_contents(None) == ""
+
+
+def test_add_references_none_report_or_urls():
+    assert add_references(None, set()) == "\n\n\n## References\n\n"
+    assert add_references("body", None) == "body"
+    assert "## References" in add_references("body", {"https://a.example"})
+
+
+def test_extract_headers_real_markdown():
+    md = "# Title\n\n## Section\n\ntext"
+    headers = extract_headers(md)
+    assert headers
+    assert headers[0]["level"] == 1


### PR DESCRIPTION
## Summary
- `extract_headers` / `extract_sections` / `table_of_contents` crashed on `None` via `markdown.markdown(None)`.
- `add_references` crashed when report markdown or visited_urls was `None`.
- Return empty lists / safe strings so post-report formatters degrade cleanly.

## Test plan
- [x] `pytest tests/test_markdown_none_inputs.py -v` (5 passed)

## Real behavior proof
Before: `AttributeError: 'NoneType' object has no attribute 'strip'` on extract_headers(None).
