### PR TITLE
fix(cli): preserve detailed report source

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -276,7 +276,7 @@ async def main(args):
             query=args.query,
             query_domains=query_domains,
             report_type="research_report",
-            report_source="web_search",
+            report_source=args.report_source,
         )
 
         report = await detailed_report.run()

--- a/tests/test_cli_detailed_report_source.py
+++ b/tests/test_cli_detailed_report_source.py
@@ -1,0 +1,41 @@
+from argparse import Namespace
+
+import pytest
+
+import cli as cli_module
+
+
+@pytest.mark.asyncio
+async def test_detailed_report_preserves_requested_report_source(tmp_path, monkeypatch):
+    captured_kwargs = {}
+
+    class FakeDetailedReport:
+        gpt_researcher = None
+
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+        async def run(self):
+            return "# Local report"
+
+    async def fake_generate_task_title(query, report, researcher):
+        return "local-report"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli_module, "DetailedReport", FakeDetailedReport)
+    monkeypatch.setattr(cli_module, "_generate_task_title", fake_generate_task_title)
+
+    args = Namespace(
+        query="Summarize my documents",
+        report_type="detailed_report",
+        tone="objective",
+        encoding="utf-8",
+        query_domains="",
+        report_source="local",
+        no_pdf=True,
+        no_docx=True,
+    )
+
+    await cli_module.main(args)
+
+    assert captured_kwargs["report_source"] == "local"


### PR DESCRIPTION
## Summary

Forward the CLI's selected `--report_source` to `DetailedReport` instead of
replacing it with the unsupported value `"web_search"`.

## Problem

The CLI accepts `web`, `local`, `hybrid`, `azure`, and other source values, but
the `detailed_report` branch discards that selection:

```python
report_source="web_search"
```

`ResearchConductor` only handles values from `ReportSource` (`"web"`,
`"local"`, `"hybrid"`, etc.). As a result, detailed CLI reports cannot honor
`--report_source local`, and the injected `"web_search"` value does not match a
supported source branch.

## Changes

- Pass `args.report_source` to `DetailedReport`.
- Add an isolated regression test proving that `--report_source local` reaches
  the detailed report unchanged.

## Verification

Before the change:

```text
E       AssertionError: assert 'web_search' == 'local'
```

After the change:

```text
tests/test_cli_detailed_report_source.py .  1 passed
```

The current `main` branch has an unrelated import-time typing failure in
`actions/query_processing.py` (#1981). The local test command supplied those
missing names process-locally; this PR does not modify that module or duplicate
the existing fixes for #1981.

## Impact

- **Breaking change:** No
- **Affected area:** CLI detailed reports only
- **Other report types:** Unchanged
- **Network/API calls in the test:** None

## Checklist

- [x] The change is limited to report-source propagation.
- [x] The regression test fails before and passes after the fix.
- [x] Open PR titles, bodies, and changed files were checked for duplicates.
- [x] The commit author uses the verified GitHub noreply address.

## Re-verification (2026-08-11)

Re-audited against `main` at `5d84d2f` through `cli.main()`. With `--report_source local`, `main` passes the unsupported hard-coded value `web_search` to `DetailedReport`; this branch forwards `local` unchanged and its regression test passes. The existing implementation required no further code changes.