### PR TITLE
fix(chat): avoid duplicate tool searches

### DIFF
--- a/backend/chat/chat.py
+++ b/backend/chat/chat.py
@@ -113,6 +113,9 @@ class ChatAgentWithMemory:
 
     def quick_search(self, query):
         """Perform a web search for current information using Tavily"""
+        if not hasattr(self, "search_metadata_by_query"):
+            self.search_metadata_by_query = {}
+
         try:
             # Check if Tavily client is available
             if self.tavily_client is None:
@@ -122,6 +125,7 @@ class ChatAgentWithMemory:
                     "sources": [],
                     "error": "Web search is disabled - TAVILY_API_KEY not configured"
                 }
+                self.search_metadata_by_query[query] = self.search_metadata
                 return {
                     "error": "Web search is disabled - TAVILY_API_KEY not configured",
                     "results": []
@@ -140,10 +144,17 @@ class ChatAgentWithMemory:
                     for result in results.get("results", [])
                 ]
             }
+            self.search_metadata_by_query[query] = self.search_metadata
             
             return results
         except Exception as e:
             logger.error(f"Error performing web search: {str(e)}", exc_info=True)
+            self.search_metadata = {
+                "query": query,
+                "sources": [],
+                "error": str(e),
+            }
+            self.search_metadata_by_query[query] = self.search_metadata
             return {
                 "error": str(e),
                 "results": []
@@ -152,6 +163,8 @@ class ChatAgentWithMemory:
 
     async def process_chat_completion(self, messages: List[Dict[str, str]]):
         """Process chat completion using configured LLM provider with tool calling support"""
+        self.search_metadata_by_query = {}
+
         # Create a search tool using the utility function
         search_tool = create_search_tool(self.quick_search)
         
@@ -170,15 +183,11 @@ class ChatAgentWithMemory:
             if metadata.get("tool") == "search_tool":
                 # Extract query from args
                 query = metadata.get("args", {}).get("query", "")
-                
-                # Trigger search again to get metadata (the search was already executed by LangChain)
-                if query:
-                    self.quick_search(query)  # This populates self.search_metadata
-                    
+
                 processed_metadata.append({
                     "tool": "quick_search",
                     "query": query,
-                    "search_metadata": self.search_metadata
+                    "search_metadata": self.search_metadata_by_query.get(query),
                 })
         
         return response, processed_metadata

--- a/tests/backend/test_chat_search_metadata.py
+++ b/tests/backend/test_chat_search_metadata.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+import pytest
+
+from backend.chat import chat as chat_module
+
+
+@pytest.mark.asyncio
+async def test_tool_search_reuses_metadata_without_second_api_call(monkeypatch):
+    calls = []
+
+    class FakeTavilyClient:
+        def search(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "results": [
+                    {
+                        "title": "Current result",
+                        "url": "https://example.com/current",
+                        "content": "Current information",
+                    }
+                ]
+            }
+
+    async def fake_chat_completion_with_tools(**kwargs):
+        result = kwargs["tools"][0].invoke({"query": "latest update"})
+        assert "Current result" in result
+        return "answer", [
+            {
+                "tool": "search_tool",
+                "args": {"query": "latest update"},
+                "call_id": "call-1",
+            }
+        ]
+
+    agent = chat_module.ChatAgentWithMemory.__new__(
+        chat_module.ChatAgentWithMemory
+    )
+    agent.tavily_client = FakeTavilyClient()
+    agent.search_metadata = None
+    agent.config = SimpleNamespace(
+        smart_llm_model="model",
+        smart_llm_provider="provider",
+        llm_kwargs={},
+    )
+
+    monkeypatch.setattr(
+        chat_module,
+        "create_chat_completion_with_tools",
+        fake_chat_completion_with_tools,
+    )
+
+    response, metadata = await agent.process_chat_completion([])
+
+    assert response == "answer"
+    assert calls == [{"query": "latest update", "max_results": 5}]
+    assert metadata == [
+        {
+            "tool": "quick_search",
+            "query": "latest update",
+            "search_metadata": {
+                "query": "latest update",
+                "sources": [
+                    {
+                        "title": "Current result",
+                        "url": "https://example.com/current",
+                        "content": "Current information",
+                    }
+                ],
+            },
+        }
+    ]
+
+
+def test_unavailable_search_records_error_metadata():
+    agent = chat_module.ChatAgentWithMemory.__new__(
+        chat_module.ChatAgentWithMemory
+    )
+    agent.tavily_client = None
+    agent.search_metadata = None
+
+    result = agent.quick_search("latest update")
+
+    assert result["results"] == []
+    assert agent.search_metadata_by_query["latest update"] == {
+        "query": "latest update",
+        "sources": [],
+        "error": "Web search is disabled - TAVILY_API_KEY not configured",
+    }


### PR DESCRIPTION
## Summary

Reuse search metadata produced by the chat tool execution instead of issuing the
same Tavily query a second time.

## Problem

`create_chat_completion_with_tools()` already executes `search_tool`, which
calls `ChatAgentWithMemory.quick_search()`. When processing the returned tool
metadata, `process_chat_completion()` called `quick_search(query)` again solely
to rebuild frontend source metadata.

One LLM tool call therefore produced two identical Tavily API requests, adding
latency and potentially doubling search usage/cost.

## Changes

- Store search metadata by query during the original tool execution.
- Reset the per-completion metadata map before each chat completion.
- Read the cached metadata while formatting frontend tool metadata.
- Record query-specific error metadata when Tavily is unavailable or fails.

## Verification

Before:

```text
Expected one Tavily call; observed two identical calls.
```

After:

```text
tests/backend/test_chat_search_metadata.py ..  2 passed
```

The tests verify:

- one Tavily request per LLM search tool call while preserving source metadata;
- the disabled-search path records query-specific error metadata.

The current `main` branch has the unrelated #1981 typing import failure; the
local test process supplied those names without modifying that module.

## Duplicate Check

Open PR #1996 also changes `backend/chat/chat.py`, but its scope is report RAG
and vector-store initialization. It does not change quick-search execution or
tool metadata processing.

## Impact

- **Breaking change:** No
- **Affected area:** Report chat web-search tool
- **API usage:** Removes one redundant request per search tool call

## Checklist

- [x] The regression test fails before and passes after the fix.
- [x] Search source metadata remains available to the frontend.
- [x] Disabled-search behavior remains covered.
- [x] Open PR titles, bodies, diffs, and changed files were checked.
