### PR TITLE
fix(azure): clean unused download directories

### DIFF
--- a/gpt_researcher/document/azure_document_loader.py
+++ b/gpt_researcher/document/azure_document_loader.py
@@ -1,6 +1,8 @@
-from azure.storage.blob import BlobServiceClient
+import shutil
 import tempfile
 from pathlib import Path, PurePosixPath
+
+from azure.storage.blob import BlobServiceClient
 
 
 class AzureDocumentLoader:
@@ -13,14 +15,21 @@ class AzureDocumentLoader:
         temp_dir = Path(tempfile.mkdtemp()).resolve()
         blobs = self.container.list_blobs()
         file_paths = []
-        for blob in blobs:
-            blob_client = self.container.get_blob_client(blob.name)
-            local_path = self._get_blob_path(temp_dir, blob.name)
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(local_path, "wb") as f:
-                blob_data = blob_client.download_blob()
-                f.write(blob_data.readall())
-            file_paths.append(str(local_path))
+        try:
+            for blob in blobs:
+                blob_client = self.container.get_blob_client(blob.name)
+                local_path = self._get_blob_path(temp_dir, blob.name)
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(local_path, "wb") as f:
+                    blob_data = blob_client.download_blob()
+                    f.write(blob_data.readall())
+                file_paths.append(str(local_path))
+        except BaseException:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            raise
+
+        if not file_paths:
+            shutil.rmtree(temp_dir, ignore_errors=True)
         return file_paths  # Pass to existing DocumentLoader
 
     @staticmethod

--- a/tests/test_azure_document_loader.py
+++ b/tests/test_azure_document_loader.py
@@ -1,8 +1,10 @@
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 class _FakeBlobServiceClient:
@@ -79,8 +81,37 @@ class TestAzureDocumentLoader(unittest.IsolatedAsyncioTestCase):
         loader = AzureDocumentLoader.__new__(AzureDocumentLoader)
         loader.container = _Container({"../escape.txt": b"nope"})
 
-        with self.assertRaises(ValueError):
-            await loader.load()
+        with tempfile.TemporaryDirectory() as parent:
+            temp_dir = Path(parent) / "azure-download"
+            temp_dir.mkdir()
+
+            with patch.object(
+                azure_document_loader.tempfile,
+                "mkdtemp",
+                return_value=str(temp_dir),
+            ):
+                with self.assertRaises(ValueError):
+                    await loader.load()
+
+            self.assertFalse(temp_dir.exists())
+
+    async def test_load_removes_unused_directory_for_empty_container(self):
+        loader = AzureDocumentLoader.__new__(AzureDocumentLoader)
+        loader.container = _Container({})
+
+        with tempfile.TemporaryDirectory() as parent:
+            temp_dir = Path(parent) / "azure-download"
+            temp_dir.mkdir()
+
+            with patch.object(
+                azure_document_loader.tempfile,
+                "mkdtemp",
+                return_value=str(temp_dir),
+            ):
+                file_paths = await loader.load()
+
+            self.assertEqual(file_paths, [])
+            self.assertFalse(temp_dir.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Remove Azure document download directories when loading fails, is cancelled, or
produces no files.

## Problem

`AzureDocumentLoader.load()` creates a directory with `tempfile.mkdtemp()`.
Successful downloads must remain available for the downstream `DocumentLoader`,
but two terminal paths had no consumer and still leaked the directory:

- path validation or download failures;
- an empty blob container.

Repeated failed/empty loads therefore accumulated unused directories under the
system temporary location.

## Changes

- Remove the download directory before re-raising any exception, including
  cancellation.
- Remove the directory when no blob files were downloaded.
- Preserve the existing successful-load behavior and returned file paths.
- Extend the existing Azure loader tests with explicit cleanup assertions.

## Verification

Before:

```text
2 failed, 1 passed
```

Both the unsafe-blob and empty-container tests observed a surviving directory.

After:

```text
tests/test_azure_document_loader.py ...  3 passed
```

No Azure account or network calls are required; the tests use the existing fake
container and blob clients.

## Impact

- **Breaking change:** No
- **Successful downloads:** Preserved for downstream parsing
- **Affected paths:** Failed, cancelled, and empty Azure loads

## Checklist

- [x] The cleanup assertions fail before and pass after the fix.
- [x] Successful nested blob downloads remain covered.
- [x] Unsafe path validation remains covered.
- [x] Open PR titles, bodies, and changed files were checked.
