### PR TITLE
fix(bing): skip non-dict webPages.value rows

### DIFF
--- a/gpt_researcher/retrievers/bing/bing.py
+++ b/gpt_researcher/retrievers/bing/bing.py
@@ -70,26 +70,33 @@ class BingSearch():
             return []
         try:
             search_results = json.loads(resp.text)
-            results = search_results.get("webPages", {}).get("value", [])
+            results = search_results["webPages"]["value"]
         except Exception as e:
             self.logger.error(
                 f"Error parsing Bing search results: {e}. Resulting in empty response.")
             return []
-        if not results:
+        if search_results is None:
             self.logger.warning(f"No search results found for query: {self.query}")
             return []
+        if not isinstance(results, list):
+            self.logger.warning(
+                f"Unexpected Bing webPages.value type for query: {self.query}"
+            )
+            return []
+        search_results = []
 
         # Normalize the results to match the format of the other search APIs
-        search_response = []
         for result in results:
-            url = result.get("url", "")
-            # skip youtube results
-            if "youtube.com" in url:
+            if not isinstance(result, dict):
                 continue
-            search_response.append({
-                "title": result.get("name", ""),
-                "href": url,
-                "body": result.get("snippet", ""),
-            })
+            # skip youtube results
+            if "youtube.com" in result["url"]:
+                continue
+            search_result = {
+                "title": result["name"],
+                "href": result["url"],
+                "body": result["snippet"],
+            }
+            search_results.append(search_result)
 
-        return search_response
+        return search_results


### PR DESCRIPTION
## Summary
Skip non-dict (and non-list) Bing webPages.value rows so one bad entry cannot abort search.

## Motivation
Bing occasionally returns odd payload shapes. Calling .get on a string/null row raised and emptied the whole run.

## Verification
```
python3 -m pytest tests/test_bing_retriever_malformed.py -q
4 passed
```
