### PR TITLE
fix(query-processing): import typing names before use

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,6 +1,12 @@
+import logging
+from typing import Any, Dict, List
+
 import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
+from ..config import Config
+from ..prompts import PromptFamily
+from ..utils.llm import create_chat_completion
 
 
 def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
@@ -32,13 +38,10 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     if not queries and fallback_query.strip():
         return [fallback_query.strip()]
     return queries
-from ..utils.llm import create_chat_completion
-from ..prompts import PromptFamily
-from typing import Any, List, Dict
-from ..config import Config
-import logging
+
 
 logger = logging.getLogger(__name__)
+
 
 async def get_search_results(
     query: str,


### PR DESCRIPTION
Move typing and module imports above _normalize_sub_queries so Python 3.11 can evaluate its annotations during module import without raising NameError.