### PR TITLE
fix(image_generator): repair LLM JSON in analysis parse

### DIFF
--- a/gpt_researcher/skills/image_generator.py
+++ b/gpt_researcher/skills/image_generator.py
@@ -6,6 +6,7 @@ contextually relevant images for research reports using AI image generation.
 
 import asyncio
 import json
+import json_repair
 import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
@@ -435,18 +436,37 @@ Return ONLY the JSON, no additional text."""
             List of image suggestion dictionaries.
         """
         try:
-            # Try to extract JSON from the response
-            json_match = re.search(r'\{[\s\S]*\}', response)
-            if not json_match:
-                logger.warning("No JSON found in analysis response")
+            if not isinstance(response, str) or not response.strip():
+                logger.warning("Empty analysis response")
                 return []
-            
-            data = json.loads(json_match.group())
+
+            # Accept raw JSON, fenced blocks, or lightly broken LLM JSON
+            data = None
+            try:
+                data = json_repair.loads(response)
+            except Exception:
+                json_match = re.search(r'\{[\s\S]*\}', response)
+                if json_match:
+                    try:
+                        data = json_repair.loads(json_match.group())
+                    except Exception:
+                        data = None
+
+            if not isinstance(data, dict):
+                logger.warning("No JSON object found in analysis response")
+                return []
+
             suggestions = data.get("suggestions", [])
             
             # Enrich with section data
             enriched = []
+            if not isinstance(suggestions, list):
+                logger.warning("Analysis JSON missing list suggestions")
+                return []
+
             for s in suggestions:
+                if not isinstance(s, dict):
+                    continue
                 section_num = s.get("section_number", 0) - 1  # Convert to 0-indexed
                 if 0 <= section_num < len(sections):
                     section = sections[section_num]

--- a/tests/test_image_generator_analysis_json_repair.py
+++ b/tests/test_image_generator_analysis_json_repair.py
@@ -1,0 +1,59 @@
+"""_parse_analysis_response should accept fenced/repaired LLM JSON."""
+
+from gpt_researcher.skills.image_generator import ImageGenerator
+
+
+SECTIONS = [
+    {
+        "header": "Intro",
+        "content": "About widgets " * 20,
+        "start_line": 3,
+    }
+]
+
+
+def _ig():
+    # ImageGenerator needs a researcher-like object only for other paths;
+    # _parse_analysis_response does not touch self beyond being a method.
+    return ImageGenerator.__new__(ImageGenerator)
+
+
+def test_parse_analysis_raw_json():
+    ig = _ig()
+    resp = '{"suggestions":[{"section_number":1,"image_prompt":"diagram","reason":"clarity"}]}'
+    out = ig._parse_analysis_response(resp, SECTIONS)
+    assert len(out) == 1
+    assert out[0]["section_header"] == "Intro"
+    assert out[0]["image_prompt"] == "diagram"
+
+
+def test_parse_analysis_fenced_json():
+    ig = _ig()
+    resp = """```json
+{"suggestions":[{"section_number":1,"image_prompt":"chart","reason":"viz"}]}
+```"""
+    out = ig._parse_analysis_response(resp, SECTIONS)
+    assert len(out) == 1
+    assert out[0]["image_prompt"] == "chart"
+
+
+def test_parse_analysis_trailing_comma_repaired():
+    ig = _ig()
+    resp = '{"suggestions":[{"section_number":1,"image_prompt":"map","reason":"geo",}],}'
+    out = ig._parse_analysis_response(resp, SECTIONS)
+    assert len(out) == 1
+    assert out[0]["image_prompt"] == "map"
+
+
+def test_parse_analysis_skips_non_dict_suggestions():
+    ig = _ig()
+    resp = '{"suggestions":["bad",{"section_number":1,"image_prompt":"ok","reason":"r"}]}'
+    out = ig._parse_analysis_response(resp, SECTIONS)
+    assert len(out) == 1
+    assert out[0]["image_prompt"] == "ok"
+
+
+def test_parse_analysis_empty():
+    ig = _ig()
+    assert ig._parse_analysis_response("", SECTIONS) == []
+    assert ig._parse_analysis_response(None, SECTIONS) == []  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Parse report-image analysis LLM output with `json_repair` (fenced / trailing commas)
- Skip non-dict suggestion rows; empty/non-str responses return []

## Motivation

`_parse_analysis_response` used regex + `json.loads` only. Common LLM wrappers (markdown fences, trailing commas) dropped all image suggestions silently. Related path `_plan_images` was hardened in #1955; this covers the analysis helper on the same skill.

## Verification

- `.venv/bin/python -m pytest tests/test_image_generator_analysis_json_repair.py -v` — 5 passed
- Covers raw JSON, fenced JSON, trailing-comma repair, non-dict rows, empty input

## Duplicate check

- Open #1955 covers planning JSON recovery, not `_parse_analysis_response` (this PR)
