### PR TITLE
fix(scraper): guard filter_urls against non-str URLs

### DIFF
--- a/gpt_researcher/actions/web_scraping.py
+++ b/gpt_researcher/actions/web_scraping.py
@@ -60,10 +60,15 @@ async def filter_urls(urls: list[str], config: Config) -> list[str]:
         list[str]: Filtered list of URLs.
     """
     filtered_urls = []
-    for url in urls:
-        # Add your filtering logic here
-        # For example, you might want to exclude certain domains or URL patterns
-        if not any(excluded in url for excluded in config.excluded_domains):
+    excluded = getattr(config, "excluded_domains", None) or []
+    if not isinstance(excluded, (list, tuple, set)):
+        excluded = []
+    for url in urls or []:
+        # URLs must be non-empty strings; null/int noise TypeErrors the
+        # substring check on excluded domains.
+        if not isinstance(url, str) or not url:
+            continue
+        if not any(isinstance(ex, str) and ex and ex in url for ex in excluded):
             filtered_urls.append(url)
     return filtered_urls
 

--- a/tests/test_filter_urls_guards.py
+++ b/tests/test_filter_urls_guards.py
@@ -1,0 +1,55 @@
+"""Regression: filter_urls guards non-str URLs and bad excluded_domains."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_filter_urls():
+    src = (
+        Path(__file__).resolve().parents[1]
+        / "gpt_researcher"
+        / "actions"
+        / "web_scraping.py"
+    ).read_text()
+    module = ast.parse(src)
+    fn = None
+    for node in module.body:
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "filter_urls":
+            fn = node
+            break
+    assert fn is not None
+    wrapper = ast.Module(body=[fn], type_ignores=[])
+    ast.fix_missing_locations(wrapper)
+    ns: dict = {}
+    exec(compile(wrapper, "filter_urls.py", "exec"), ns)
+    return ns["filter_urls"]
+
+
+filter_urls = _load_filter_urls()
+
+
+def test_skips_non_string_urls():
+    cfg = SimpleNamespace(excluded_domains=["bad.example"])
+    out = asyncio.run(
+        filter_urls(
+            ["https://ok.test", None, 12, "", "https://bad.example/x"],
+            cfg,
+        )
+    )
+    assert out == ["https://ok.test"]
+
+
+def test_tolerates_none_excluded_domains():
+    cfg = SimpleNamespace(excluded_domains=None)
+    out = asyncio.run(filter_urls(["https://ok.test"], cfg))
+    assert out == ["https://ok.test"]
+
+
+def test_tolerates_non_list_excluded_domains():
+    cfg = SimpleNamespace(excluded_domains="not-a-list")
+    out = asyncio.run(filter_urls(["https://ok.test"], cfg))
+    assert out == ["https://ok.test"]


### PR DESCRIPTION
## Summary
Skip non-string URL entries and tolerate bad `excluded_domains` shapes in `filter_urls`.

## Motivation
Null/int URLs TypeError’d the domain membership check; non-list excluded_domains crashed the same path.

## Verification
```
.venv/bin/python -m pytest tests/test_filter_urls_guards.py -q
3 passed
```