### PR TITLE
fix(scraper): harden image class parsing in get_relevant_images

### DIFF
--- a/gpt_researcher/scraper/utils.py
+++ b/gpt_researcher/scraper/utils.py
@@ -18,6 +18,8 @@ def get_relevant_images(soup: BeautifulSoup, url: str) -> list:
     image_urls = []
     
     try:
+        if soup is None:
+            return []
         # Find all img tags with src attribute
         all_images = soup.find_all('img', src=True)
         
@@ -26,7 +28,12 @@ def get_relevant_images(soup: BeautifulSoup, url: str) -> list:
             if img_src.startswith(('http://', 'https://')):
                 score = 0
                 # Check for relevant classes
-                if any(cls in img.get('class', []) for cls in ['header', 'featured', 'hero', 'thumbnail', 'main', 'content']):
+                classes = img.get("class") or []
+                if isinstance(classes, str):
+                    classes = classes.split()
+                elif not isinstance(classes, (list, tuple, set)):
+                    classes = []
+                if any(cls in classes for cls in ['header', 'featured', 'hero', 'thumbnail', 'main', 'content']):
                     score = 4  # Higher score
                 # Check for size attributes
                 elif img.get('width') and img.get('height'):

--- a/tests/test_scraper_images_class_guard.py
+++ b/tests/test_scraper_images_class_guard.py
@@ -1,0 +1,81 @@
+"""get_relevant_images tolerates odd class attrs and None soup."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "scraper" / "utils.py"
+
+
+class _Img:
+    def __init__(self, src: str, classes):
+        self._src = src
+        self._classes = classes
+
+    def __getitem__(self, key):
+        if key == "src":
+            return self._src
+        raise KeyError(key)
+
+    def get(self, key, default=None):
+        if key == "class":
+            return self._classes
+        if key == "width":
+            return default
+        if key == "height":
+            return default
+        return default
+
+
+def _load():
+    bs4 = types.ModuleType("bs4")
+    bs4.BeautifulSoup = object
+    sys.modules.setdefault("bs4", bs4)
+    parental = types.ModuleType("gpt_researcher")
+    scraper = types.ModuleType("gpt_researcher.scraper")
+    sys.modules.setdefault("gpt_researcher", parental)
+    sys.modules.setdefault("gpt_researcher.scraper", scraper)
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.scraper.utils", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ImagesClassGuard(unittest.TestCase):
+    def test_none_soup(self):
+        mod = _load()
+        self.assertEqual(mod.get_relevant_images(None, "https://ex.com"), [])
+
+    def test_string_class_attr(self):
+        mod = _load()
+        soup = MagicMock()
+        soup.find_all.return_value = [
+            _Img("https://cdn.example/a.jpg", "header hero")
+        ]
+        out = mod.get_relevant_images(soup, "https://ex.com/")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["score"], 4)
+
+    def test_non_sequence_class_attr(self):
+        mod = _load()
+        soup = MagicMock()
+        soup.find_all.return_value = [_Img("https://cdn.example/b.jpg", 123)]
+        out = mod.get_relevant_images(soup, "https://ex.com/")
+        # falls through without class score; may still be included if no size req
+        # with no width/height, score stays 0 and is included
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["score"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`get_relevant_images` returns `[]` for `None` soup and normalizes non-list `class` attributes before membership checks.

## Motivation
Odd `class` values (string / non-sequence) or a missing soup could error out of image scoring and drop all images for the page.

## Real behavior proof
```
python3 -m pytest tests/test_scraper_images_class_guard.py -q
# 3 passed
```

## Test plan
- [x] None soup; string class; non-sequence class