### PR TITLE
fix(utils): coerce None token counts in cost helpers

### DIFF
--- a/gpt_researcher/actions/utils.py
+++ b/gpt_researcher/actions/utils.py
@@ -75,6 +75,23 @@ def calculate_cost(
     Returns:
         float: The calculated cost in USD.
     """
+    try:
+        prompt_tokens = int(prompt_tokens or 0)
+        completion_tokens = int(completion_tokens or 0)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid token counts for cost calculation "
+            f"(prompt={prompt_tokens!r}, completion={completion_tokens!r}); treating as 0."
+        )
+        prompt_tokens = 0
+        completion_tokens = 0
+    if prompt_tokens < 0:
+        prompt_tokens = 0
+    if completion_tokens < 0:
+        completion_tokens = 0
+    if not isinstance(model, str) or not model:
+        model = ""
+
     # Define cost per 1k tokens for different models
     costs = {
         "gpt-3.5-turbo": 0.002,
@@ -107,7 +124,11 @@ def format_token_count(count: int) -> str:
     Returns:
         str: The formatted token count.
     """
-    return f"{count:,}"
+    try:
+        value = int(count or 0)
+    except (TypeError, ValueError):
+        return "0"
+    return f"{value:,}"
 
 
 async def update_cost(

--- a/tests/test_utils_token_cost_guard.py
+++ b/tests/test_utils_token_cost_guard.py
@@ -1,0 +1,20 @@
+"""Regression: calculate_cost / format_token_count tolerate None token counts."""
+
+from gpt_researcher.actions.utils import calculate_cost, format_token_count
+
+
+def test_format_token_count_none_and_string():
+    assert format_token_count(None) == "0"
+    assert format_token_count("1200") == "1,200"
+    assert format_token_count(1200) == "1,200"
+
+
+def test_calculate_cost_none_tokens():
+    assert calculate_cost(None, 0, "gpt-4") == 0.0
+    assert calculate_cost(0, None, "gpt-4") == 0.0
+    # 1000 + 0 tokens at gpt-4 0.03 / 1k
+    assert calculate_cost(1000, 0, "gpt-4") == 0.03
+
+
+def test_calculate_cost_unknown_model_default():
+    assert calculate_cost(10, 10, "unknown-model-xyz") == 0.0001


### PR DESCRIPTION
## Summary
- `format_token_count(None)` raised `TypeError` via f-string formatting.
- `calculate_cost(None, ...)` raised on `prompt_tokens + completion_tokens`.
- Coerce invalid/negative counts to 0 so websocket cost updates with missing usage metadata do not crash.

## Test plan
- [x] `pytest tests/test_utils_token_cost_guard.py -v` (3 passed)

## Real behavior proof
Before: `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`.
