### PR TITLE
fix(utils): coerce rate_limit_delay in GlobalRateLimiter.configure

### DIFF
--- a/gpt_researcher/utils/rate_limiter.py
+++ b/gpt_researcher/utils/rate_limiter.py
@@ -55,7 +55,19 @@ class GlobalRateLimiter:
         Args:
             rate_limit_delay: Minimum seconds between requests (0 = no limit)
         """
-        self.rate_limit_delay = rate_limit_delay
+        # Env/config may hand us strings; wait_if_needed compares as float.
+        if rate_limit_delay is None:
+            self.rate_limit_delay = 0.0
+            return
+        try:
+            delay = float(rate_limit_delay)
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"rate_limit_delay must be a number, got {rate_limit_delay!r}"
+            ) from e
+        if delay < 0:
+            raise ValueError(f"rate_limit_delay must be non-negative, got {delay}")
+        self.rate_limit_delay = delay
 
     async def wait_if_needed(self):
         """

--- a/tests/test_rate_limiter_configure.py
+++ b/tests/test_rate_limiter_configure.py
@@ -1,0 +1,46 @@
+"""GlobalRateLimiter.configure must coerce/validate delay values."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+path = (
+    Path(__file__).resolve().parents[1]
+    / "gpt_researcher"
+    / "utils"
+    / "rate_limiter.py"
+)
+spec = importlib.util.spec_from_file_location("gptr_rate_limiter_ut", path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+GlobalRateLimiter = mod.GlobalRateLimiter
+
+
+def test_configure_coerces_string_delay():
+    limiter = GlobalRateLimiter()
+    limiter.reset()
+    limiter.configure("0.25")
+    assert limiter.rate_limit_delay == 0.25
+
+
+def test_configure_none_is_zero():
+    limiter = GlobalRateLimiter()
+    limiter.configure(None)
+    assert limiter.rate_limit_delay == 0.0
+
+
+def test_configure_rejects_negative():
+    limiter = GlobalRateLimiter()
+    with pytest.raises(ValueError, match="non-negative"):
+        limiter.configure(-1)
+
+
+def test_configure_rejects_garbage():
+    limiter = GlobalRateLimiter()
+    with pytest.raises(ValueError):
+        limiter.configure("fast")


### PR DESCRIPTION
## Summary
Coerce/validate `rate_limit_delay` in `GlobalRateLimiter.configure`.

## Motivation
String/None env values break float comparisons in `wait_if_needed`.

## Verification
```
.venv/bin/python -m pytest tests/test_rate_limiter_configure.py -q
4 passed
```