### PR TITLE
fix(brave): skip non-dict web.results rows

### DIFF
--- a/gpt_researcher/retrievers/brave/brave.py
+++ b/gpt_researcher/retrievers/brave/brave.py
@@ -69,10 +69,18 @@ class BraveSearch:
             )
             return []
 
+        if not isinstance(results, list):
+            self.logger.warning(
+                f"Unexpected Brave web.results type for query: {self.query}"
+            )
+            return []
+
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
+            if not isinstance(result, dict):
+                continue
             url = result.get("url")
             if not url:
                 continue


### PR DESCRIPTION
## Summary
Skip non-dict Brave web.results rows and reject non-list payloads.

## Motivation
Calling .get on a non-dict result aborts the whole Brave search.

## Verification
```
python3 -m pytest tests/test_brave_retriever_malformed.py -q
2 passed
```
