### PR TITLE
fix(searchapi): guard organic_results shape and rows

### DIFF
--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -61,22 +61,31 @@ class SearchApiSearch():
             response = requests.get(encoded_url, headers=headers, timeout=20)
             if response.status_code == 200:
                 search_results = response.json()
-                if search_results:
-                    results = search_results["organic_results"]
-                    results_processed = 0
-                    for result in results:
-                        # skip youtube results
-                        if "youtube.com" in result["link"]:
-                            continue
-                        if results_processed >= max_results:
-                            break
-                        search_result = {
-                            "title": result["title"],
-                            "href": result["link"],
-                            "body": result["snippet"],
-                        }
-                        search_response.append(search_result)
-                        results_processed += 1
+                if not isinstance(search_results, dict):
+                    return []
+                # Missing/empty organic_results must not raise KeyError.
+                results = search_results.get("organic_results") or []
+                if not isinstance(results, list):
+                    return []
+                results_processed = 0
+                for result in results:
+                    if not isinstance(result, dict):
+                        continue
+                    link = result.get("link") or ""
+                    if not link:
+                        continue
+                    # skip youtube results
+                    if "youtube.com" in link:
+                        continue
+                    if results_processed >= max_results:
+                        break
+                    search_result = {
+                        "title": result.get("title") or "",
+                        "href": link,
+                        "body": result.get("snippet") or "",
+                    }
+                    search_response.append(search_result)
+                    results_processed += 1
         except Exception as e:
             print(f"Error: {e}. Failed fetching sources. Resulting in empty response.")
             search_response = []


### PR DESCRIPTION
## Summary
Harden SearchApi organic_results parsing: missing key, non-list, non-dict rows, missing links.

## Motivation
search_results["organic_results"] and result["link"] raised on common empty/error payloads and aborted search.

## Verification
```
python3 -m pytest tests/test_searchapi_retriever_malformed.py -q
3 passed
```
