### PR TITLE
Document and scraper robustness: 6 verified fixes

### DIFF
--- a/gpt_researcher/document/azure_document_loader.py
+++ b/gpt_researcher/document/azure_document_loader.py
@@ -1,6 +1,8 @@
-from azure.storage.blob import BlobServiceClient
+import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
+
+from azure.storage.blob import BlobServiceClient
 
 
 class AzureDocumentLoader:
@@ -13,14 +15,21 @@ class AzureDocumentLoader:
         temp_dir = Path(tempfile.mkdtemp()).resolve()
         blobs = self.container.list_blobs()
         file_paths = []
-        for blob in blobs:
-            blob_client = self.container.get_blob_client(blob.name)
-            local_path = self._get_blob_path(temp_dir, blob.name)
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(local_path, "wb") as f:
-                blob_data = blob_client.download_blob()
-                f.write(blob_data.readall())
-            file_paths.append(str(local_path))
+        try:
+            for blob in blobs:
+                blob_client = self.container.get_blob_client(blob.name)
+                local_path = self._get_blob_path(temp_dir, blob.name)
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(local_path, "wb") as f:
+                    blob_data = blob_client.download_blob()
+                    f.write(blob_data.readall())
+                file_paths.append(str(local_path))
+        except BaseException:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            raise
+
+        if not file_paths:
+            shutil.rmtree(temp_dir, ignore_errors=True)
         return file_paths  # Pass to existing DocumentLoader
 
     @staticmethod

--- a/gpt_researcher/document/document.py
+++ b/gpt_researcher/document/document.py
@@ -80,7 +80,7 @@ class DocumentLoader:
             loader = loader_dict.get(file_extension, None)
             if loader:
                 try:
-                    ret_data = loader.load()
+                    ret_data = await asyncio.to_thread(loader.load)
                 except Exception as e:
                     print(f"Failed to load HTML document : {file_path}")
                     print(e)

--- a/gpt_researcher/document/langchain_document.py
+++ b/gpt_researcher/document/langchain_document.py
@@ -15,10 +15,13 @@ class LangChainDocumentLoader:
     async def load(self, metadata_source_index="title") -> List[Dict[str, str]]:
         docs = []
         for document in self.documents:
+            source = document.metadata.get(
+                metadata_source_index
+            ) or document.metadata.get("source", "")
             docs.append(
                 {
                     "raw_content": document.page_content,
-                    "url": document.metadata.get(metadata_source_index, ""),
+                    "url": source,
                 }
             )
         return docs

--- a/gpt_researcher/document/online_document.py
+++ b/gpt_researcher/document/online_document.py
@@ -1,6 +1,8 @@
 import os
 import aiohttp
 import tempfile
+from urllib.parse import urlparse
+
 from langchain_community.document_loaders import (
     PyMuPDFLoader,
     TextLoader,
@@ -90,6 +92,6 @@ class OnlineDocumentLoader:
     def _get_extension(url: str) -> str:
         # Lower-case the extension so loader lookup (whose keys are lower-case,
         # e.g. "pdf"/"docx") matches URLs that use upper-case extensions like
-        # "report.PDF" or "doc.DOCX". The leading "?" split drops query strings
-        # (signed CDN/S3 URLs) before extracting the suffix.
-        return os.path.splitext(url.split("?")[0])[1].lower()
+        # "report.PDF" or "doc.DOCX". Parse the URL path so signed query
+        # strings and fragments such as "#page=2" do not pollute the suffix.
+        return os.path.splitext(urlparse(url).path)[1].lower()

--- a/gpt_researcher/document/online_document.py
+++ b/gpt_researcher/document/online_document.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import aiohttp
 import tempfile
@@ -78,7 +79,7 @@ class OnlineDocumentLoader:
 
             loader = loader_dict.get(file_extension, None)
             if loader:
-                ret_data = loader.load()
+                ret_data = await asyncio.to_thread(loader.load)
 
         except Exception as e:
             print(f"Failed to load document : {file_path}")

--- a/gpt_researcher/scraper/browser/browser.py
+++ b/gpt_researcher/scraper/browser/browser.py
@@ -70,7 +70,10 @@ class BrowserScraper:
             return "", [], ""
         finally:
             if self.driver:
-                self.driver.quit()
+                try:
+                    self.driver.quit()
+                except Exception as e:
+                    print(f"Failed to close browser driver: {str(e)}")
             self._cleanup_cookie_file()
 
     def _import_selenium(self):

--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -41,32 +41,37 @@ class PyMuPDFScraper:
         """
         try:
             if self.is_url():
+                response = None
+                temp_filename = None
                 try:
-                    response = requests.get(self.link, timeout=(5, 30), stream=True)
-                    response.raise_for_status()
-                except requests.exceptions.SSLError:
-                    import logging
-                    logging.getLogger(__name__).warning(
-                        f"SSL verification failed for {self.link}, retrying without verification"
-                    )
-                    response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
-                    response.raise_for_status()
+                    try:
+                        response = requests.get(self.link, timeout=(5, 30), stream=True)
+                        response.raise_for_status()
+                    except requests.exceptions.SSLError:
+                        import logging
+                        if response is not None:
+                            response.close()
+                        logging.getLogger(__name__).warning(
+                            f"SSL verification failed for {self.link}, retrying without verification"
+                        )
+                        response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
+                        response.raise_for_status()
 
-                with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
-                    temp_filename = temp_file.name  # Get the temporary file name
-                    for chunk in response.iter_content(chunk_size=8192):
-                        temp_file.write(chunk)  # Write the downloaded content to the temporary file
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+                        temp_filename = temp_file.name  # Get the temporary file name
+                        for chunk in response.iter_content(chunk_size=8192):
+                            temp_file.write(chunk)  # Write the downloaded content to the temporary file
 
-                # Always clean up the downloaded temp file, even if loading fails
-                # (PyMuPDFLoader.load() can raise on a malformed/partial PDF).
-                try:
                     loader = PyMuPDFLoader(temp_filename)
                     doc = loader.load()
                 finally:
-                    try:
-                        os.remove(temp_filename)
-                    except OSError:
-                        pass
+                    if response is not None:
+                        response.close()
+                    if temp_filename is not None:
+                        try:
+                            os.remove(temp_filename)
+                        except OSError:
+                            pass
             else:
                 loader = PyMuPDFLoader(self.link)
                 doc = loader.load()

--- a/tests/test_azure_document_loader.py
+++ b/tests/test_azure_document_loader.py
@@ -1,8 +1,10 @@
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 class _FakeBlobServiceClient:
@@ -79,8 +81,37 @@ class TestAzureDocumentLoader(unittest.IsolatedAsyncioTestCase):
         loader = AzureDocumentLoader.__new__(AzureDocumentLoader)
         loader.container = _Container({"../escape.txt": b"nope"})
 
-        with self.assertRaises(ValueError):
-            await loader.load()
+        with tempfile.TemporaryDirectory() as parent:
+            temp_dir = Path(parent) / "azure-download"
+            temp_dir.mkdir()
+
+            with patch.object(
+                azure_document_loader.tempfile,
+                "mkdtemp",
+                return_value=str(temp_dir),
+            ):
+                with self.assertRaises(ValueError):
+                    await loader.load()
+
+            self.assertFalse(temp_dir.exists())
+
+    async def test_load_removes_unused_directory_for_empty_container(self):
+        loader = AzureDocumentLoader.__new__(AzureDocumentLoader)
+        loader.container = _Container({})
+
+        with tempfile.TemporaryDirectory() as parent:
+            temp_dir = Path(parent) / "azure-download"
+            temp_dir.mkdir()
+
+            with patch.object(
+                azure_document_loader.tempfile,
+                "mkdtemp",
+                return_value=str(temp_dir),
+            ):
+                file_paths = await loader.load()
+
+            self.assertEqual(file_paths, [])
+            self.assertFalse(temp_dir.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_browser_teardown_cleanup.py
+++ b/tests/test_browser_teardown_cleanup.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from gpt_researcher.scraper.browser.browser import BrowserScraper
+
+
+class _FailingDriver:
+    def quit(self):
+        raise RuntimeError("browser already disconnected")
+
+
+def test_quit_failure_does_not_mask_result_or_skip_cookie_cleanup():
+    scraper = BrowserScraper.__new__(BrowserScraper)
+    scraper.url = "https://example.com"
+    scraper.driver = _FailingDriver()
+    scraper.setup_driver = Mock()
+    scraper._visit_google_and_save_cookies = Mock()
+    scraper._load_saved_cookies = Mock()
+    scraper._add_header = Mock()
+    scraper.scrape_text_with_selenium = Mock(
+        return_value=("page content", [], "Page title")
+    )
+    scraper._cleanup_cookie_file = Mock()
+
+    result = scraper.scrape()
+
+    assert result == ("page content", [], "Page title")
+    scraper._cleanup_cookie_file.assert_called_once_with()

--- a/tests/test_document_loader_offload.py
+++ b/tests/test_document_loader_offload.py
@@ -1,0 +1,103 @@
+import asyncio
+import importlib.util
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+document_module = _load_module(
+    "document_loader_offload_testmod",
+    "gpt_researcher/document/document.py",
+)
+online_module = _load_module(
+    "online_document_loader_offload_testmod",
+    "gpt_researcher/document/online_document.py",
+)
+
+
+class _Page:
+    page_content = "content"
+    metadata = {"source": "source.txt"}
+
+
+class _SlowLoader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def load(self):
+        time.sleep(0.05)
+        return [_Page()]
+
+
+LOADER_NAMES = (
+    "PyMuPDFLoader",
+    "TextLoader",
+    "UnstructuredCSVLoader",
+    "UnstructuredExcelLoader",
+    "UnstructuredMarkdownLoader",
+    "UnstructuredPowerPointLoader",
+    "UnstructuredWordDocumentLoader",
+)
+
+
+async def _heartbeat_completes_while_loading(load):
+    heartbeat_ran = False
+
+    async def heartbeat():
+        nonlocal heartbeat_ran
+        await asyncio.sleep(0.01)
+        heartbeat_ran = True
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await load()
+    completed_during_load = heartbeat_ran
+    await heartbeat_task
+    return completed_during_load
+
+
+class DocumentLoaderOffloadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_local_document_parsing_keeps_event_loop_responsive(self):
+        replacements = {name: _SlowLoader for name in LOADER_NAMES}
+        replacements["BSHTMLLoader"] = _SlowLoader
+        loader = document_module.DocumentLoader.__new__(
+            document_module.DocumentLoader
+        )
+
+        with patch.multiple(document_module, **replacements):
+            responsive = await _heartbeat_completes_while_loading(
+                lambda: loader._load_document("source.txt", "txt")
+            )
+
+        self.assertTrue(responsive)
+
+    async def test_online_document_parsing_keeps_event_loop_responsive(self):
+        replacements = {name: _SlowLoader for name in LOADER_NAMES}
+        loader = online_module.OnlineDocumentLoader.__new__(
+            online_module.OnlineDocumentLoader
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as file:
+            path = file.name
+
+        with patch.multiple(online_module, **replacements):
+            responsive = await _heartbeat_completes_while_loading(
+                lambda: loader._load_document(path, "txt")
+            )
+
+        self.assertTrue(responsive)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_langchain_document_loader.py
+++ b/tests/test_langchain_document_loader.py
@@ -1,0 +1,48 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+from langchain_core.documents import Document
+
+module_path = (
+    Path(__file__).resolve().parents[1]
+    / "gpt_researcher"
+    / "document"
+    / "langchain_document.py"
+)
+spec = importlib.util.spec_from_file_location("langchain_document", module_path)
+langchain_document = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(langchain_document)
+LangChainDocumentLoader = langchain_document.LangChainDocumentLoader
+
+
+class TestLangChainDocumentLoader(unittest.IsolatedAsyncioTestCase):
+    async def test_load_falls_back_to_standard_source_metadata(self):
+        document = Document(
+            page_content="Document content",
+            metadata={"source": "document.pdf"},
+        )
+
+        loaded_documents = await LangChainDocumentLoader([document]).load()
+
+        self.assertEqual(
+            loaded_documents,
+            [{"raw_content": "Document content", "url": "document.pdf"}],
+        )
+
+    async def test_load_prefers_requested_metadata_field(self):
+        document = Document(
+            page_content="Document content",
+            metadata={"title": "Document title", "source": "document.pdf"},
+        )
+
+        loaded_documents = await LangChainDocumentLoader([document]).load()
+
+        self.assertEqual(
+            loaded_documents,
+            [{"raw_content": "Document content", "url": "Document title"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_online_document_extension.py
+++ b/tests/test_online_document_extension.py
@@ -20,5 +20,15 @@ def test_get_extension_strips_query_string():
     assert OnlineDocumentLoader._get_extension("https://x.com/a.pdf") == ".pdf"
 
 
+def test_get_extension_strips_url_fragment():
+    assert OnlineDocumentLoader._get_extension("https://x.com/report.pdf#page=2") == ".pdf"
+    assert (
+        OnlineDocumentLoader._get_extension(
+            "https://x.com/report.PDF?sig=abc#page=2"
+        )
+        == ".pdf"
+    )
+
+
 def test_get_extension_no_extension():
     assert OnlineDocumentLoader._get_extension("https://x.com/page") == ""

--- a/tests/test_pymupdf_tempfile_cleanup.py
+++ b/tests/test_pymupdf_tempfile_cleanup.py
@@ -17,11 +17,23 @@ from gpt_researcher.scraper.pymupdf.pymupdf import PyMuPDFScraper
 
 
 class _FakeResponse:
+    def __init__(self):
+        self.closed = False
+
     def raise_for_status(self):
         return None
 
     def iter_content(self, chunk_size=8192):
         yield b"%PDF-1.4 not-a-real-pdf"
+
+    def close(self):
+        self.closed = True
+
+
+class _InterruptedResponse(_FakeResponse):
+    def iter_content(self, chunk_size=8192):
+        yield b"%PDF-1.4 partial"
+        raise RuntimeError("connection interrupted")
 
 
 def _temp_pdfs() -> set:
@@ -33,12 +45,13 @@ def test_tempfile_removed_when_loader_raises():
 
     before = _temp_pdfs()
 
-    with patch(
-        "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
-        return_value=_FakeResponse(),
-    ), patch(
-        "gpt_researcher.scraper.pymupdf.pymupdf.PyMuPDFLoader"
-    ) as mock_loader:
+    with (
+        patch(
+            "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
+            return_value=_FakeResponse(),
+        ),
+        patch("gpt_researcher.scraper.pymupdf.pymupdf.PyMuPDFLoader") as mock_loader,
+    ):
         mock_loader.return_value.load.side_effect = RuntimeError("corrupt PDF")
 
         content, images, title = scraper.scrape()
@@ -46,5 +59,22 @@ def test_tempfile_removed_when_loader_raises():
     # Broad except still yields the empty-result contract...
     assert (content, images, title) == ("", [], "")
     # ...but no new *.pdf temp file is left behind.
+    leaked = _temp_pdfs() - before
+    assert not leaked, f"PyMuPDFScraper leaked temp file(s): {leaked}"
+
+
+def test_response_and_tempfile_cleaned_when_download_is_interrupted():
+    scraper = PyMuPDFScraper("https://example.com/interrupted.pdf")
+    response = _InterruptedResponse()
+    before = _temp_pdfs()
+
+    with patch(
+        "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
+        return_value=response,
+    ):
+        result = scraper.scrape()
+
+    assert result == ("", [], "")
+    assert response.closed
     leaked = _temp_pdfs() - before
     assert not leaked, f"PyMuPDFScraper leaked temp file(s): {leaked}"


### PR DESCRIPTION
## Summary

Consolidates six document-loading and scraper robustness fixes into one tested
batch. Each behavior remains an independent commit.

Includes the original #2024 scope and supersedes #2028, #2032, #2037, #2038,
and #2044.

## Included fixes

- Strip URL fragments before online document extension detection.
- Remove unused Azure download directories on failure or empty results.
- Preserve standard LangChain `metadata["source"]` values.
- Close streamed PDF responses and remove interrupted temporary downloads.
- Isolate Selenium teardown failures and preserve cookie cleanup.
- Move synchronous local and online parser work off the asyncio event loop.

## Verification

- 29 focused and adjacent tests passed.
- Ruff `F821`/`ASYNC251` checks passed.
- Python 3.11 compile checks passed.
- `git diff --check` passed.

The test process supplies `Any`/`List` process-locally for the existing import
regression tracked by #1981. This batch does not modify that file.

## Impact

- No intentional breaking changes.
- Loader selection, document metadata precedence, successful Azure downloads,
  and scraper return contracts remain unchanged.
- Focused tests do not require Azure, Selenium, external HTTP, or LLM access.

AI-assisted consolidation; every included behavior was revalidated locally.
