### PR TITLE
fix(publisher): coerce None research_data/sources in layout

### DIFF
--- a/multi_agents/agents/publisher.py
+++ b/multi_agents/agents/publisher.py
@@ -21,7 +21,10 @@ class PublisherAgent:
 
     def generate_layout(self, research_state: dict):
         sections = []
-        for subheader in research_state.get("research_data", []):
+        research_data = research_state.get("research_data") or []
+        if not isinstance(research_data, (list, tuple)):
+            research_data = [research_data]
+        for subheader in research_data:
             if isinstance(subheader, dict):
                 # Handle dictionary case
                 for key, value in subheader.items():
@@ -29,15 +32,24 @@ class PublisherAgent:
             else:
                 # Handle string case
                 sections.append(f"{subheader}")
-        
-        sections_text = '\n\n'.join(sections)
-        references = '\n'.join(f"{reference}" for reference in research_state.get("sources", []))
-        headers = research_state.get("headers", {})
-        
+
+        sections_text = "\n\n".join(sections)
+        sources = research_state.get("sources") or []
+        if not isinstance(sources, (list, tuple)):
+            sources = [sources] if sources else []
+        references = "\n".join(f"{reference}" for reference in sources)
+        headers = research_state.get("headers") or {}
+        if not isinstance(headers, dict):
+            headers = {}
+
         diagrams_text = ""
-        diagrams = research_state.get("diagrams", [])
+        diagrams = research_state.get("diagrams") or []
+        if not isinstance(diagrams, (list, tuple)):
+            diagrams = [diagrams] if diagrams else []
         if diagrams:
-            diagrams_text = "\n## Visualizations\n" + "\n\n".join(diagrams) + "\n"
+            diagrams_text = (
+                "\n## Visualizations\n" + "\n\n".join(str(d) for d in diagrams) + "\n"
+            )
 
         layout = f"""# {headers.get('title')}
 #### {headers.get("date")}: {research_state.get('date')}

--- a/tests/test_publisher_layout_guards.py
+++ b/tests/test_publisher_layout_guards.py
@@ -1,0 +1,47 @@
+"""PublisherAgent.generate_layout guards for None sources/research_data."""
+import importlib.util
+import pathlib
+import sys
+import types
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.modules.setdefault("multi_agents", types.ModuleType("multi_agents"))
+sys.modules["multi_agents"].__path__ = [str(ROOT / "multi_agents")]
+agents = types.ModuleType("multi_agents.agents")
+agents.__path__ = [str(ROOT / "multi_agents" / "agents")]
+sys.modules.setdefault("multi_agents.agents", agents)
+utils = types.ModuleType("multi_agents.agents.utils")
+utils.__path__ = [str(ROOT / "multi_agents" / "agents" / "utils")]
+sys.modules.setdefault("multi_agents.agents.utils", utils)
+
+ff = types.ModuleType("multi_agents.agents.utils.file_formats")
+ff.write_md_to_pdf = ff.write_md_to_word = ff.write_text_to_md = None
+sys.modules["multi_agents.agents.utils.file_formats"] = ff
+views = types.ModuleType("multi_agents.agents.utils.views")
+views.print_agent_output = lambda *a, **k: None
+sys.modules["multi_agents.agents.utils.views"] = views
+
+path = ROOT / "multi_agents/agents/publisher.py"
+spec = importlib.util.spec_from_file_location("multi_agents.agents.publisher", path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+PublisherAgent = mod.PublisherAgent
+
+
+def test_none_sources_does_not_typeerror():
+    agent = PublisherAgent(output_dir="/tmp")
+    layout = agent.generate_layout(
+        {
+            "research_data": None,
+            "sources": None,
+            "headers": None,
+            "diagrams": None,
+            "introduction": "intro",
+            "table_of_contents": "toc",
+            "conclusion": "end",
+            "date": "today",
+        }
+    )
+    assert "intro" in layout
+    assert isinstance(layout, str)


### PR DESCRIPTION
## Summary
`PublisherAgent.generate_layout` TypeError'd when `research_data`/`sources`/`headers`/`diagrams` were explicit `None` (dict.get default skipped). Coerce to empty collections.

## Test plan
- `pytest tests/test_publisher_layout_guards.py -v` (1 passed)
