### PR TITLE
fix(scraper): tolerate None in parse_dimension

### DIFF
--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -57,6 +57,16 @@ def get_relevant_images(soup: BeautifulSoup, url: str) -> list:
 
 def parse_dimension(value: str) -> int:
     """Parse dimension value, handling px units"""
+    # HTML width/height attrs are often missing or non-string; callers pass
+    # img.get('width') which may be None.
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        try:
+            return int(float(value))
+        except (ValueError, TypeError) as e:
+            logging.debug("Could not parse dimension value %r: %s", value, e)
+            return None
     if value.lower().endswith('px'):
         value = value[:-2]  # Remove 'px' suffix
     try:

--- a/tests/test_parse_dimension_none.py
+++ b/tests/test_parse_dimension_none.py
@@ -1,0 +1,25 @@
+"""parse_dimension must tolerate None/non-str width/height attrs."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load():
+    path = Path(__file__).resolve().parents[1] / "gpt_researcher" / "scraper" / "utils.py"
+    spec = importlib.util.spec_from_file_location("scraper_utils_ut", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_parse_dimension_none():
+    u = _load()
+    assert u.parse_dimension(None) is None
+
+
+def test_parse_dimension_px_and_int():
+    u = _load()
+    assert u.parse_dimension("100px") == 100
+    assert u.parse_dimension(80) == 80
+    assert u.parse_dimension("auto") is None


### PR DESCRIPTION
## Summary
`parse_dimension` called `value.lower()` on HTML dim attrs; `img.get('width')` is often `None` and crashed image scoring.

## Changes
- Guard None/non-str inputs
- Unit tests

## Test plan
- `pytest tests/test_parse_dimension_none.py -q`