### PR TITLE
fix(config): validate providers under optimized Python

### DIFF
--- a/gpt_researcher/config/config.py
+++ b/gpt_researcher/config/config.py
@@ -209,16 +209,18 @@ class Config:
             return None, None
         try:
             llm_provider, llm_model = llm_str.split(":", 1)
-            assert llm_provider in _SUPPORTED_PROVIDERS, (
-                f"Unsupported {llm_provider}.\nSupported llm providers are: "
-                + ", ".join(_SUPPORTED_PROVIDERS)
-            )
-            return llm_provider, llm_model
-        except ValueError:
+        except ValueError as exc:
             raise ValueError(
                 "Set SMART_LLM or FAST_LLM = '<llm_provider>:<llm_model>' "
                 "Eg 'openai:gpt-4o-mini'"
+            ) from exc
+
+        if llm_provider not in _SUPPORTED_PROVIDERS:
+            raise ValueError(
+                f"Unsupported {llm_provider}.\nSupported llm providers are: "
+                + ", ".join(_SUPPORTED_PROVIDERS)
             )
+        return llm_provider, llm_model
 
     @staticmethod
     def parse_reasoning_effort(reasoning_effort_str: str | None) -> str | None:
@@ -238,16 +240,18 @@ class Config:
             return None, None
         try:
             embedding_provider, embedding_model = embedding_str.split(":", 1)
-            assert embedding_provider in _SUPPORTED_PROVIDERS, (
-                f"Unsupported {embedding_provider}.\nSupported embedding providers are: "
-                + ", ".join(_SUPPORTED_PROVIDERS)
-            )
-            return embedding_provider, embedding_model
-        except ValueError:
+        except ValueError as exc:
             raise ValueError(
                 "Set EMBEDDING = '<embedding_provider>:<embedding_model>' "
                 "Eg 'openai:text-embedding-3-large'"
+            ) from exc
+
+        if embedding_provider not in _SUPPORTED_PROVIDERS:
+            raise ValueError(
+                f"Unsupported {embedding_provider}.\nSupported embedding providers are: "
+                + ", ".join(_SUPPORTED_PROVIDERS)
             )
+        return embedding_provider, embedding_model
 
     def validate_doc_path(self):
         """Ensure that the folder exists at the doc path"""

--- a/tests/test_provider_validation_optimized.py
+++ b/tests/test_provider_validation_optimized.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("method_name", ["parse_llm", "parse_embedding"])
+def test_provider_validation_survives_optimized_python(method_name):
+    project_root = Path(__file__).resolve().parents[1]
+    script = f"""
+import builtins
+import typing
+
+builtins.Any = typing.Any
+builtins.List = typing.List
+
+from gpt_researcher.config.config import Config
+
+try:
+    Config.{method_name}("unsupported-provider:model")
+except ValueError:
+    pass
+else:
+    raise SystemExit("unsupported provider was accepted")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Keep LLM and embedding provider validation active when Python runs with
optimization enabled.

## Problem

`Config.parse_llm()` and `Config.parse_embedding()` used `assert` to reject
unsupported providers. Python removes assertions under `python -O`, so invalid
values were silently accepted:

```text
unsupported-provider:model
```

This deferred the failure to a later, less clear provider initialization path
and made configuration behavior depend on interpreter flags.

## Changes

- Separate `<provider>:<model>` format parsing from provider validation.
- Replace both assertions with explicit `ValueError` checks.
- Preserve the existing unsupported-provider and malformed-value messages.
- Add real `python -O` subprocess regression tests for both provider types.

## Verification

Before:

```text
python -O accepted unsupported LLM and embedding providers
```

After:

```text
tests/test_provider_validation_optimized.py ..  2 passed
tests/test_convert_env_value_optional.py .......  7 passed
9 passed
```

The current `main` branch has an unrelated import-time typing failure in
`actions/query_processing.py` (#1981). The subprocess test supplies those names
without modifying that module.

## Duplicate Check

Other open PRs touching `config.py` handle MCP initialization, JSON environment
parsing, checkpoints, or WebSocket behavior. None changes `parse_llm()` or
`parse_embedding()`.

## Impact

- **Breaking change:** No for valid configuration
- **Behavioral correction:** Invalid providers consistently fail fast
- **Affected modes:** Normal and optimized Python now match

## Checklist

- [x] The regression tests fail before and pass after the fix.
- [x] Both LLM and embedding providers are covered.
- [x] Related configuration tests pass.
- [x] Open PR titles, bodies, and changed files were checked.
