### PR TITLE
fix(vector_store): skip non-dict docs and missing content

### DIFF
--- a/gpt_researcher/vector_store/vector_store.py
+++ b/gpt_researcher/vector_store/vector_store.py
@@ -24,8 +24,27 @@ class VectorStoreWrapper:
         self.vector_store.add_documents(splitted_documents)
     
     def _create_langchain_documents(self, data: List[Dict[str, str]]) -> List[Document]:
-        """Convert GPT Researcher Document to Langchain Document"""
-        return [Document(page_content=item["raw_content"], metadata={"source": item["url"]}) for item in data]
+        """Convert GPT Researcher Document to Langchain Document.
+
+        Skip non-dict rows and entries without usable ``raw_content``. Missing
+        ``url`` still yields a document with empty source rather than KeyError.
+        """
+        docs: List[Document] = []
+        if not data:
+            return docs
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("raw_content")
+            if content is None:
+                continue
+            docs.append(
+                Document(
+                    page_content=str(content),
+                    metadata={"source": item.get("url") or ""},
+                )
+            )
+        return docs
 
     def _split_documents(self, documents: List[Document], chunk_size: int = 1000, chunk_overlap: int = 200) -> List[Document]:
         """

--- a/tests/test_vector_store_doc_guards.py
+++ b/tests/test_vector_store_doc_guards.py
@@ -1,0 +1,73 @@
+"""VectorStoreWrapper must skip bad document rows."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "vector_store" / "vector_store.py"
+
+
+def _load():
+    # stub langchain pieces imported at module level
+    lc_docs = types.ModuleType("langchain_core.documents")
+    class Document:
+        def __init__(self, page_content, metadata=None):
+            self.page_content = page_content
+            self.metadata = metadata or {}
+    lc_docs.Document = Document
+    sys.modules["langchain_core"] = types.ModuleType("langchain_core")
+    sys.modules["langchain_core.documents"] = lc_docs
+
+    lc_vs = types.ModuleType("langchain_community.vectorstores")
+    class VectorStore:
+        pass
+    lc_vs.VectorStore = VectorStore
+    sys.modules["langchain_community"] = types.ModuleType("langchain_community")
+    sys.modules["langchain_community.vectorstores"] = lc_vs
+
+    splitter_mod = types.ModuleType("langchain_text_splitters")
+    class RecursiveCharacterTextSplitter:
+        def __init__(self, **k):
+            pass
+        def split_documents(self, docs):
+            return docs
+    splitter_mod.RecursiveCharacterTextSplitter = RecursiveCharacterTextSplitter
+    sys.modules["langchain_text_splitters"] = splitter_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.vector_store.vector_store", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class VectorStoreDocGuards(unittest.TestCase):
+    def test_skips_non_dict_and_none_content(self):
+        mod = _load()
+        wrap = mod.VectorStoreWrapper(MagicMock())
+        docs = wrap._create_langchain_documents(
+            [
+                None,
+                "x",
+                {"url": "https://a", "raw_content": None},
+                {"url": "https://b", "raw_content": "hello"},
+                {"raw_content": "no-url"},
+            ]
+        )
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0].page_content, "hello")
+        self.assertEqual(docs[0].metadata["source"], "https://b")
+        self.assertEqual(docs[1].metadata["source"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`VectorStoreWrapper._create_langchain_documents` skips non-dict rows and null `raw_content`, and tolerates missing `url`.

## Motivation
Bad crawler rows (None / bare strings / partial dicts) used to raise KeyError mid-load and drop the whole batch.

## Real behavior proof
```
python3 -m pytest tests/test_vector_store_doc_guards.py -q
# 1 passed
```

## Test plan
- [x] mixed bad/good document list