### PR TITLE
fix(mcp): skip non-dict server configs in client conversion

### DIFF
--- a/gpt_researcher/mcp/client.py
+++ b/gpt_researcher/mcp/client.py
@@ -47,6 +47,15 @@ class MCPClientManager:
         server_configs = {}
         
         for i, config in enumerate(self.mcp_configs):
+            # GPT Researcher MCP configs are dicts; tolerate list/json drift so
+            # a single bad entry cannot AttributeError the whole conversion.
+            if not isinstance(config, dict):
+                logger.warning(
+                    "Skipping MCP server config at index %s: expected dict, got %s",
+                    i,
+                    type(config).__name__,
+                )
+                continue
             # Generate server name
             server_name = config.get("name", f"mcp_server_{i+1}")
             

--- a/tests/test_mcp_client_non_dict_config.py
+++ b/tests/test_mcp_client_non_dict_config.py
@@ -1,0 +1,35 @@
+"""MCPClientManager must skip non-dict server configs."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load client.py directly to avoid gpt_researcher package __init__ side effects /
+# unrelated import-time NameErrors on other modules.
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT_PATH = ROOT / "gpt_researcher" / "mcp" / "client.py"
+spec = importlib.util.spec_from_file_location("gptr_mcp_client_under_test", CLIENT_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+MCPClientManager = mod.MCPClientManager
+
+
+def test_skips_non_dict_entries():
+    mgr = MCPClientManager(
+        [
+            {"name": "ok", "connection_url": "https://example.test/mcp"},
+            "not-a-dict",
+            None,
+            12,
+            {"name": "stdio_ok", "connection_type": "stdio", "command": "echo"},
+        ]
+    )
+    out = mgr.convert_configs_to_langchain_format()
+    assert "ok" in out
+    assert out["ok"]["transport"] == "streamable_http"
+    assert "stdio_ok" in out
+    assert out["stdio_ok"]["transport"] == "stdio"
+    assert len(out) == 2


### PR DESCRIPTION
## Summary
Skip non-dict entries while converting MCP server configs to langchain format.

## Motivation
A single bad list item did `config.get` and crashed conversion.

## Verification
```
.venv/bin/python -m pytest tests/test_mcp_client_non_dict_config.py -q
1 passed
```