### PR TITLE
fix(costs): price Anthropic prompt-cache tokens

### DIFF
--- a/gpt_researcher/utils/costs.py
+++ b/gpt_researcher/utils/costs.py
@@ -103,32 +103,52 @@ def _resolve_anthropic_model_name(
     ).lower()
 
 
+def _coerce_token_count(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _extract_anthropic_usage(
     response_metadata: Mapping[str, Any] | None = None,
     usage_metadata: Mapping[str, Any] | Any | None = None,
 ) -> dict[str, int] | None:
+    """Extract Anthropic usage including prompt-cache token fields.
+
+    Anthropic Messages usage may include:
+    - input_tokens / output_tokens
+    - cache_creation_input_tokens (billed ~1.25x input)
+    - cache_read_input_tokens (billed ~0.1x input)
+    """
     metadata = _mapping_to_dict(response_metadata)
     usage = _mapping_to_dict(metadata.get("usage"))
 
+    def _from_usage(usage_dict: dict[str, Any]) -> dict[str, int] | None:
+        input_tokens = usage_dict.get("input_tokens")
+        output_tokens = usage_dict.get("output_tokens")
+        if input_tokens is None or output_tokens is None:
+            return None
+        return {
+            "input_tokens": int(input_tokens),
+            "output_tokens": int(output_tokens),
+            "cache_creation_input_tokens": _coerce_token_count(
+                usage_dict.get("cache_creation_input_tokens")
+            ),
+            "cache_read_input_tokens": _coerce_token_count(
+                usage_dict.get("cache_read_input_tokens")
+            ),
+        }
+
     if usage:
-        input_tokens = usage.get("input_tokens")
-        output_tokens = usage.get("output_tokens")
-        if input_tokens is not None and output_tokens is not None:
-            return {
-                "input_tokens": int(input_tokens),
-                "output_tokens": int(output_tokens),
-            }
+        parsed = _from_usage(usage)
+        if parsed is not None:
+            return parsed
 
     usage = _mapping_to_dict(usage_metadata)
-    input_tokens = usage.get("input_tokens")
-    output_tokens = usage.get("output_tokens")
-    if input_tokens is None or output_tokens is None:
-        return None
-
-    return {
-        "input_tokens": int(input_tokens),
-        "output_tokens": int(output_tokens),
-    }
+    return _from_usage(usage)
 
 
 def _get_anthropic_pricing(model_name: str) -> tuple[float, float] | None:
@@ -177,9 +197,19 @@ def calculate_anthropic_cost(
 
     input_price_per_mtok, output_price_per_mtok = pricing
     multiplier = _get_anthropic_pricing_multiplier(model_name, request_options=request_options)
+    # Anthropic prompt caching: cache writes ~1.25x input, cache reads ~0.1x input.
+    # input_tokens is non-cache input only; cache fields are billed separately.
+    cache_write_price_per_mtok = input_price_per_mtok * 1.25
+    cache_read_price_per_mtok = input_price_per_mtok * 0.1
     input_cost = usage["input_tokens"] * input_price_per_mtok / 1_000_000
+    cache_write_cost = (
+        usage.get("cache_creation_input_tokens", 0) * cache_write_price_per_mtok / 1_000_000
+    )
+    cache_read_cost = (
+        usage.get("cache_read_input_tokens", 0) * cache_read_price_per_mtok / 1_000_000
+    )
     output_cost = usage["output_tokens"] * output_price_per_mtok / 1_000_000
-    return (input_cost + output_cost) * multiplier
+    return (input_cost + cache_write_cost + cache_read_cost + output_cost) * multiplier
 
 
 def _extract_usage_tokens(

--- a/tests/test_anthropic_cache_costs.py
+++ b/tests/test_anthropic_cache_costs.py
@@ -1,0 +1,66 @@
+"""Anthropic prompt-cache token pricing (issue #1986)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_costs():
+    path = Path(__file__).resolve().parents[1] / "gpt_researcher" / "utils" / "costs.py"
+    spec = importlib.util.spec_from_file_location("gptr_costs_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_anthropic_cache_creation_tokens_increase_cost():
+    costs = _load_costs()
+    base = costs.calculate_llm_cost(
+        llm_provider="anthropic",
+        model="claude-sonnet-4-5",
+        input_content="",
+        output_content="",
+        response_metadata={
+            "model": "claude-sonnet-4-5",
+            "usage": {"input_tokens": 50, "output_tokens": 300},
+        },
+    )
+    with_cache = costs.calculate_llm_cost(
+        llm_provider="anthropic",
+        model="claude-sonnet-4-5",
+        input_content="",
+        output_content="",
+        response_metadata={
+            "model": "claude-sonnet-4-5",
+            "usage": {
+                "input_tokens": 50,
+                "cache_creation_input_tokens": 4000,
+                "cache_read_input_tokens": 0,
+                "output_tokens": 300,
+            },
+        },
+    )
+    assert base == 0.00465
+    assert abs(with_cache - 0.01965) < 1e-12
+    assert with_cache > base
+
+
+def test_anthropic_cache_read_tokens_increase_cost():
+    costs = _load_costs()
+    with_read = costs.calculate_llm_cost(
+        llm_provider="anthropic",
+        model="claude-sonnet-4-5",
+        input_content="",
+        output_content="",
+        response_metadata={
+            "model": "claude-sonnet-4-5",
+            "usage": {
+                "input_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 4000,
+                "output_tokens": 300,
+            },
+        },
+    )
+    assert abs(with_read - 0.00585) < 1e-12


### PR DESCRIPTION
## Summary
Anthropic usage includes `cache_creation_input_tokens` / `cache_read_input_tokens`, but cost helpers only priced `input_tokens`+`output_tokens`, so cache traffic was billed at $0.

## Changes
- Extract cache fields in `_extract_anthropic_usage`
- Price cache write at 1.25× input and cache read at 0.1× input in `calculate_anthropic_cost`
- Regression tests

Closes #1986

## Test plan
- `pytest tests/test_anthropic_cache_costs.py -q` (2 passed)