### PR TITLE
fix(semantic_scholar): guard openAccessPdf and payload shapes

### DIFF
--- a/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
+++ b/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
@@ -20,10 +20,7 @@ class SemanticScholarSearch:
         """
         self.query = query
         assert sort in self.VALID_SORT_CRITERIA, "Invalid sort criterion"
-        # Preserve the exact (camelCase) criterion. The Semantic Scholar API
-        # expects ``citationCount`` / ``publicationDate`` verbatim; lowercasing
-        # them produced ``citationcount`` / ``publicationdate``, which the API
-        # rejects or silently ignores.
+        # Keep API sort casing (citationCount / publicationDate); only validate above.
         self.sort = sort
 
     def search(self, max_results: int = 20) -> List[Dict[str, str]]:
@@ -47,28 +44,41 @@ class SemanticScholarSearch:
             print(f"An error occurred while accessing Semantic Scholar API: {e}")
             return []
 
-        payload = response.json()
+        try:
+            payload = response.json()
+        except ValueError as e:
+            print(f"An error occurred while decoding Semantic Scholar JSON: {e}")
+            return []
+
         if not isinstance(payload, dict):
             return []
-        results = payload.get("data") or []
+
+        results = payload.get("data", [])
         if not isinstance(results, list):
             return []
 
         search_result = []
+
         for result in results:
             if not isinstance(result, dict):
                 continue
-            pdf = result.get("openAccessPdf")
-            if not (result.get("isOpenAccess") and isinstance(pdf, dict)):
+            if not result.get("isOpenAccess"):
                 continue
-            href = pdf.get("url") or ""
+            open_access_pdf = result.get("openAccessPdf")
+            # API may return null, a URL string, or an object with url.
+            if isinstance(open_access_pdf, dict):
+                href = open_access_pdf.get("url") or ""
+            elif isinstance(open_access_pdf, str):
+                href = open_access_pdf
+            else:
+                continue
             if not href:
                 continue
             search_result.append(
                 {
-                    "title": result.get("title") or "No Title",
+                    "title": result.get("title", "No Title"),
                     "href": href,
-                    "body": result.get("abstract") or "Abstract not available",
+                    "body": result.get("abstract", "Abstract not available"),
                 }
             )
 

--- a/tests/retrievers/test_semantic_scholar_guards.py
+++ b/tests/retrievers/test_semantic_scholar_guards.py
@@ -1,0 +1,87 @@
+"""Guards for Semantic Scholar openAccessPdf / payload shapes."""
+
+from unittest.mock import MagicMock, patch
+
+from gpt_researcher.retrievers.semantic_scholar.semantic_scholar import (
+    SemanticScholarSearch,
+)
+
+
+def _search_with_payload(payload):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = payload
+    with patch(
+        "gpt_researcher.retrievers.semantic_scholar.semantic_scholar.requests.get",
+        return_value=mock_resp,
+    ):
+        return SemanticScholarSearch("test query").search(max_results=5)
+
+
+def test_open_access_pdf_as_string_url():
+    out = _search_with_payload(
+        {
+            "data": [
+                {
+                    "title": "Paper",
+                    "abstract": "Abs",
+                    "isOpenAccess": True,
+                    "openAccessPdf": "https://example.com/p.pdf",
+                }
+            ]
+        }
+    )
+    assert out == [
+        {
+            "title": "Paper",
+            "href": "https://example.com/p.pdf",
+            "body": "Abs",
+        }
+    ]
+
+
+def test_open_access_pdf_object_url():
+    out = _search_with_payload(
+        {
+            "data": [
+                {
+                    "title": "Paper",
+                    "abstract": "Abs",
+                    "isOpenAccess": True,
+                    "openAccessPdf": {"url": "https://example.com/o.pdf"},
+                }
+            ]
+        }
+    )
+    assert out[0]["href"] == "https://example.com/o.pdf"
+
+
+def test_skips_null_open_access_and_non_dict_rows():
+    out = _search_with_payload(
+        {
+            "data": [
+                None,
+                "bad",
+                {
+                    "title": "Closed",
+                    "isOpenAccess": False,
+                    "openAccessPdf": {"url": "https://x"},
+                },
+                {
+                    "title": "OA no pdf",
+                    "isOpenAccess": True,
+                    "openAccessPdf": None,
+                },
+            ]
+        }
+    )
+    assert out == []
+
+
+def test_non_dict_json_returns_empty():
+    assert _search_with_payload([]) == []
+
+
+def test_sort_preserves_camel_case():
+    s = SemanticScholarSearch("q", sort="citationCount")
+    assert s.sort == "citationCount"


### PR DESCRIPTION
## Summary

- Guard non-dict JSON/`data` rows and string/null `openAccessPdf` shapes.
- Preserve API sort casing (`citationCount` / `publicationDate`).

## Motivation

`openAccessPdf.get` crashed when the field was a bare URL string; lowering sort broke valid Semantic Scholar enum values.

## Verification

- `.venv/bin/python -m pytest tests/retrievers/test_semantic_scholar_guards.py -q` — 5 passed

## Duplicate check

- Prior #1897 closed; main still has `.get` on openAccessPdf without shape guards.