### PR TITLE
feat(retrievers): add Microsoft Web IQ support

### DIFF
--- a/.claude/references/retrievers.md
+++ b/.claude/references/retrievers.md
@@ -25,6 +25,7 @@
 | Exa | `ExaSearch` | `EXA_API_KEY` |
 | GroundRoute | `GroundRouteSearch` | `GROUNDROUTE_API_KEY` |
 | fastCRW | `CRWRetriever` | `CRW_API_KEY` |
+| Microsoft Web IQ | `WebIQSearch` | `WEBIQ_API_KEY` |
 | BoCha | `BoChaSearch` | `BOCHA_API_KEY` |
 | Xquik | `XquikSearch` | `XQUIK_API_KEY` |
 | GetXAPI (X/Twitter) | `GetXAPISearch` | `GETXAPI_API_KEY` |

--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,16 @@ NCBI_API_KEY=
 # STRATEGIC_TOKEN_LIMIT=16000
 GROUNDROUTE_API_KEY=
 
+# Microsoft Web IQ Search v3
+WEBIQ_API_KEY=
+# WEBIQ_ENDPOINT=https://api.microsoft.ai/v3/search/web
+# WEBIQ_LANGUAGE=en
+# WEBIQ_REGION=US
+# WEBIQ_CONTENT_FORMAT=passage  # passage, text, html, or markdown
+# WEBIQ_MAX_LENGTH=2500  # Search snippet size; full report content comes from the scraper
+# WEBIQ_SAFE_SEARCH=strict  # off or strict
+# WEBIQ_TIMEOUT=15
+
 # --- URL safety (added with the SSRF guard) ---
 # Scraped URLs are resolved and rejected when they point at private, loopback,
 # link-local or cloud-metadata addresses. If you deliberately research internal

--- a/docs/docs/gpt-researcher/gptr/config.md
+++ b/docs/docs/gpt-researcher/gptr/config.md
@@ -50,7 +50,7 @@ python gpt_researcher/main.py --config_path my_config.json
 
 Below is a list of current supported options:
 
-- **`RETRIEVER`**: Search engine or research retriever used for retrieving sources. Defaults to `tavily`. Options include `tavily`, `duckduckgo`, `bing`, `brave`, `google`, `searchapi`, `serper`, `serpapi`, `searx`, `arxiv`, `openalex`, `semantic_scholar`, `pubmed_central`, `exa`, `crw`, `groundroute`, `bocha`, `xquik`, `custom`, and `mcp`. You can also combine retrievers with commas, such as `tavily,openalex,semantic_scholar`. [Check here](https://github.com/assafelovic/gpt-researcher/tree/master/gpt_researcher/retrievers) for supported retrievers
+- **`RETRIEVER`**: Search engine or research retriever used for retrieving sources. Defaults to `tavily`. Options include `tavily`, `duckduckgo`, `bing`, `brave`, `google`, `searchapi`, `serper`, `serpapi`, `searx`, `arxiv`, `openalex`, `semantic_scholar`, `pubmed_central`, `exa`, `crw`, `groundroute`, `bocha`, `xquik`, `webiq`, `custom`, and `mcp`. You can also combine retrievers with commas, such as `tavily,openalex,semantic_scholar`. [Check here](https://github.com/assafelovic/gpt-researcher/tree/master/gpt_researcher/retrievers) for supported retrievers
 - **`EMBEDDING`**: Embedding model. Defaults to `openai:text-embedding-3-small`. Options: `ollama`, `huggingface`, `azure_openai`, `custom`.
 - **`SIMILARITY_THRESHOLD`**: Threshold value for similarity comparison when processing documents. Defaults to `0.42`.
 - **`FAST_LLM`**: Model name for fast LLM operations such summaries. Defaults to `openai:gpt-5.4-mini`.

--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -47,6 +47,7 @@ Thanks to our community, we have integrated the following web search engines and
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
 - [Xquik](https://xquik.com/) - Env: `RETRIEVER=xquik` and `XQUIK_API_KEY`
+- [Microsoft Web IQ](https://webiq.microsoft.ai/documentation/overview/) - Env: `RETRIEVER=webiq` and `WEBIQ_API_KEY`
 - [MCP](../retrievers/mcp-configs) - Env: `RETRIEVER=mcp`
 
 ## Custom Retrievers
@@ -99,6 +100,22 @@ To use [Brave Search](https://brave.com/search/api/) as your search engine:
 RETRIEVER=brave
 BRAVE_API_KEY=your_api_key_here
 ```
+
+### Microsoft Web IQ
+
+To use [Microsoft Web IQ](https://webiq.microsoft.ai/documentation/overview/) as your search engine:
+
+```bash
+RETRIEVER=webiq
+WEBIQ_API_KEY=your_api_key_here
+```
+
+Web IQ Search returns query-relevant passages of up to 2,500 characters by
+default. GPT Researcher keeps these as search snippets and scrapes the result
+URLs through its normal pipeline. Increasing `WEBIQ_MAX_LENGTH` can provide more
+context to quick-search summaries, but does not change how full report sources
+are scraped. Language, region, endpoint, content format, safe search, result
+length, and request timeout options are documented in `.env.example`.
 
 ### Serper
 

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -34,6 +34,7 @@ def get_retriever(retriever: str):
         - mcp: Model Context Protocol retriever
         - xquik: Xquik X/Twitter search
         - getxapi: GetXAPI X/Twitter search
+        - webiq: Microsoft Web IQ search
     """
     match retriever:
         case "google":
@@ -120,6 +121,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import GetXAPISearch
 
             return GetXAPISearch
+        case "webiq":
+            from gpt_researcher.retrievers import WebIQSearch
+
+            return WebIQSearch
 
         case _:
             return None

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -19,6 +19,7 @@ from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
 from .openalex.openalex import OpenAlexSearch
+from .webiq.webiq import WebIQSearch
 
 __all__ = [
     "TavilySearch",
@@ -41,5 +42,6 @@ __all__ = [
     "MCPRetriever",
     "BoChaSearch",
     "XquikSearch",
-    "OpenAlexSearch"
+    "OpenAlexSearch",
+    "WebIQSearch",
 ]

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -80,6 +80,7 @@ VALID_RETRIEVERS = [
     "mcp",
     "xquik",
     "openalex",
+    "webiq",
     "mock"
 ]
 

--- a/gpt_researcher/retrievers/webiq/__init__.py
+++ b/gpt_researcher/retrievers/webiq/__init__.py
@@ -1,0 +1,3 @@
+from .webiq import WebIQSearch
+
+__all__ = ["WebIQSearch"]

--- a/gpt_researcher/retrievers/webiq/webiq.py
+++ b/gpt_researcher/retrievers/webiq/webiq.py
@@ -1,0 +1,191 @@
+"""Microsoft Web IQ Web Search v3 retriever for GPT Researcher.
+
+API documentation: https://webiq.microsoft.ai/documentation/overview/
+"""
+
+import logging
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+
+class WebIQSearch:
+    """Search the web with Microsoft Web IQ Web Search v3."""
+
+    # Web IQ returns a URL plus a snippet whose size is set by
+    # WEBIQ_MAX_LENGTH (2500 characters by default). That snippet is a preview,
+    # not the article, so the page still has to be fetched -- and declaring it
+    # here keeps the legacy >100-character heuristic from mistaking a long
+    # snippet for already-scraped content and dropping the citation.
+    requires_scraping = True
+
+    DEFAULT_ENDPOINT = "https://api.microsoft.ai/v3/search/web"
+    DEFAULT_LANGUAGE = "en"
+    DEFAULT_REGION = "US"
+    DEFAULT_TIMEOUT = 15
+    MAX_QUERY_LENGTH = 1000
+
+    def __init__(self, query, headers=None, query_domains=None, **kwargs: Any):
+        self.logger = logging.getLogger(__name__)
+        request_headers = headers or {}
+        header_api_key = request_headers.get("webiq_api_key")
+
+        self.query = str(query or "")
+        if isinstance(query_domains, str):
+            query_domains = [query_domains]
+        self.query_domains = list(query_domains or [])
+        self.endpoint = os.getenv("WEBIQ_ENDPOINT", self.DEFAULT_ENDPOINT)
+        self.language = os.getenv("WEBIQ_LANGUAGE", self.DEFAULT_LANGUAGE)
+        self.region = os.getenv("WEBIQ_REGION", self.DEFAULT_REGION)
+
+        self.content_format = os.getenv("WEBIQ_CONTENT_FORMAT", "passage").strip().lower()
+        if self.content_format not in {"passage", "text", "html", "markdown"}:
+            self.logger.warning(
+                "Unsupported WEBIQ_CONTENT_FORMAT=%r; using 'passage'",
+                self.content_format,
+            )
+            self.content_format = "passage"
+
+        self.max_length = self._env_int("WEBIQ_MAX_LENGTH", 2500, 1, 500000)
+        self.safe_search = os.getenv("WEBIQ_SAFE_SEARCH", "strict").strip().lower()
+        # Web IQ Web Search v3 documents only "off" and "strict".
+        if self.safe_search not in {"off", "strict"}:
+            self.logger.warning(
+                "Unsupported WEBIQ_SAFE_SEARCH=%r; using 'strict'",
+                self.safe_search,
+            )
+            self.safe_search = "strict"
+
+        self.timeout = self._env_int("WEBIQ_TIMEOUT", self.DEFAULT_TIMEOUT, 1, 120)
+        self.api_key = str(header_api_key or os.getenv("WEBIQ_API_KEY", "")).strip()
+        if not self.api_key:
+            raise ValueError(
+                "Microsoft Web IQ API key not found. Pass webiq_api_key in "
+                "headers or set the WEBIQ_API_KEY environment variable."
+            )
+
+    @staticmethod
+    def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
+        try:
+            value = int(os.getenv(name, str(default)))
+        except ValueError:
+            value = default
+        return max(minimum, min(value, maximum))
+
+    @staticmethod
+    def _normalize_domain(value: Any) -> str:
+        domain = str(value or "").strip()
+        if domain.lower().startswith("site:"):
+            domain = domain[5:].strip()
+        if "://" in domain:
+            domain = urlparse(domain).netloc
+        domain = domain.split("/", 1)[0].strip()
+        if (
+            not domain
+            or len(domain) > 253
+            or any(character.isspace() for character in domain)
+            or any(
+                not (character.isalnum() or character in ".-:")
+                for character in domain
+            )
+        ):
+            return ""
+        return domain
+
+    def _build_query(self) -> str:
+        query = self.query.strip()[: self.MAX_QUERY_LENGTH]
+        domains = list(
+            dict.fromkeys(
+                domain
+                for domain in map(self._normalize_domain, self.query_domains)
+                if domain
+            )
+        )
+        invalid_count = len(self.query_domains) - len(domains)
+        if invalid_count:
+            self.logger.warning(
+                "Ignored %d invalid or duplicate Web IQ domain filters",
+                invalid_count,
+            )
+
+        valid_count = len(domains)
+        while domains:
+            operators = " OR ".join(f"site:{domain}" for domain in domains)
+            clause = f" site:{domains[0]}" if len(domains) == 1 else f" ({operators})"
+            if len(query) + len(clause) <= self.MAX_QUERY_LENGTH:
+                if len(domains) < valid_count:
+                    self.logger.warning(
+                        "Web IQ query limit kept %d of %d valid domain filters",
+                        len(domains),
+                        valid_count,
+                    )
+                return query + clause
+            domains.pop()
+
+        if valid_count:
+            self.logger.warning(
+                "Web IQ query limit left no room for %d valid domain filters",
+                valid_count,
+            )
+        return query
+
+    def search(self, max_results=10) -> list[dict[str, str]]:
+        """Run a Web IQ search and return normalized search results."""
+        try:
+            result_limit = max(1, min(int(max_results), 50))
+        except (TypeError, ValueError):
+            result_limit = 10
+
+        payload = {
+            "query": self._build_query(),
+            "maxResults": result_limit,
+            "language": self.language,
+            "region": self.region,
+            "contentFormat": self.content_format,
+            "maxLength": self.max_length,
+            "safeSearch": self.safe_search,
+        }
+        headers = {
+            "x-apikey": self.api_key,
+            "content-type": "application/json",
+            "accept": "application/json",
+        }
+
+        try:
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except (requests.RequestException, ValueError) as exc:
+            self.logger.warning("Microsoft Web IQ search failed: %s", exc)
+            return []
+
+        web_results = data.get("webResults") if isinstance(data, dict) else None
+        if not isinstance(web_results, list):
+            self.logger.warning("Microsoft Web IQ response has no webResults list")
+            return []
+
+        results = []
+        for item in web_results[:result_limit]:
+            if not isinstance(item, dict):
+                continue
+            url = item.get("url") or item.get("clickUrl")
+            if not isinstance(url, str) or not url.strip():
+                continue
+            title = item.get("title")
+            content = item.get("content")
+            results.append(
+                {
+                    "title": title if isinstance(title, str) else "",
+                    "href": url.strip(),
+                    "body": content if isinstance(content, str) else "",
+                }
+            )
+
+        return results

--- a/tests/test_webiq_retriever.py
+++ b/tests/test_webiq_retriever.py
@@ -1,0 +1,162 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from gpt_researcher.retrievers.webiq.webiq import WebIQSearch
+
+
+class TestWebIQSearch(unittest.TestCase):
+    def test_missing_api_key_raises_clear_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "WEBIQ_API_KEY"):
+                WebIQSearch("test query")
+
+    def test_header_api_key_takes_precedence(self):
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "environment-key"}, clear=True):
+            retriever = WebIQSearch(
+                "test query", headers={"webiq_api_key": "header-key"}
+            )
+        self.assertEqual(retriever.api_key, "header-key")
+
+    def test_domains_use_or_and_invalid_values_are_dropped(self):
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            query = WebIQSearch(
+                "test query",
+                query_domains=[
+                    "https://one.example/path",
+                    "two.example",
+                    "bad domain.example",
+                    "two.example",
+                ],
+            )._build_query()
+        self.assertEqual(query, "test query (site:one.example OR site:two.example)")
+
+    def test_string_domain_is_treated_as_one_filter(self):
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            query = WebIQSearch(
+                "test query", query_domains="example.com"
+            )._build_query()
+        self.assertEqual(query, "test query site:example.com")
+
+    def test_many_domains_preserve_the_complete_research_query(self):
+        long_query = (
+            "what are the latest breakthroughs in solid state battery "
+            "manufacturing and commercialization " * 4
+        ).strip()
+        domains = [f"subdomain-{i}.example.com" for i in range(40)]
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            query = WebIQSearch(long_query, query_domains=domains)._build_query()
+
+        self.assertLessEqual(len(query), WebIQSearch.MAX_QUERY_LENGTH)
+        self.assertTrue(query.startswith(long_query))
+        self.assertLess(query.count("site:"), len(domains))
+        self.assertTrue(query.endswith(")"))
+
+    def test_all_invalid_domains_emit_warning(self):
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            with self.assertLogs(
+                "gpt_researcher.retrievers.webiq.webiq", level="WARNING"
+            ):
+                query = WebIQSearch(
+                    "test query", query_domains=["bad domain", "bad)domain"]
+                )._build_query()
+        self.assertEqual(query, "test query")
+
+    def test_invalid_content_and_safe_search_values_warn_and_fall_back(self):
+        env = {
+            "WEBIQ_API_KEY": "test-key",
+            "WEBIQ_CONTENT_FORMAT": "unknown",
+            "WEBIQ_SAFE_SEARCH": "moderate",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertLogs(
+                "gpt_researcher.retrievers.webiq.webiq", level="WARNING"
+            ):
+                retriever = WebIQSearch("test query")
+        self.assertEqual(retriever.content_format, "passage")
+        self.assertEqual(retriever.safe_search, "strict")
+
+    @patch("gpt_researcher.retrievers.webiq.webiq.requests.post")
+    def test_search_uses_custom_endpoint_without_manual_host(self, mock_post):
+        response = MagicMock()
+        response.json.return_value = {"webResults": []}
+        mock_post.return_value = response
+        env = {
+            "WEBIQ_API_KEY": "test-key",
+            "WEBIQ_ENDPOINT": "https://proxy.example/v3/search/web",
+            "WEBIQ_TIMEOUT": "20",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            WebIQSearch("test query").search(max_results=3)
+
+        call = mock_post.call_args
+        self.assertEqual(call.args[0], "https://proxy.example/v3/search/web")
+        self.assertNotIn("host", call.kwargs["headers"])
+        self.assertEqual(call.kwargs["timeout"], 20)
+        self.assertEqual(call.kwargs["json"]["maxLength"], 2500)
+
+    @patch("gpt_researcher.retrievers.webiq.webiq.requests.post")
+    def test_search_normalizes_and_guards_malformed_fields(self, mock_post):
+        response = MagicMock()
+        response.json.return_value = {
+            "webResults": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com/article",
+                    "content": "Relevant passage.",
+                },
+                {
+                    "title": {"unexpected": "object"},
+                    "url": "https://example.com/malformed",
+                    "content": ["unexpected", "list"],
+                },
+                {"title": "Invalid URL", "url": {"not": "a string"}},
+                None,
+            ]
+        }
+        mock_post.return_value = response
+
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            results = WebIQSearch("test query").search(max_results=5)
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "title": "Example",
+                    "href": "https://example.com/article",
+                    "body": "Relevant passage.",
+                },
+                {
+                    "title": "",
+                    "href": "https://example.com/malformed",
+                    "body": "",
+                },
+            ],
+        )
+
+    @patch("gpt_researcher.retrievers.webiq.webiq.requests.post")
+    def test_request_failure_returns_empty_list(self, mock_post):
+        mock_post.side_effect = requests.Timeout("timed out")
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            self.assertEqual(WebIQSearch("test query").search(), [])
+
+    @patch("gpt_researcher.retrievers.webiq.webiq.requests.post")
+    def test_malformed_response_returns_empty_list(self, mock_post):
+        response = MagicMock()
+        response.json.return_value = {"webResults": None}
+        mock_post.return_value = response
+        with patch.dict(os.environ, {"WEBIQ_API_KEY": "test-key"}, clear=True):
+            self.assertEqual(WebIQSearch("test query").search(), [])
+
+    def test_declares_that_results_still_need_scraping(self):
+        # The "content" field is a snippet sized by WEBIQ_MAX_LENGTH, not the
+        # page, so the URL must still be fetched. Without this declaration the
+        # legacy >100-character heuristic would treat it as fetched content.
+        self.assertIs(WebIQSearch.requires_scraping, True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add an opt-in Web IQ Web Search v3 retriever with per-request API key injection, domain filtering, configuration documentation, malformed-response guards, and mocked unit tests.

Follow the official document: https://webiq.microsoft.ai/documentation/ and tested using real API.