### PR TITLE
fix(scraper): return empty string when soup is None

### DIFF
--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -138,6 +138,8 @@ def clean_soup(soup: BeautifulSoup) -> BeautifulSoup:
 
 def get_text_from_soup(soup: BeautifulSoup) -> str:
     """Get the relevant text from the soup with improved filtering"""
+    if soup is None:
+        return ""
     text = soup.get_text(strip=True, separator="\n")
     # Remove excess whitespace
     text = re.sub(r"\s{2,}", " ", text)

--- a/tests/test_get_text_from_soup_none.py
+++ b/tests/test_get_text_from_soup_none.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import importlib.util
+from pathlib import Path
+
+def _load():
+    path = Path(__file__).resolve().parents[1] / "gpt_researcher" / "scraper" / "utils.py"
+    spec = importlib.util.spec_from_file_location("su", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def test_none_soup():
+    assert _load().get_text_from_soup(None) == ""


### PR DESCRIPTION
## Summary
`get_text_from_soup(None)` raised `AttributeError` when a scrape failed before a soup was built.

## Test plan
- `pytest tests/test_get_text_from_soup_none.py -q`