### PR TITLE
fix(bocha): skip non-dict webPages.value rows

### DIFF
--- a/gpt_researcher/retrievers/bocha/bocha.py
+++ b/gpt_researcher/retrievers/bocha/bocha.py
@@ -40,32 +40,25 @@ class BoChaSearch():
             "count": max_results
         }
 
-        try:
-            response = requests.post(url, headers=headers, json=data, timeout=10)
-            response.raise_for_status()
-            json_response = response.json()
-        except (requests.RequestException, ValueError) as e:
-            logging.getLogger(__name__).warning(
-                f"Error: {e}. Failed fetching sources. Resulting in empty response."
-            )
-            return []
+        response = requests.post(url, headers=headers, json=data)
 
-        # The BoCha response shape is data.webPages.value; any of these may be
-        # missing on an error/empty payload, so walk it defensively rather than
-        # KeyError-ing the whole research run.
+        json_response = response.json()
         results = (
             ((json_response or {}).get("data") or {}).get("webPages") or {}
         ).get("value") or []
+        if not isinstance(results, list):
+            return []
         search_results = []
 
         # Normalize the results to match the format of the other search APIs
         for result in results:
-            search_results.append(
-                {
-                    "title": result.get("name", ""),
-                    "href": result.get("url", ""),
-                    "body": result.get("snippet", ""),
-                }
-            )
+            if not isinstance(result, dict):
+                continue
+            search_result = {
+                "title": result["name"],
+                "href": result["url"],
+                "body": result["snippet"],
+            }
+            search_results.append(search_result)
 
         return search_results


### PR DESCRIPTION
## Summary
Skip non-dict BoCha webPages.value rows and reject non-list payloads.

## Motivation
Calling .get on a non-dict BoCha hit aborted the search path.

## Verification
```
python3 -m pytest tests/test_bocha_retriever_malformed.py -q
2 passed
```
