### PR TITLE
fix(scraper): use session for PyMuPDF PDF downloads

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -41,15 +41,18 @@ class PyMuPDFScraper:
         """
         try:
             if self.is_url():
+                # Prefer caller-provided session so User-Agent / headers apply
+                # (bare requests.get uses python-requests/* and 403s on SEC EDGAR).
+                http = self.session if self.session is not None else requests
                 try:
-                    response = requests.get(self.link, timeout=(5, 30), stream=True)
+                    response = http.get(self.link, timeout=(5, 30), stream=True)
                     response.raise_for_status()
                 except requests.exceptions.SSLError:
                     import logging
                     logging.getLogger(__name__).warning(
                         f"SSL verification failed for {self.link}, retrying without verification"
                     )
-                    response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
+                    response = http.get(self.link, timeout=(5, 30), stream=True, verify=False)
                     response.raise_for_status()
 
                 with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:

--- a/tests/test_pymupdf_session_ua.py
+++ b/tests/test_pymupdf_session_ua.py
@@ -1,0 +1,75 @@
+"""PyMuPDFScraper must use the provided session for HTTP PDF downloads (#1847)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "scraper" / "pymupdf" / "pymupdf.py"
+
+
+def _load_pymupdf_module():
+    # Direct load to avoid packaging gpt_researcher (json_repair etc.).
+    pkg = types.ModuleType("gpt_researcher")
+    scraper = types.ModuleType("gpt_researcher.scraper")
+    pymupdf_pkg = types.ModuleType("gpt_researcher.scraper.pymupdf")
+    sys.modules.setdefault("gpt_researcher", pkg)
+    sys.modules.setdefault("gpt_researcher.scraper", scraper)
+    sys.modules.setdefault("gpt_researcher.scraper.pymupdf", pymupdf_pkg)
+
+    # stub languagе langchain_community loader import path used inside module
+    lc = types.ModuleType("langchain_community")
+    lcd = types.ModuleType("langchain_community.document_loaders")
+    class PyMuPDFLoader:  # placeholder overwritten in patch
+        def __init__(self, *a, **k):
+            pass
+        def load(self):
+            return []
+    lcd.PyMuPDFLoader = PyMuPDFLoader
+    sys.modules.setdefault("langchain_community", lc)
+    sys.modules.setdefault("langchain_community.document_loaders", lcd)
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.scraper.pymupdf.pymupdf", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class PyMuPDFSessionUATests(unittest.TestCase):
+    def test_scrape_url_uses_session_get_not_bare_requests(self):
+        mod = _load_pymupdf_module()
+        session = MagicMock()
+        resp = MagicMock()
+        resp.iter_content = MagicMock(return_value=[b"%PDF-1.4"])
+        resp.raise_for_status = MagicMock()
+        session.get.return_value = resp
+
+        scraper = mod.PyMuPDFScraper("https://example.com/doc.pdf", session=session)
+        page = MagicMock()
+        page.page_content = "hello"
+        page.metadata = {"title": "T"}
+        with patch.object(mod, "requests") as requests_mod, patch.object(
+            mod, "PyMuPDFLoader"
+        ) as loader_cls:
+            requests_mod.exceptions = __import__("requests").exceptions
+            loader_cls.return_value.load.return_value = [page]
+            text, images, title = scraper.scrape()
+
+        requests_mod.get.assert_not_called()
+        session.get.assert_called()
+        self.assertTrue(session.get.call_args.kwargs.get("stream"))
+        self.assertIn("hello", text)
+        self.assertEqual(title, "T")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Use the provided `requests.Session` (User-Agent) for `PyMuPDFScraper` HTTP PDF downloads instead of bare `requests.get`.

## Motivation
Closes #1847. SEC EDGAR and similar hosts 403 default `python-requests/*` UAs while HTML scrapes with the configured session work.

## Real behavior proof
```
python3 -m pytest tests/test_pymupdf_session_ua.py -q
# 1 passed
```

## Test plan
- [x] unit: session.get used; bare requests.get not called