### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ####
 
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fgpt-researcher%2Fassafelovic.svg)](https://mcptoplist.com/server/mcp.so%2Fgpt-researcher%2Fassafelovic)
+
 [![Website](https://img.shields.io/badge/Official%20Website-gptr.dev-teal?style=for-the-badge&logo=world&logoColor=white&color=0891b2)](https://gptr.dev)
 [![Documentation](https://img.shields.io/badge/Documentation-DOCS-f472b6?logo=googledocs&logoColor=white&style=for-the-badge)](https://docs.gptr.dev)
 [![Discord](https://img.shields.io/discord/1127851779011391548?logo=discord&logoColor=white&label=Discord&color=34b76a&style=for-the-badge)](https://discord.gg/QgZXvJAccX)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **🔎 GPT Researcher MCP Server** is currently ranked **#97**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fgpt-researcher%2Fassafelovic.svg)](https://mcptoplist.com/server/mcp.so%2Fgpt-researcher%2Fassafelovic)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building 🔎 GPT Researcher MCP Server!
