### PR TITLE
fix(pubmed): guard esearch idlist shape before iterating

### DIFF
--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -62,7 +62,14 @@ class PubMedCentralSearch:
             response.raise_for_status()
             data = response.json()
             
-            id_list = data.get('esearchresult', {}).get('idlist', [])
+            esearch = data.get("esearchresult") or {}
+            if not isinstance(esearch, dict):
+                return []
+            id_list = esearch.get("idlist") or []
+            if not isinstance(id_list, list):
+                return []
+            # IDs are strings/ints in NCT/PMC payloads; drop other shapes
+            id_list = [str(i) for i in id_list if isinstance(i, (str, int)) and str(i)]
             print(f"Found {len(id_list)} articles with full text available")
             return id_list
             

--- a/tests/test_pubmed_idlist_shape.py
+++ b/tests/test_pubmed_idlist_shape.py
@@ -1,0 +1,40 @@
+"""PubMed esearch idlist must be a list before search loops."""
+import importlib.util
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+_requests = types.ModuleType("requests")
+_requests.get = MagicMock()
+_requests.RequestException = Exception
+sys.modules["requests"] = _requests
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "gpt_researcher"
+    / "retrievers"
+    / "pubmed_central"
+    / "pubmed_central.py"
+)
+_spec = importlib.util.spec_from_file_location("_pubmed_idlist", _PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_non_list_idlist_returns_empty():
+    s = _mod.PubMedCentralSearch("q")
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"esearchresult": {"idlist": "PMC1"}}
+    _mod.requests.get = MagicMock(return_value=resp)
+    assert s._search_articles(5) == []
+
+
+def test_list_ids_normalized_to_str():
+    s = _mod.PubMedCentralSearch("q")
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"esearchresult": {"idlist": [1, "PMC2", None, {}]}}
+    _mod.requests.get = MagicMock(return_value=resp)
+    assert s._search_articles(5) == ["1", "PMC2"]


### PR DESCRIPTION
## Summary
eutils `idlist` is not always a list; harden `_search_articles` so non-list / mixed entries return a clean `list[str]` (or empty).

## Test plan
- `pytest tests/test_pubmed_idlist_shape.py -v` (2 passed)
