### PR TITLE
fix(openalex): tolerate non-dict OA location payloads

### DIFF
--- a/gpt_researcher/retrievers/openalex/openalex.py
+++ b/gpt_researcher/retrievers/openalex/openalex.py
@@ -97,12 +97,16 @@ class OpenAlexSearch:
         Prefer the open-access PDF URL, then the landing page URL from
         primary_location, then the OpenAlex work URL as fallback.
         """
-        oa_location = result.get("best_oa_location") or {}
+        oa_location = result.get("best_oa_location")
+        if not isinstance(oa_location, dict):
+            oa_location = {}
         pdf_url = oa_location.get("pdf_url")
         if pdf_url:
             return pdf_url
 
-        primary = result.get("primary_location") or {}
+        primary = result.get("primary_location")
+        if not isinstance(primary, dict):
+            primary = {}
         landing = primary.get("landing_page_url")
         if landing:
             return landing

--- a/tests/retrievers/test_openalex_location_guards.py
+++ b/tests/retrievers/test_openalex_location_guards.py
@@ -1,0 +1,40 @@
+"""OpenAlex location fields must tolerate non-dict API shapes."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MOD_PATH = ROOT / "gpt_researcher" / "retrievers" / "openalex" / "openalex.py"
+
+
+def _load():
+    name = "gptr_openalex_under_test"
+    spec = importlib.util.spec_from_file_location(name, MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_pick_href_non_dict_locations_fall_back_to_id():
+    mod = _load()
+    href = mod.OpenAlexSearch._pick_href(
+        {
+            "best_oa_location": "unexpected",
+            "primary_location": [],
+            "id": "https://openalex.org/W1",
+        }
+    )
+    assert href == "https://openalex.org/W1"
+
+
+def test_pick_href_prefers_pdf_when_dict():
+    mod = _load()
+    href = mod.OpenAlexSearch._pick_href(
+        {
+            "best_oa_location": {"pdf_url": "https://example.com/a.pdf"},
+            "id": "https://openalex.org/W1",
+        }
+    )
+    assert href == "https://example.com/a.pdf"


### PR DESCRIPTION
## Summary
OpenAlex `best_oa_location` / `primary_location` are not always dicts. Non-dict values crashed `_pick_href` via `.get`.

## Verification
```
python -m pytest tests/retrievers/test_openalex_location_guards.py -q
# 2 passed
```
