### PR TITLE
Backend and multi-agent hardening: 8 verified fixes

### DIFF
--- a/backend/chat/chat.py
+++ b/backend/chat/chat.py
@@ -113,6 +113,9 @@ class ChatAgentWithMemory:
 
     def quick_search(self, query):
         """Perform a web search for current information using Tavily"""
+        if not hasattr(self, "search_metadata_by_query"):
+            self.search_metadata_by_query = {}
+
         try:
             # Check if Tavily client is available
             if self.tavily_client is None:
@@ -122,6 +125,7 @@ class ChatAgentWithMemory:
                     "sources": [],
                     "error": "Web search is disabled - TAVILY_API_KEY not configured"
                 }
+                self.search_metadata_by_query[query] = self.search_metadata
                 return {
                     "error": "Web search is disabled - TAVILY_API_KEY not configured",
                     "results": []
@@ -140,10 +144,17 @@ class ChatAgentWithMemory:
                     for result in results.get("results", [])
                 ]
             }
+            self.search_metadata_by_query[query] = self.search_metadata
             
             return results
         except Exception as e:
             logger.error(f"Error performing web search: {str(e)}", exc_info=True)
+            self.search_metadata = {
+                "query": query,
+                "sources": [],
+                "error": str(e),
+            }
+            self.search_metadata_by_query[query] = self.search_metadata
             return {
                 "error": str(e),
                 "results": []
@@ -152,6 +163,8 @@ class ChatAgentWithMemory:
 
     async def process_chat_completion(self, messages: List[Dict[str, str]]):
         """Process chat completion using configured LLM provider with tool calling support"""
+        self.search_metadata_by_query = {}
+
         # Create a search tool using the utility function
         search_tool = create_search_tool(self.quick_search)
         
@@ -170,15 +183,11 @@ class ChatAgentWithMemory:
             if metadata.get("tool") == "search_tool":
                 # Extract query from args
                 query = metadata.get("args", {}).get("query", "")
-                
-                # Trigger search again to get metadata (the search was already executed by LangChain)
-                if query:
-                    self.quick_search(query)  # This populates self.search_metadata
-                    
+
                 processed_metadata.append({
                     "tool": "quick_search",
                     "query": query,
-                    "search_metadata": self.search_metadata
+                    "search_metadata": self.search_metadata_by_query.get(query),
                 })
         
         return response, processed_metadata

--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -300,10 +300,14 @@ async def write_report(research_request: ResearchRequest, research_id: str = Non
         return_researcher=True
     )
 
-    docx_path = await write_md_to_word(report_information[0], research_id)
-    pdf_path = await write_md_to_pdf(report_information[0], research_id)
-    if research_request.report_type != "multi_agents":
+    if research_request.report_type == "multi_agents":
+        report = report_information
+    else:
         report, researcher = report_information
+
+    docx_path = await write_md_to_word(report, research_id)
+    pdf_path = await write_md_to_pdf(report, research_id)
+    if research_request.report_type != "multi_agents":
         response = {
             "research_id": research_id,
             "research_information": {
@@ -318,7 +322,7 @@ async def write_report(research_request: ResearchRequest, research_id: str = Non
             "pdf_path": pdf_path
         }
     else:
-        response = { "research_id": research_id, "report": "", "docx_path": docx_path, "pdf_path": pdf_path }
+        response = { "research_id": research_id, "report": report, "docx_path": docx_path, "pdf_path": pdf_path }
 
     return response
 

--- a/backend/server/report_store.py
+++ b/backend/server/report_store.py
@@ -9,25 +9,31 @@ class ReportStore:
         self._path = path
         self._lock = asyncio.Lock()
 
-    async def _ensure_parent_dir(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-
     async def _read_all_unlocked(self) -> Dict[str, Dict[str, Any]]:
-        if not self._path.exists():
+        def read_all() -> Dict[str, Dict[str, Any]]:
+            if not self._path.exists():
+                return {}
+            try:
+                data = json.loads(self._path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return data  # type: ignore[return-value]
+            except Exception:
+                return {}
             return {}
-        try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                return data  # type: ignore[return-value]
-        except Exception:
-            return {}
-        return {}
+
+        return await asyncio.to_thread(read_all)
 
     async def _write_all_unlocked(self, data: Dict[str, Dict[str, Any]]) -> None:
-        await self._ensure_parent_dir()
-        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
-        tmp_path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-        tmp_path.replace(self._path)
+        def write_all() -> None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp_path.write_text(
+                json.dumps(data, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp_path.replace(self._path)
+
+        await asyncio.to_thread(write_all)
 
     async def list_reports(self, report_ids: List[str] | None = None) -> List[Dict[str, Any]]:
         async with self._lock:

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -170,6 +170,7 @@ async def handle_start_command(websocket, data: str, manager):
         mcp_strategy,
         mcp_configs,
         max_search_results,
+        logs_handler=logs_handler,
     )
     report = str(report)
     file_paths = await generate_report_files(report, sanitized_filename)

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -9,6 +9,7 @@ from typing import Awaitable, Dict, List, Any
 from fastapi.responses import JSONResponse, FileResponse
 from gpt_researcher.document.document import DocumentLoader
 from gpt_researcher import GPTResearcher
+from gpt_researcher.actions import stream_output
 from utils import write_md_to_pdf, write_md_to_word, write_text_to_md
 from pathlib import Path
 from datetime import datetime

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -294,6 +294,7 @@ def update_environment_variables(config: Dict[str, str]):
 
 
 async def handle_file_upload(file, DOC_PATH: str) -> Dict[str, str]:
+    os.makedirs(DOC_PATH, exist_ok=True)
     file_path = os.path.join(DOC_PATH, os.path.basename(file.filename))
     with open(file_path, "wb") as buffer:
         shutil.copyfileobj(file.file, buffer)

--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from fastapi import HTTPException
 import logging
 import hashlib
+import uuid
 
 from .multi_agent_runner import run_multi_agent_task
 
@@ -36,7 +37,7 @@ class CustomLogsHandler:
     def __init__(self, websocket, task: str):
         self.logs = []
         self.websocket = websocket
-        sanitized_filename = sanitize_filename(f"task_{int(time.time())}_{task}")
+        sanitized_filename = sanitize_filename(f"task_{uuid.uuid4().hex}_{task}")
         self.log_file = os.path.join("outputs", f"{sanitized_filename}.json")
         self.timestamp = datetime.now().isoformat()
         # Initialize log file with metadata

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -98,7 +98,7 @@ class WebSocketManager:
             except Exception:
                 pass  # If this fails too, there's nothing more we can do
 
-    async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None):
+    async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None, logs_handler=None):
         """Start streaming the output."""
         tone = Tone[tone]
         # add customized JSON config file path here
@@ -109,14 +109,15 @@ class WebSocketManager:
             task, report_type, report_source, source_urls, document_urls, tone, websocket, 
             headers=headers, query_domains=query_domains, config_path=config_path,
             mcp_enabled=mcp_enabled, mcp_strategy=mcp_strategy, mcp_configs=mcp_configs,
-            max_search_results=max_search_results
+            max_search_results=max_search_results, logs_handler=logs_handler
         )
         return report
 
-async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False, mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None):
+async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False, mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None, logs_handler=None):
     """Run the agent."""    
-    # Create logs handler for this research task
-    logs_handler = CustomLogsHandler(websocket, task)
+    # Reuse the WebSocket command handler so its initialized query is not
+    # overwritten by a second handler targeting the same log file.
+    logs_handler = logs_handler or CustomLogsHandler(websocket, task)
 
     # Log MCP initialization. Retriever and strategy are configured per-request
     # inside GPTResearcher via mcp_configs/mcp_strategy params — no os.environ

--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -57,8 +57,8 @@ async def write_md_to_pdf(text: str, path: str) -> str:
         # Moved imports to inner function to avoid known import errors with gobject-2.0
         from md2pdf.core import md2pdf
         md2pdf(file_path,
-               md_content=text,
-               css_file_path=css_path,
+               raw=text,
+               css=css_path,
                base_url=None)
         print(f"Report written to {file_path}")
     except Exception as e:

--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -1,8 +1,10 @@
-import aiofiles
+import inspect
+import os
 import urllib
 import uuid
+
+import aiofiles
 import mistune
-import os
 
 async def write_to_file(filename: str, text: str) -> None:
     """Asynchronously write text to a file in UTF-8 encoding.
@@ -56,10 +58,20 @@ async def write_md_to_pdf(text: str, path: str) -> str:
         
         # Moved imports to inner function to avoid known import errors with gobject-2.0
         from md2pdf.core import md2pdf
-        md2pdf(file_path,
-               raw=text,
-               css=css_path,
-               base_url=None)
+        if "raw" in inspect.signature(md2pdf).parameters:
+            md2pdf(
+                file_path,
+                raw=text,
+                css=css_path,
+                base_url=None,
+            )
+        else:
+            md2pdf(
+                file_path,
+                md_content=text,
+                css_file_path=css_path,
+                base_url=None,
+            )
         print(f"Report written to {file_path}")
     except Exception as e:
         print(f"Error in converting Markdown to PDF: {e}")

--- a/tests/backend/test_chat_search_metadata.py
+++ b/tests/backend/test_chat_search_metadata.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+import pytest
+
+from backend.chat import chat as chat_module
+
+
+@pytest.mark.asyncio
+async def test_tool_search_reuses_metadata_without_second_api_call(monkeypatch):
+    calls = []
+
+    class FakeTavilyClient:
+        def search(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "results": [
+                    {
+                        "title": "Current result",
+                        "url": "https://example.com/current",
+                        "content": "Current information",
+                    }
+                ]
+            }
+
+    async def fake_chat_completion_with_tools(**kwargs):
+        result = kwargs["tools"][0].invoke({"query": "latest update"})
+        assert "Current result" in result
+        return "answer", [
+            {
+                "tool": "search_tool",
+                "args": {"query": "latest update"},
+                "call_id": "call-1",
+            }
+        ]
+
+    agent = chat_module.ChatAgentWithMemory.__new__(
+        chat_module.ChatAgentWithMemory
+    )
+    agent.tavily_client = FakeTavilyClient()
+    agent.search_metadata = None
+    agent.config = SimpleNamespace(
+        smart_llm_model="model",
+        smart_llm_provider="provider",
+        llm_kwargs={},
+    )
+
+    monkeypatch.setattr(
+        chat_module,
+        "create_chat_completion_with_tools",
+        fake_chat_completion_with_tools,
+    )
+
+    response, metadata = await agent.process_chat_completion([])
+
+    assert response == "answer"
+    assert calls == [{"query": "latest update", "max_results": 5}]
+    assert metadata == [
+        {
+            "tool": "quick_search",
+            "query": "latest update",
+            "search_metadata": {
+                "query": "latest update",
+                "sources": [
+                    {
+                        "title": "Current result",
+                        "url": "https://example.com/current",
+                        "content": "Current information",
+                    }
+                ],
+            },
+        }
+    ]
+
+
+def test_unavailable_search_records_error_metadata():
+    agent = chat_module.ChatAgentWithMemory.__new__(
+        chat_module.ChatAgentWithMemory
+    )
+    agent.tavily_client = None
+    agent.search_metadata = None
+
+    result = agent.quick_search("latest update")
+
+    assert result["results"] == []
+    assert agent.search_metadata_by_query["latest update"] == {
+        "query": "latest update",
+        "sources": [],
+        "error": "Web search is disabled - TAVILY_API_KEY not configured",
+    }

--- a/tests/backend/test_file_upload_directory.py
+++ b/tests/backend/test_file_upload_directory.py
@@ -1,0 +1,71 @@
+import builtins
+import importlib
+import io
+import sys
+import tempfile
+import types
+import typing
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _load_server_utils():
+    utils_module = types.ModuleType("utils")
+    utils_module.write_md_to_pdf = lambda *args, **kwargs: None
+    utils_module.write_md_to_word = lambda *args, **kwargs: None
+    utils_module.write_text_to_md = lambda *args, **kwargs: None
+
+    original_any = getattr(builtins, "Any", None)
+    original_list = getattr(builtins, "List", None)
+    builtins.Any = typing.Any
+    builtins.List = typing.List
+    try:
+        with patch.dict(sys.modules, {"utils": utils_module}):
+            return importlib.import_module("backend.server.server_utils")
+    finally:
+        if original_any is None:
+            del builtins.Any
+        else:
+            builtins.Any = original_any
+        if original_list is None:
+            del builtins.List
+        else:
+            builtins.List = original_list
+
+
+server_utils = _load_server_utils()
+
+
+class _DocumentLoader:
+    def __init__(self, path):
+        self.path = path
+
+    async def load(self):
+        return []
+
+
+class FileUploadDirectoryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_upload_creates_document_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            document_dir = Path(temp_dir) / "documents"
+            upload = SimpleNamespace(
+                filename="notes.txt",
+                file=io.BytesIO(b"uploaded content"),
+            )
+
+            with patch.object(server_utils, "DocumentLoader", _DocumentLoader):
+                result = await server_utils.handle_file_upload(
+                    upload,
+                    str(document_dir),
+                )
+
+            uploaded_file = document_dir / "notes.txt"
+            self.assertTrue(document_dir.is_dir())
+            self.assertEqual(uploaded_file.read_bytes(), b"uploaded content")
+            self.assertEqual(result["path"], str(uploaded_file))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backend/test_file_upload_directory.py
+++ b/tests/backend/test_file_upload_directory.py
@@ -1,10 +1,8 @@
-import builtins
-import importlib
+import importlib.util
 import io
 import sys
 import tempfile
 import types
-import typing
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,27 +10,46 @@ from unittest.mock import patch
 
 
 def _load_server_utils():
+    gpt_researcher = types.ModuleType("gpt_researcher")
+    gpt_researcher.__path__ = []
+    gpt_researcher.GPTResearcher = object
+
+    document_package = types.ModuleType("gpt_researcher.document")
+    document_package.__path__ = []
+    document_module = types.ModuleType("gpt_researcher.document.document")
+    document_module.DocumentLoader = object
+
     utils_module = types.ModuleType("utils")
     utils_module.write_md_to_pdf = lambda *args, **kwargs: None
     utils_module.write_md_to_word = lambda *args, **kwargs: None
     utils_module.write_text_to_md = lambda *args, **kwargs: None
 
-    original_any = getattr(builtins, "Any", None)
-    original_list = getattr(builtins, "List", None)
-    builtins.Any = typing.Any
-    builtins.List = typing.List
-    try:
-        with patch.dict(sys.modules, {"utils": utils_module}):
-            return importlib.import_module("backend.server.server_utils")
-    finally:
-        if original_any is None:
-            del builtins.Any
-        else:
-            builtins.Any = original_any
-        if original_list is None:
-            del builtins.List
-        else:
-            builtins.List = original_list
+    runner_module = types.ModuleType("backend.server.multi_agent_runner")
+    runner_module.run_multi_agent_task = None
+
+    chat_package = types.ModuleType("chat")
+    chat_package.__path__ = []
+    chat_module = types.ModuleType("chat.chat")
+    chat_module.ChatAgentWithMemory = object
+
+    module_path = Path(__file__).resolve().parents[2] / "backend/server/server_utils.py"
+    spec = importlib.util.spec_from_file_location(
+        "backend.server._server_utils_upload_test",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    dependencies = {
+        "gpt_researcher": gpt_researcher,
+        "gpt_researcher.document": document_package,
+        "gpt_researcher.document.document": document_module,
+        "utils": utils_module,
+        "backend.server.multi_agent_runner": runner_module,
+        "chat": chat_package,
+        "chat.chat": chat_module,
+    }
+    with patch.dict(sys.modules, dependencies):
+        spec.loader.exec_module(module)
+    return module
 
 
 server_utils = _load_server_utils()

--- a/tests/backend/test_log_file_uniqueness.py
+++ b/tests/backend/test_log_file_uniqueness.py
@@ -1,0 +1,58 @@
+import builtins
+import importlib
+import os
+import sys
+import tempfile
+import types
+import typing
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+def _load_server_utils():
+    utils_module = types.ModuleType("utils")
+    utils_module.write_md_to_pdf = lambda *args, **kwargs: None
+    utils_module.write_md_to_word = lambda *args, **kwargs: None
+    utils_module.write_text_to_md = lambda *args, **kwargs: None
+
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+        patch.dict(sys.modules, {"utils": utils_module}),
+    ):
+        return importlib.import_module("backend.server.server_utils")
+
+
+server_utils = _load_server_utils()
+
+
+class LogFileUniquenessTests(unittest.TestCase):
+    def test_same_task_in_same_second_uses_distinct_log_files(self):
+        fake_uuid = SimpleNamespace(
+            uuid4=Mock(
+                side_effect=[
+                    SimpleNamespace(hex="a" * 32),
+                    SimpleNamespace(hex="b" * 32),
+                ]
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous_cwd = os.getcwd()
+            os.chdir(temp_dir)
+            try:
+                with (
+                    patch.object(server_utils.time, "time", return_value=1000),
+                    patch.object(server_utils, "uuid", fake_uuid, create=True),
+                ):
+                    first = server_utils.CustomLogsHandler(None, "same task")
+                    second = server_utils.CustomLogsHandler(None, "same task")
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertNotEqual(first.log_file, second.log_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backend/test_multi_agent_report_export.py
+++ b/tests/backend/test_multi_agent_report_export.py
@@ -1,0 +1,86 @@
+import pytest
+
+from backend.server import app as app_module
+
+
+@pytest.mark.asyncio
+async def test_multi_agent_report_exports_and_returns_full_report(monkeypatch):
+    exported_reports = []
+
+    async def fake_run_agent(**kwargs):
+        return "complete multi-agent report"
+
+    async def fake_write_md_to_word(report, research_id):
+        exported_reports.append(("docx", report, research_id))
+        return "outputs/report.docx"
+
+    async def fake_write_md_to_pdf(report, research_id):
+        exported_reports.append(("pdf", report, research_id))
+        return "outputs/report.pdf"
+
+    monkeypatch.setattr(app_module, "run_agent", fake_run_agent)
+    monkeypatch.setattr(app_module, "write_md_to_word", fake_write_md_to_word)
+    monkeypatch.setattr(app_module, "write_md_to_pdf", fake_write_md_to_pdf)
+
+    request = app_module.ResearchRequest(
+        task="test",
+        report_type="multi_agents",
+        report_source="web",
+        tone="Objective",
+        repo_name="",
+        branch_name="",
+        generate_in_background=False,
+    )
+
+    response = await app_module.write_report(request, research_id="report-id")
+
+    assert exported_reports == [
+        ("docx", "complete multi-agent report", "report-id"),
+        ("pdf", "complete multi-agent report", "report-id"),
+    ]
+    assert response["report"] == "complete multi-agent report"
+
+
+@pytest.mark.asyncio
+async def test_standard_report_keeps_research_metadata(monkeypatch):
+    class FakeResearcher:
+        visited_urls = {"https://example.com"}
+
+        def get_source_urls(self):
+            return ["https://example.com"]
+
+        def get_costs(self):
+            return 0.25
+
+        def get_research_images(self):
+            return ["image.png"]
+
+    async def fake_run_agent(**kwargs):
+        return "standard report", FakeResearcher()
+
+    async def fake_export(report, research_id):
+        return f"outputs/{research_id}"
+
+    monkeypatch.setattr(app_module, "run_agent", fake_run_agent)
+    monkeypatch.setattr(app_module, "write_md_to_word", fake_export)
+    monkeypatch.setattr(app_module, "write_md_to_pdf", fake_export)
+
+    request = app_module.ResearchRequest(
+        task="test",
+        report_type="research_report",
+        report_source="web",
+        tone="Objective",
+        repo_name="",
+        branch_name="",
+        generate_in_background=False,
+    )
+
+    response = await app_module.write_report(request, research_id="report-id")
+
+    assert response["report"] == "standard report"
+    assert response["research_information"] == {
+        "source_urls": ["https://example.com"],
+        "research_costs": 0.25,
+        "visited_urls": ["https://example.com"],
+        "research_images": ["image.png"],
+    }

--- a/tests/backend/test_multi_agent_stream_output.py
+++ b/tests/backend/test_multi_agent_stream_output.py
@@ -1,0 +1,56 @@
+import builtins
+import importlib
+import sys
+import types
+import typing
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _load_server_utils():
+    utils_module = types.ModuleType("utils")
+    utils_module.write_md_to_pdf = lambda *args, **kwargs: None
+    utils_module.write_md_to_word = lambda *args, **kwargs: None
+    utils_module.write_text_to_md = lambda *args, **kwargs: None
+
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+        patch.dict(sys.modules, {"utils": utils_module}),
+    ):
+        return importlib.import_module("backend.server.server_utils")
+
+
+server_utils = _load_server_utils()
+
+
+class MultiAgentStreamOutputTests(unittest.IsolatedAsyncioTestCase):
+    async def test_execute_multi_agents_passes_stream_output_callback(self):
+        websocket = object()
+        manager = SimpleNamespace(active_connections=[websocket])
+        received = {}
+
+        async def run_multi_agent_task(query, active_websocket, output_callback):
+            received.update(
+                query=query,
+                websocket=active_websocket,
+                output_callback=output_callback,
+            )
+            return "research report"
+
+        with patch.object(
+            server_utils,
+            "run_multi_agent_task",
+            run_multi_agent_task,
+        ):
+            result = await server_utils.execute_multi_agents(manager)
+
+        self.assertEqual(result, {"report": "research report"})
+        self.assertEqual(received["query"], "Is AI in a hype cycle?")
+        self.assertIs(received["websocket"], websocket)
+        self.assertTrue(callable(received["output_callback"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backend/test_multi_agent_stream_output.py
+++ b/tests/backend/test_multi_agent_stream_output.py
@@ -1,25 +1,61 @@
-import builtins
-import importlib
+import importlib.util
 import sys
 import types
-import typing
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 
+async def expected_stream_output(*args, **kwargs):
+    pass
+
+
 def _load_server_utils():
+    gpt_researcher = types.ModuleType("gpt_researcher")
+    gpt_researcher.__path__ = []
+    gpt_researcher.GPTResearcher = object
+
+    document_package = types.ModuleType("gpt_researcher.document")
+    document_package.__path__ = []
+    document_module = types.ModuleType("gpt_researcher.document.document")
+    document_module.DocumentLoader = object
+
+    actions_module = types.ModuleType("gpt_researcher.actions")
+    actions_module.stream_output = expected_stream_output
+
     utils_module = types.ModuleType("utils")
     utils_module.write_md_to_pdf = lambda *args, **kwargs: None
     utils_module.write_md_to_word = lambda *args, **kwargs: None
     utils_module.write_text_to_md = lambda *args, **kwargs: None
 
-    with (
-        patch.object(builtins, "Any", typing.Any, create=True),
-        patch.object(builtins, "List", typing.List, create=True),
-        patch.dict(sys.modules, {"utils": utils_module}),
-    ):
-        return importlib.import_module("backend.server.server_utils")
+    runner_module = types.ModuleType("backend.server.multi_agent_runner")
+    runner_module.run_multi_agent_task = None
+
+    chat_package = types.ModuleType("chat")
+    chat_package.__path__ = []
+    chat_module = types.ModuleType("chat.chat")
+    chat_module.ChatAgentWithMemory = object
+
+    module_path = Path(__file__).resolve().parents[2] / "backend/server/server_utils.py"
+    spec = importlib.util.spec_from_file_location(
+        "backend.server._server_utils_stream_test",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    dependencies = {
+        "gpt_researcher": gpt_researcher,
+        "gpt_researcher.document": document_package,
+        "gpt_researcher.document.document": document_module,
+        "gpt_researcher.actions": actions_module,
+        "utils": utils_module,
+        "backend.server.multi_agent_runner": runner_module,
+        "chat": chat_package,
+        "chat.chat": chat_module,
+    }
+    with patch.dict(sys.modules, dependencies):
+        spec.loader.exec_module(module)
+    return module
 
 
 server_utils = _load_server_utils()
@@ -49,7 +85,8 @@ class MultiAgentStreamOutputTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {"report": "research report"})
         self.assertEqual(received["query"], "Is AI in a hype cycle?")
         self.assertIs(received["websocket"], websocket)
-        self.assertTrue(callable(received["output_callback"]))
+        self.assertIs(server_utils.stream_output, expected_stream_output)
+        self.assertIs(received["output_callback"], expected_stream_output)
 
 
 if __name__ == "__main__":

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 from fastapi import WebSocket
+from backend.server import server_utils
 from backend.server.server_utils import CustomLogsHandler
 import os
 import json
@@ -59,3 +60,49 @@ async def test_content_update():
         assert log_data['content']['query'] == "test query"
         assert log_data['content']['sources'] == ["source1", "source2"]
         assert log_data['content']['report'] == "test report"
+
+
+@pytest.mark.asyncio
+async def test_start_command_passes_initialized_logs_handler(
+    tmp_path, monkeypatch
+):
+    mock_websocket = AsyncMock()
+    captured = {}
+
+    class FakeManager:
+        async def start_streaming(self, *args, **kwargs):
+            captured.update(kwargs)
+            return "report"
+
+    async def fake_generate_report_files(report, filename):
+        return {}
+
+    async def fake_send_file_paths(websocket, file_paths):
+        return None
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        server_utils, "generate_report_files", fake_generate_report_files
+    )
+    monkeypatch.setattr(server_utils, "send_file_paths", fake_send_file_paths)
+
+    command = {
+        "task": "test query",
+        "report_type": "research_report",
+        "source_urls": [],
+        "document_urls": [],
+        "tone": "Objective",
+        "report_source": "web",
+    }
+
+    await server_utils.handle_start_command(
+        mock_websocket,
+        f"start {json.dumps(command)}",
+        FakeManager(),
+    )
+
+    logs_handler = captured["logs_handler"]
+    with open(logs_handler.log_file, "r") as file:
+        log_data = json.load(file)
+
+    assert log_data["content"]["query"] == "test query"

--- a/tests/test_multi_agent_pdf_export_api.py
+++ b/tests/test_multi_agent_pdf_export_api.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
     / "multi_agents"
@@ -19,21 +18,44 @@ file_formats = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(file_formats)
 
 
+@pytest.mark.parametrize("api_version", ["legacy", "current"])
 @pytest.mark.asyncio
-async def test_pdf_export_uses_current_md2pdf_api(tmp_path, monkeypatch):
+async def test_pdf_export_supports_md2pdf_api_versions(
+    api_version,
+    tmp_path,
+    monkeypatch,
+):
     captured = {}
 
-    def fake_md2pdf(pdf, raw=None, md=None, css=None, base_url=None):
-        captured.update(
-            {
-                "pdf": pdf,
-                "raw": raw,
-                "md": md,
-                "css": css,
-                "base_url": base_url,
-            }
-        )
-        Path(pdf).write_bytes(b"pdf")
+    if api_version == "current":
+
+        def fake_md2pdf(pdf, raw=None, md=None, css=None, base_url=None):
+            captured.update(
+                pdf=pdf,
+                content=raw,
+                markdown_file=md,
+                css=css,
+                base_url=base_url,
+            )
+            Path(pdf).write_bytes(b"pdf")
+
+    else:
+
+        def fake_md2pdf(
+            pdf_file_path,
+            md_content=None,
+            md_file_path=None,
+            css_file_path=None,
+            base_url=None,
+        ):
+            captured.update(
+                pdf=pdf_file_path,
+                content=md_content,
+                markdown_file=md_file_path,
+                css=css_file_path,
+                base_url=base_url,
+            )
+            Path(pdf_file_path).write_bytes(b"pdf")
 
     core_module = types.ModuleType("md2pdf.core")
     core_module.md2pdf = fake_md2pdf
@@ -47,7 +69,7 @@ async def test_pdf_export_uses_current_md2pdf_api(tmp_path, monkeypatch):
     assert result
     output_path = Path(urllib.parse.unquote(result))
     assert output_path.exists()
-    assert captured["raw"] == "# Report"
-    assert captured["md"] is None
+    assert captured["content"] == "# Report"
+    assert captured["markdown_file"] is None
     assert Path(captured["css"]).name == "pdf_styles.css"
     assert captured["base_url"] is None

--- a/tests/test_multi_agent_pdf_export_api.py
+++ b/tests/test_multi_agent_pdf_export_api.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+import types
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "multi_agents"
+    / "agents"
+    / "utils"
+    / "file_formats.py"
+)
+SPEC = importlib.util.spec_from_file_location("multi_agent_file_formats", MODULE_PATH)
+file_formats = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(file_formats)
+
+
+@pytest.mark.asyncio
+async def test_pdf_export_uses_current_md2pdf_api(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_md2pdf(pdf, raw=None, md=None, css=None, base_url=None):
+        captured.update(
+            {
+                "pdf": pdf,
+                "raw": raw,
+                "md": md,
+                "css": css,
+                "base_url": base_url,
+            }
+        )
+        Path(pdf).write_bytes(b"pdf")
+
+    core_module = types.ModuleType("md2pdf.core")
+    core_module.md2pdf = fake_md2pdf
+    package_module = types.ModuleType("md2pdf")
+    package_module.core = core_module
+    monkeypatch.setitem(sys.modules, "md2pdf", package_module)
+    monkeypatch.setitem(sys.modules, "md2pdf.core", core_module)
+
+    result = await file_formats.write_md_to_pdf("# Report", str(tmp_path))
+
+    assert result
+    output_path = Path(urllib.parse.unquote(result))
+    assert output_path.exists()
+    assert captured["raw"] == "# Report"
+    assert captured["md"] is None
+    assert Path(captured["css"]).name == "pdf_styles.css"
+    assert captured["base_url"] is None

--- a/tests/test_report_store_async_io.py
+++ b/tests/test_report_store_async_io.py
@@ -1,0 +1,80 @@
+import asyncio
+import importlib.util
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "report_store_async_io_testmod",
+    ROOT / "backend/server/report_store.py",
+)
+REPORT_STORE_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REPORT_STORE_MODULE)
+ReportStore = REPORT_STORE_MODULE.ReportStore
+
+
+async def _heartbeat_completes_while(operation):
+    heartbeat_ran = False
+
+    async def heartbeat():
+        nonlocal heartbeat_ran
+        await asyncio.sleep(0.01)
+        heartbeat_ran = True
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await operation()
+    completed_during_operation = heartbeat_ran
+    await heartbeat_task
+    return completed_during_operation
+
+
+class ReportStoreAsyncIOTests(unittest.IsolatedAsyncioTestCase):
+    async def test_read_does_not_block_event_loop(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "reports.json"
+            path.write_text(
+                json.dumps({"r1": {"id": "r1"}}),
+                encoding="utf-8",
+            )
+            store = ReportStore(path)
+            original_read_text = Path.read_text
+
+            def slow_read_text(file_path, *args, **kwargs):
+                time.sleep(0.05)
+                return original_read_text(file_path, *args, **kwargs)
+
+            with patch.object(Path, "read_text", slow_read_text):
+                responsive = await _heartbeat_completes_while(
+                    lambda: store.get_report("r1")
+                )
+
+        self.assertTrue(responsive)
+
+    async def test_write_does_not_block_event_loop(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "reports.json"
+            store = ReportStore(path)
+            original_write_text = Path.write_text
+
+            def slow_write_text(file_path, *args, **kwargs):
+                time.sleep(0.05)
+                return original_write_text(file_path, *args, **kwargs)
+
+            with patch.object(Path, "write_text", slow_write_text):
+                responsive = await _heartbeat_completes_while(
+                    lambda: store.upsert_report("r1", {"id": "r1"})
+                )
+
+            stored = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertTrue(responsive)
+        self.assertEqual(stored, {"r1": {"id": "r1"}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -5,7 +5,7 @@ import types
 import unittest
 from enum import Enum
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -108,6 +108,60 @@ class WebSocketManagerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(report, "stub-report")
         self.assertEqual(call_kwargs["config_path"], "custom-config")
+
+    async def test_start_streaming_forwards_existing_logs_handler(self):
+        websocket_manager = _load_websocket_manager_module()
+        manager = websocket_manager.WebSocketManager()
+        call_kwargs = {}
+        logs_handler = object()
+
+        async def fake_run_agent(*args, **kwargs):
+            call_kwargs.update(kwargs)
+            return "stub-report"
+
+        websocket_manager.run_agent = fake_run_agent
+
+        await manager.start_streaming(
+            task="test-task",
+            report_type="research_report",
+            report_source="web",
+            source_urls=[],
+            document_urls=[],
+            tone="Objective",
+            websocket=object(),
+            logs_handler=logs_handler,
+        )
+
+        self.assertIs(call_kwargs["logs_handler"], logs_handler)
+
+    async def test_run_agent_reuses_existing_logs_handler(self):
+        websocket_manager = _load_websocket_manager_module()
+        logs_handler = object()
+        received = {}
+
+        async def fake_run_multi_agent_task(*args, **kwargs):
+            received.update(kwargs)
+            return {"report": "stub-report"}
+
+        websocket_manager.run_multi_agent_task = fake_run_multi_agent_task
+        websocket_manager.CustomLogsHandler = Mock(
+            side_effect=AssertionError("unexpected second logs handler")
+        )
+
+        report = await websocket_manager.run_agent(
+            task="test-task",
+            report_type="multi_agents",
+            report_source="web",
+            source_urls=[],
+            document_urls=[],
+            tone=websocket_manager.Tone.Objective,
+            websocket=object(),
+            logs_handler=logs_handler,
+        )
+
+        self.assertEqual(report, "stub-report")
+        self.assertIs(received["websocket"], logs_handler)
+        websocket_manager.CustomLogsHandler.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Consolidates eight backend and multi-agent fixes into one tested batch. Logical
fixes remain separate commits; follow-up test-hardening commits are preserved
where they were already part of the original PR history.

Includes the original #2025 scope and supersedes #2026, #2029, #2031, #2033,
#2034, #2039, and #2046.

## Included fixes

- Export and return complete multi-agent reports from the REST endpoint.
- Reuse chat search metadata instead of repeating the Tavily request.
- Reuse the initialized WebSocket log handler through the streaming run.
- Support both legacy and current `md2pdf` APIs.
- Create `DOC_PATH` before the first direct upload.
- Supply the shared stream callback to the multi-agent runner.
- Give concurrent research log handlers unique output files.
- Move ReportStore JSON I/O off the asyncio event loop.

## Verification

- 19 combined focused and adjacent tests passed.
- Ruff `F821`/`ASYNC251` checks passed.
- Python 3.11 compile checks passed.
- `git diff --check` passed.

The test environment included the declared `tavily-python` dependency. It also
supplied `Any`/`List` process-locally for the existing #1981 import regression;
no source workaround for that unrelated issue is included.

## Impact

- No intentional breaking changes.
- REST, WebSocket, report export, upload, logging, and persistence paths retain
  their existing public interfaces.
- Focused tests avoid network, LLM, and real multi-agent execution.

AI-assisted consolidation; every included behavior was revalidated locally.
