### PR TITLE
fix(agent): prefer json_repair on choose_agent hot path

### DIFF
--- a/gpt_researcher/actions/agent_creator.py
+++ b/gpt_researcher/actions/agent_creator.py
@@ -55,7 +55,16 @@ async def choose_agent(
             **kwargs
         )
 
-        agent_dict = json.loads(response)
+        # Prefer json_repair so fenced / lightly broken LLM JSON succeeds
+        # on the hot path instead of always falling through exception handling.
+        try:
+            agent_dict = json_repair.loads(response) if response is not None else None
+        except Exception:
+            agent_dict = None
+        if not isinstance(agent_dict, dict):
+            agent_dict = json.loads(response)
+        if not isinstance(agent_dict, dict):
+            raise ValueError("agent JSON was not an object")
         return agent_dict["server"], agent_dict["agent_role_prompt"]
 
     except Exception as e:

--- a/tests/test_create_agent_json_repair_primary.py
+++ b/tests/test_create_agent_json_repair_primary.py
@@ -1,0 +1,60 @@
+"""choose_agent hot path should parse fenced agent JSON via json_repair."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gpt_researcher.actions.agent_creator import choose_agent
+
+
+@pytest.mark.asyncio
+async def test_choose_agent_accepts_fenced_json():
+    cfg = SimpleNamespace(
+        smart_llm_model="m",
+        smart_llm_provider="p",
+        llm_kwargs={},
+    )
+    family = SimpleNamespace(auto_agent_instructions=lambda: "sys")
+    fenced = """```json
+{"server": "Research", "agent_role_prompt": "dig deep"}
+```"""
+
+    with patch(
+        "gpt_researcher.actions.agent_creator.create_chat_completion",
+        new=AsyncMock(return_value=fenced),
+    ):
+        server, role = await choose_agent(
+            "q",
+            cfg,
+            cost_callback=None,
+            prompt_family=family,
+        )
+
+    assert server == "Research"
+    assert role == "dig deep"
+
+
+@pytest.mark.asyncio
+async def test_choose_agent_accepts_trailing_comma_json():
+    cfg = SimpleNamespace(
+        smart_llm_model="m",
+        smart_llm_provider="p",
+        llm_kwargs={},
+    )
+    family = SimpleNamespace(auto_agent_instructions=lambda: "sys")
+    body = '{"server": "Ops", "agent_role_prompt": "run ops",}'
+
+    with patch(
+        "gpt_researcher.actions.agent_creator.create_chat_completion",
+        new=AsyncMock(return_value=body),
+    ):
+        server, role = await choose_agent(
+            "q",
+            cfg,
+            cost_callback=None,
+            prompt_family=family,
+        )
+
+    assert server == "Ops"
+    assert role == "run ops"


### PR DESCRIPTION
## Summary

- Use `json_repair.loads` first in `choose_agent` before strict `json.loads`
- Keep `handle_json_error` as fallback for unrecoverable payloads

## Motivation

LLM agent-selection responses often arrive fenced or with trailing commas. Strict `json.loads` always threw into the recovery path; repairing on the hot path avoids an unnecessary log/exception berth and matches other skills that already use json_repair.

## Verification

- `.venv/bin/python -m pytest tests/test_create_agent_json_repair_primary.py -v` — 2 passed

## Duplicate check

- No open PR for choose_agent primary-path json_repair (handle_json_error already used repair on failure only)
