### PR TITLE
Core/runtime hardening: 8 verified fixes

### DIFF
--- a/backend/report_type/deep_research/example.py
+++ b/backend/report_type/deep_research/example.py
@@ -284,10 +284,14 @@ class DeepResearch:
         answers = ["Automatically proceeding with research"] * len(follow_up_questions)
 
         # Combine query and Q&A
+        follow_up_qa = " ".join(
+            f"Q: {question}\nA: {answer}"
+            for question, answer in zip(follow_up_questions, answers)
+        )
         combined_query = f"""
         Initial Query: {self.query}
         Follow-up Questions and Answers:
-        {' '.join([f'Q: {q}\nA: {a}' for q, a in zip(follow_up_questions, answers)])}
+        {follow_up_qa}
         """
 
         # Run deep research

--- a/cli.py
+++ b/cli.py
@@ -276,7 +276,7 @@ async def main(args):
             query=args.query,
             query_domains=query_domains,
             report_type="research_report",
-            report_source="web_search",
+            report_source=args.report_source,
         )
 
         report = await detailed_report.run()

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -168,10 +168,10 @@ class GPTResearcher:
         self.log_handler = log_handler
         self.prompt_family = get_prompt_family(prompt_family or self.cfg.prompt_family, self.cfg)
         
-        # Process MCP configurations if provided
-        self.mcp_configs = mcp_configs
-        if mcp_configs:
-            self._process_mcp_configs(mcp_configs)
+        # Explicit per-instance configs override file/environment configuration.
+        self.mcp_configs = self.cfg.mcp_servers if mcp_configs is None else mcp_configs
+        if self.mcp_configs:
+            self._process_mcp_configs(self.mcp_configs)
         
         self.retrievers = get_retrievers(self.headers, self.cfg)
         self.memory = Memory(

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -164,6 +164,7 @@ class GPTResearcher:
         self.headers = headers or {}
         self.research_costs = 0.0
         self.step_costs: dict[str, float] = {}
+        self._background_tasks: set[asyncio.Task] = set()
         self._current_step: str = "general"
         self.log_handler = log_handler
         self.prompt_family = get_prompt_family(prompt_family or self.cfg.prompt_family, self.cfg)
@@ -787,8 +788,20 @@ class GPTResearcher:
         step = self._current_step
         self.step_costs[step] = self.step_costs.get(step, 0.0) + cost
         if self.log_handler:
-            self._log_event("research", step="cost_update", details={
-                "cost": cost,
-                "total_cost": self.research_costs,
-                "step_name": step,
-            })
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return
+            task = loop.create_task(
+                self._log_event(
+                    "research",
+                    step="cost_update",
+                    details={
+                        "cost": cost,
+                        "total_cost": self.research_costs,
+                        "step_name": step,
+                    },
+                )
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -199,16 +199,18 @@ class Config:
             return None, None
         try:
             llm_provider, llm_model = llm_str.split(":", 1)
-            assert llm_provider in _SUPPORTED_PROVIDERS, (
-                f"Unsupported {llm_provider}.\nSupported llm providers are: "
-                + ", ".join(_SUPPORTED_PROVIDERS)
-            )
-            return llm_provider, llm_model
-        except ValueError:
+        except ValueError as exc:
             raise ValueError(
                 "Set SMART_LLM or FAST_LLM = '<llm_provider>:<llm_model>' "
                 "Eg 'openai:gpt-4o-mini'"
+            ) from exc
+
+        if llm_provider not in _SUPPORTED_PROVIDERS:
+            raise ValueError(
+                f"Unsupported {llm_provider}.\nSupported llm providers are: "
+                + ", ".join(_SUPPORTED_PROVIDERS)
             )
+        return llm_provider, llm_model
 
     @staticmethod
     def parse_reasoning_effort(reasoning_effort_str: str | None) -> str | None:
@@ -228,16 +230,18 @@ class Config:
             return None, None
         try:
             embedding_provider, embedding_model = embedding_str.split(":", 1)
-            assert embedding_provider in _SUPPORTED_PROVIDERS, (
-                f"Unsupported {embedding_provider}.\nSupported embedding providers are: "
-                + ", ".join(_SUPPORTED_PROVIDERS)
-            )
-            return embedding_provider, embedding_model
-        except ValueError:
+        except ValueError as exc:
             raise ValueError(
                 "Set EMBEDDING = '<embedding_provider>:<embedding_model>' "
                 "Eg 'openai:text-embedding-3-large'"
+            ) from exc
+
+        if embedding_provider not in _SUPPORTED_PROVIDERS:
+            raise ValueError(
+                f"Unsupported {embedding_provider}.\nSupported embedding providers are: "
+                + ", ".join(_SUPPORTED_PROVIDERS)
             )
+        return embedding_provider, embedding_model
 
     def validate_doc_path(self):
         """Ensure that the folder exists at the doc path"""

--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -49,16 +49,6 @@ class Config:
         if config_to_use['REPORT_SOURCE'] != 'web':
           self._set_doc_path(config_to_use)
 
-        # MCP support configuration
-        self.mcp_servers = []  # List of MCP server configurations
-        self.mcp_allowed_root_paths = []  # Allowed root paths for MCP servers
-
-        # Read from config
-        if hasattr(self, 'mcp_servers'):
-            self.mcp_servers = self.mcp_servers
-        if hasattr(self, 'mcp_allowed_root_paths'):
-            self.mcp_allowed_root_paths = self.mcp_allowed_root_paths
-
     def _set_attributes(self, config: Dict[str, Any]) -> None:
         """Set configuration attributes from config dictionary.
 

--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -113,6 +113,24 @@ class ChatLogger:
                     "stacktrace": traceback.format_exc()
                 }) + "\n")
 
+
+def _content_to_text(content: Any) -> str:
+    """Normalize LangChain message content into plain text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "".join(parts)
+    return str(content)
+
+
 class GenericLLMProvider:
 
     def __init__(self, llm, chat_log: str | None = None,  verbose: bool = True):
@@ -360,7 +378,7 @@ class GenericLLMProvider:
             output = await self.llm.ainvoke(messages, **kwargs)
             self._capture_response_metadata(output)
 
-            res = output.content
+            res = _content_to_text(output.content)
 
         else:
             res = await self.stream_response(messages, websocket, **kwargs)
@@ -378,7 +396,7 @@ class GenericLLMProvider:
         # Streaming the response using the chain astream method from langchain
         async for chunk in self.llm.astream(messages, **kwargs):
             self._capture_response_metadata(chunk)
-            content = chunk.content
+            content = _content_to_text(chunk.content)
             if not content:
                 continue
             response += content

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -393,6 +393,12 @@ Return ONLY a JSON object using this exact schema:
         if visited_urls is None:
             visited_urls = set()
 
+        all_learnings = learnings.copy()
+        all_citations = citations.copy()
+        all_visited_urls = visited_urls.copy()
+        all_context = []
+        all_sources = []
+
         progress = ResearchProgress(depth, breadth)
 
         if on_progress:
@@ -412,12 +418,6 @@ Return ONLY a JSON object using this exact schema:
                 'context': all_context,
                 'sources': all_sources,
             }
-
-        all_learnings = learnings.copy()
-        all_citations = citations.copy()
-        all_visited_urls = visited_urls.copy()
-        all_context = []
-        all_sources = []
 
         # Process queries with concurrency limit
         semaphore = asyncio.Semaphore(self.concurrency_limit)

--- a/gpt_researcher/utils/logging_config.py
+++ b/gpt_researcher/utils/logging_config.py
@@ -56,8 +56,11 @@ def setup_research_logging():
     research_logger = logging.getLogger('research')
     research_logger.setLevel(logging.INFO)
     
-    # Remove any existing handlers to avoid duplicates
-    research_logger.handlers.clear()
+    # Remove and close existing handlers to avoid duplicate output and leaked
+    # file descriptors when logging is configured more than once.
+    for handler in research_logger.handlers[:]:
+        research_logger.removeHandler(handler)
+        handler.close()
     
     # Add file handler
     research_logger.addHandler(file_handler)
@@ -72,6 +75,7 @@ def setup_research_logging():
     
     # Create JSON handler
     json_handler = JSONResearchHandler(json_file)
+    research_logger.json_handler = json_handler
     
     return str(log_file), str(json_file), research_logger, json_handler
 

--- a/tests/skills/test_deep_research_empty_results.py
+++ b/tests/skills/test_deep_research_empty_results.py
@@ -10,6 +10,29 @@ from gpt_researcher.skills.deep_research import DeepResearchSkill
 
 
 @pytest.mark.asyncio
+async def test_stops_when_no_search_queries_are_generated():
+    skill = DeepResearchSkill.__new__(DeepResearchSkill)
+    skill.generate_search_queries = AsyncMock(return_value=[])
+
+    result = await skill.deep_research(
+        query="topic",
+        breadth=2,
+        depth=3,
+        learnings=["existing learning"],
+        citations={"existing learning": "https://example.com/source"},
+        visited_urls={"https://example.com/source"},
+    )
+
+    assert result == {
+        "learnings": ["existing learning"],
+        "visited_urls": {"https://example.com/source"},
+        "citations": {"existing learning": "https://example.com/source"},
+        "context": [],
+        "sources": [],
+    }
+
+
+@pytest.mark.asyncio
 async def test_stops_when_all_query_processors_return_none():
     researcher = SimpleNamespace(
         cfg=SimpleNamespace(

--- a/tests/test_cli_detailed_report_source.py
+++ b/tests/test_cli_detailed_report_source.py
@@ -1,0 +1,41 @@
+from argparse import Namespace
+
+import pytest
+
+import cli as cli_module
+
+
+@pytest.mark.asyncio
+async def test_detailed_report_preserves_requested_report_source(tmp_path, monkeypatch):
+    captured_kwargs = {}
+
+    class FakeDetailedReport:
+        gpt_researcher = None
+
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+        async def run(self):
+            return "# Local report"
+
+    async def fake_generate_task_title(query, report, researcher):
+        return "local-report"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli_module, "DetailedReport", FakeDetailedReport)
+    monkeypatch.setattr(cli_module, "_generate_task_title", fake_generate_task_title)
+
+    args = Namespace(
+        query="Summarize my documents",
+        report_type="detailed_report",
+        tone="objective",
+        encoding="utf-8",
+        query_domains="",
+        report_source="local",
+        no_pdf=True,
+        no_docx=True,
+    )
+
+    await cli_module.main(args)
+
+    assert captured_kwargs["report_source"] == "local"

--- a/tests/test_cost_logging.py
+++ b/tests/test_cost_logging.py
@@ -1,0 +1,61 @@
+import asyncio
+import builtins
+import importlib
+import typing
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+def _load_researcher_class():
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+    ):
+        return importlib.import_module("gpt_researcher.agent").GPTResearcher
+
+
+GPTResearcher = _load_researcher_class()
+
+
+class CostLoggingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_add_costs_schedules_cost_update_log(self):
+        researcher = GPTResearcher.__new__(GPTResearcher)
+        researcher.research_costs = 0.0
+        researcher.step_costs = {}
+        researcher._background_tasks = set()
+        researcher._current_step = "research"
+        researcher.log_handler = AsyncMock()
+
+        researcher.add_costs(0.25)
+        await asyncio.sleep(0)
+
+        self.assertEqual(researcher.research_costs, 0.25)
+        self.assertEqual(researcher.step_costs, {"research": 0.25})
+        researcher.log_handler.on_research_step.assert_awaited_once_with(
+            "cost_update",
+            {
+                "cost": 0.25,
+                "total_cost": 0.25,
+                "step_name": "research",
+            },
+        )
+
+
+class SynchronousCostLoggingTests(unittest.TestCase):
+    def test_add_costs_without_running_loop_still_accumulates(self):
+        researcher = GPTResearcher.__new__(GPTResearcher)
+        researcher.research_costs = 0.0
+        researcher.step_costs = {}
+        researcher._background_tasks = set()
+        researcher._current_step = "research"
+        researcher.log_handler = AsyncMock()
+
+        researcher.add_costs(0.25)
+
+        self.assertEqual(researcher.research_costs, 0.25)
+        self.assertEqual(researcher.step_costs, {"research": 0.25})
+        researcher.log_handler.on_research_step.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_content_blocks.py
+++ b/tests/test_llm_content_blocks.py
@@ -1,0 +1,71 @@
+import asyncio
+import builtins
+import importlib
+import typing
+import unittest
+from unittest.mock import patch
+
+
+def _load_provider_class():
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+    ):
+        module = importlib.import_module(
+            "gpt_researcher.llm_provider.generic.base"
+        )
+    return module.GenericLLMProvider
+
+
+GenericLLMProvider = _load_provider_class()
+
+
+class _Message:
+    def __init__(self, content):
+        self.content = content
+        self.usage_metadata = None
+        self.response_metadata = {}
+
+
+class _BlockContentLLM:
+    async def ainvoke(self, messages, **kwargs):
+        return _Message(
+            [
+                {"type": "text", "text": "Hello"},
+                {"type": "metadata", "value": "ignored"},
+                " world",
+            ]
+        )
+
+    async def astream(self, messages, **kwargs):
+        yield _Message([{"type": "text", "text": "Hello"}])
+        yield _Message(["\n", {"type": "text", "text": "world"}])
+
+
+class LLMContentBlockTests(unittest.TestCase):
+    def test_non_streaming_content_blocks_return_text(self):
+        provider = GenericLLMProvider(_BlockContentLLM(), verbose=False)
+
+        response = asyncio.run(
+            provider.get_chat_response(
+                [{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+        )
+
+        self.assertEqual(response, "Hello world")
+
+    def test_streaming_content_blocks_are_joined(self):
+        provider = GenericLLMProvider(_BlockContentLLM(), verbose=False)
+
+        response = asyncio.run(
+            provider.stream_response(
+                [{"role": "user", "content": "hi"}],
+            )
+        )
+
+        self.assertEqual(response, "Hello\nworld")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_config_loading.py
+++ b/tests/test_mcp_config_loading.py
@@ -1,0 +1,56 @@
+import json
+
+from gpt_researcher import GPTResearcher
+from gpt_researcher.config.config import Config
+
+
+MCP_SERVERS = [
+    {
+        "name": "local-search",
+        "command": "python",
+        "args": ["search_server.py"],
+    }
+]
+
+
+def test_config_preserves_mcp_servers_from_file(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"MCP_SERVERS": MCP_SERVERS}))
+
+    config = Config(str(config_path))
+
+    assert config.mcp_servers == MCP_SERVERS
+
+
+def test_config_preserves_mcp_servers_from_environment(monkeypatch):
+    monkeypatch.setenv("MCP_SERVERS", json.dumps(MCP_SERVERS))
+
+    config = Config()
+
+    assert config.mcp_servers == MCP_SERVERS
+
+
+def test_researcher_uses_configured_mcp_servers(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"MCP_SERVERS": MCP_SERVERS}))
+    monkeypatch.setattr("gpt_researcher.agent.Memory", lambda *args, **kwargs: object())
+
+    researcher = GPTResearcher(query="test query", config_path=str(config_path))
+
+    assert researcher.mcp_configs == MCP_SERVERS
+    assert "mcp" in researcher.cfg.retrievers
+
+
+def test_explicit_empty_mcp_configs_override_file_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"MCP_SERVERS": MCP_SERVERS}))
+    monkeypatch.setattr("gpt_researcher.agent.Memory", lambda *args, **kwargs: object())
+
+    researcher = GPTResearcher(
+        query="test query",
+        config_path=str(config_path),
+        mcp_configs=[],
+    )
+
+    assert researcher.mcp_configs == []
+    assert researcher.cfg.retrievers == ["tavily"]

--- a/tests/test_provider_validation_optimized.py
+++ b/tests/test_provider_validation_optimized.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("method_name", ["parse_llm", "parse_embedding"])
+def test_provider_validation_survives_optimized_python(method_name):
+    project_root = Path(__file__).resolve().parents[1]
+    script = f"""
+import builtins
+import typing
+
+builtins.Any = typing.Any
+builtins.List = typing.List
+
+from gpt_researcher.config.config import Config
+
+try:
+    Config.{method_name}("unsupported-provider:model")
+except ValueError:
+    pass
+else:
+    raise SystemExit("unsupported provider was accepted")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_structured_logging_setup.py
+++ b/tests/test_structured_logging_setup.py
@@ -1,0 +1,44 @@
+import logging
+
+import pytest
+
+from gpt_researcher.utils.logging_config import (
+    get_json_handler,
+    setup_research_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_research_logger():
+    yield
+    logger = logging.getLogger("research")
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+    if hasattr(logger, "json_handler"):
+        del logger.json_handler
+
+
+def test_setup_registers_json_handler_for_research_conductor(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    _, _, logger, json_handler = setup_research_logging()
+
+    assert get_json_handler() is json_handler
+    assert logger.json_handler is json_handler
+
+
+def test_setup_closes_replaced_file_handlers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    _, _, logger, _ = setup_research_logging()
+    old_file_handlers = [
+        handler
+        for handler in logger.handlers
+        if isinstance(handler, logging.FileHandler)
+    ]
+
+    setup_research_logging()
+
+    assert old_file_handlers
+    assert all(handler.stream is None for handler in old_file_handlers)


### PR DESCRIPTION
## Summary

Consolidates eight independently verified core/runtime fixes into one reviewable
batch. Each fix remains a separate commit so it can be reviewed, reverted, or
cherry-picked independently.

Includes the original #2022 scope and supersedes #2023, #2027, #2030, #2035,
#2040, #2041, and #2043.

## Included fixes

- Preserve configured MCP servers and explicit overrides (refs #1523).
- Forward the CLI's selected detailed-report source.
- Keep LLM and embedding provider validation active under `python -O`.
- Register and safely replace the structured JSON log handler.
- Initialize deep-research aggregation before the zero-query return.
- Restore Python 3.11 syntax compatibility in the deep-research example.
- Schedule asynchronous cost log events without unawaited coroutines.
- Normalize structured LangChain content blocks (refs #1628).

## Verification

- 46 focused and adjacent pytest cases passed.
- 4 focused unittest cases passed.
- Python 3.11 and 3.12 compile checks passed.
- Ruff `F821`/`RUF006` checks passed.
- `git diff --check` passed.

The test process supplies `Any`/`List` process-locally for the existing import
regression tracked by #1981. This batch does not modify that file or duplicate
the active fix in #1988.

## Impact

- No intentional breaking changes.
- Eight independent fixes, preserved as eight commits.
- No network or LLM calls are required by the focused regressions.

AI-assisted consolidation; every included behavior was revalidated locally.
