### PR TITLE
fix(server): reuse WebSocket research log handler

### DIFF
--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -170,6 +170,7 @@ async def handle_start_command(websocket, data: str, manager):
         mcp_strategy,
         mcp_configs,
         max_search_results,
+        logs_handler=logs_handler,
     )
     report = str(report)
     file_paths = await generate_report_files(report, sanitized_filename)

--- a/backend/server/websocket_manager.py
+++ b/backend/server/websocket_manager.py
@@ -98,7 +98,7 @@ class WebSocketManager:
             except Exception:
                 pass  # If this fails too, there's nothing more we can do
 
-    async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None):
+    async def start_streaming(self, task, report_type, report_source, source_urls, document_urls, tone, websocket, headers=None, query_domains=[], mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None, logs_handler=None):
         """Start streaming the output."""
         tone = Tone[tone]
         # add customized JSON config file path here
@@ -109,14 +109,15 @@ class WebSocketManager:
             task, report_type, report_source, source_urls, document_urls, tone, websocket, 
             headers=headers, query_domains=query_domains, config_path=config_path,
             mcp_enabled=mcp_enabled, mcp_strategy=mcp_strategy, mcp_configs=mcp_configs,
-            max_search_results=max_search_results
+            max_search_results=max_search_results, logs_handler=logs_handler
         )
         return report
 
-async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False, mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None):
+async def run_agent(task, report_type, report_source, source_urls, document_urls, tone: Tone, websocket, stream_output=stream_output, headers=None, query_domains=[], config_path="", return_researcher=False, mcp_enabled=False, mcp_strategy="fast", mcp_configs=[], max_search_results=None, logs_handler=None):
     """Run the agent."""    
-    # Create logs handler for this research task
-    logs_handler = CustomLogsHandler(websocket, task)
+    # Reuse the WebSocket command handler so its initialized query is not
+    # overwritten by a second handler targeting the same log file.
+    logs_handler = logs_handler or CustomLogsHandler(websocket, task)
 
     # Log MCP initialization. Retriever and strategy are configured per-request
     # inside GPTResearcher via mcp_configs/mcp_strategy params — no os.environ

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 from fastapi import WebSocket
+from backend.server import server_utils
 from backend.server.server_utils import CustomLogsHandler
 import os
 import json
@@ -59,3 +60,49 @@ async def test_content_update():
         assert log_data['content']['query'] == "test query"
         assert log_data['content']['sources'] == ["source1", "source2"]
         assert log_data['content']['report'] == "test report"
+
+
+@pytest.mark.asyncio
+async def test_start_command_passes_initialized_logs_handler(
+    tmp_path, monkeypatch
+):
+    mock_websocket = AsyncMock()
+    captured = {}
+
+    class FakeManager:
+        async def start_streaming(self, *args, **kwargs):
+            captured.update(kwargs)
+            return "report"
+
+    async def fake_generate_report_files(report, filename):
+        return {}
+
+    async def fake_send_file_paths(websocket, file_paths):
+        return None
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        server_utils, "generate_report_files", fake_generate_report_files
+    )
+    monkeypatch.setattr(server_utils, "send_file_paths", fake_send_file_paths)
+
+    command = {
+        "task": "test query",
+        "report_type": "research_report",
+        "source_urls": [],
+        "document_urls": [],
+        "tone": "Objective",
+        "report_source": "web",
+    }
+
+    await server_utils.handle_start_command(
+        mock_websocket,
+        f"start {json.dumps(command)}",
+        FakeManager(),
+    )
+
+    logs_handler = captured["logs_handler"]
+    with open(logs_handler.log_file, "r") as file:
+        log_data = json.load(file)
+
+    assert log_data["content"]["query"] == "test query"

--- a/tests/test_websocket_manager.py
+++ b/tests/test_websocket_manager.py
@@ -5,7 +5,7 @@ import types
 import unittest
 from enum import Enum
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -108,6 +108,60 @@ class WebSocketManagerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(report, "stub-report")
         self.assertEqual(call_kwargs["config_path"], "custom-config")
+
+    async def test_start_streaming_forwards_existing_logs_handler(self):
+        websocket_manager = _load_websocket_manager_module()
+        manager = websocket_manager.WebSocketManager()
+        call_kwargs = {}
+        logs_handler = object()
+
+        async def fake_run_agent(*args, **kwargs):
+            call_kwargs.update(kwargs)
+            return "stub-report"
+
+        websocket_manager.run_agent = fake_run_agent
+
+        await manager.start_streaming(
+            task="test-task",
+            report_type="research_report",
+            report_source="web",
+            source_urls=[],
+            document_urls=[],
+            tone="Objective",
+            websocket=object(),
+            logs_handler=logs_handler,
+        )
+
+        self.assertIs(call_kwargs["logs_handler"], logs_handler)
+
+    async def test_run_agent_reuses_existing_logs_handler(self):
+        websocket_manager = _load_websocket_manager_module()
+        logs_handler = object()
+        received = {}
+
+        async def fake_run_multi_agent_task(*args, **kwargs):
+            received.update(kwargs)
+            return {"report": "stub-report"}
+
+        websocket_manager.run_multi_agent_task = fake_run_multi_agent_task
+        websocket_manager.CustomLogsHandler = Mock(
+            side_effect=AssertionError("unexpected second logs handler")
+        )
+
+        report = await websocket_manager.run_agent(
+            task="test-task",
+            report_type="multi_agents",
+            report_source="web",
+            source_urls=[],
+            document_urls=[],
+            tone=websocket_manager.Tone.Objective,
+            websocket=object(),
+            logs_handler=logs_handler,
+        )
+
+        self.assertEqual(report, "stub-report")
+        self.assertIs(received["websocket"], logs_handler)
+        websocket_manager.CustomLogsHandler.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Reuse the WebSocket command's initialized research log handler throughout the
streaming run.

## Problem

`handle_start_command()` creates a `CustomLogsHandler` and writes the query into
its JSON log. `WebSocketManager.start_streaming()` then calls `run_agent()`,
which created a second handler for the same task and file name.

The second constructor rewrote the JSON file with empty content, discarding the
query and any entrypoint metadata before research started.

## Changes

- Pass the existing handler from `handle_start_command()` to
  `WebSocketManager.start_streaming()`.
- Forward it to `run_agent()`.
- Reuse it when provided while retaining automatic handler creation for REST
  and other direct callers.
- Add propagation and no-second-construction regression tests.

## Verification

Before:

```text
3 failed, 5 passed
```

The entrypoint did not pass a handler, and the manager/runner did not accept it.

After:

```text
tests/test_websocket_manager.py .....  5 passed
tests/test_logging.py ...              3 passed
8 passed
```

The tests verify the full handler propagation chain and that the initialized
query remains in the JSON log.

The current `main` branch has the unrelated #1981 typing import failure; the
local test process supplies those names without modifying that module.

## Impact

- **Breaking change:** No
- **WebSocket research logs:** Preserve entrypoint metadata
- **Direct/REST runs:** Continue creating their own handler when none is passed

## Checklist

- [x] The regression tests fail before and pass after the fix.
- [x] Existing WebSocket manager and logging tests pass.
- [x] Open PR titles, bodies, and changed files were checked.
- [x] The change is limited to log-handler lifecycle propagation.
