### PR TITLE
fix(logging): register structured JSON handler

### DIFF
--- a/gpt_researcher/utils/logging_config.py
+++ b/gpt_researcher/utils/logging_config.py
@@ -56,8 +56,11 @@ def setup_research_logging():
     research_logger = logging.getLogger('research')
     research_logger.setLevel(logging.INFO)
     
-    # Remove any existing handlers to avoid duplicates
-    research_logger.handlers.clear()
+    # Remove and close existing handlers to avoid duplicate output and leaked
+    # file descriptors when logging is configured more than once.
+    for handler in research_logger.handlers[:]:
+        research_logger.removeHandler(handler)
+        handler.close()
     
     # Add file handler
     research_logger.addHandler(file_handler)
@@ -72,6 +75,7 @@ def setup_research_logging():
     
     # Create JSON handler
     json_handler = JSONResearchHandler(json_file)
+    research_logger.json_handler = json_handler
     
     return str(log_file), str(json_file), research_logger, json_handler
 

--- a/tests/test_structured_logging_setup.py
+++ b/tests/test_structured_logging_setup.py
@@ -1,0 +1,44 @@
+import logging
+
+import pytest
+
+from gpt_researcher.utils.logging_config import (
+    get_json_handler,
+    setup_research_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_research_logger():
+    yield
+    logger = logging.getLogger("research")
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+    if hasattr(logger, "json_handler"):
+        del logger.json_handler
+
+
+def test_setup_registers_json_handler_for_research_conductor(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    _, _, logger, json_handler = setup_research_logging()
+
+    assert get_json_handler() is json_handler
+    assert logger.json_handler is json_handler
+
+
+def test_setup_closes_replaced_file_handlers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    _, _, logger, _ = setup_research_logging()
+    old_file_handlers = [
+        handler
+        for handler in logger.handlers
+        if isinstance(handler, logging.FileHandler)
+    ]
+
+    setup_research_logging()
+
+    assert old_file_handlers
+    assert all(handler.stream is None for handler in old_file_handlers)


### PR DESCRIPTION
## Summary

Register the structured JSON handler on the research logger and safely close
handlers replaced by repeated logging setup.

## Problem

`setup_research_logging()` created and returned a `JSONResearchHandler`, while
`get_json_handler()` tried to read `research_logger.json_handler`. The setup
function never assigned that attribute, so `ResearchConductor` always received
`None` and all of its structured logging branches were unreachable.

The setup function also cleared existing handlers without closing them, leaving
old file streams open when logging was configured more than once.

## Changes

- Attach the new JSON handler to the `research` logger.
- Remove and close each existing handler before replacement.
- Add isolated tests for getter registration and file-handler cleanup.
- Clean global logger state after each test.

## Verification

Before:

```text
get_json_handler() is None
old FileHandler.stream remains open
2 failed
```

After:

```text
tests/test_structured_logging_setup.py ..  2 passed
```

The current `main` branch has the unrelated #1981 typing import failure; the
local test process supplies those names without modifying that module.

## Scope

This changes only `gpt_researcher/utils/logging_config.py`, which is imported by
`ResearchConductor`. The unused duplicate under `backend/server` is intentionally
left outside this PR.

## Impact

- **Breaking change:** No
- **Structured research logs:** Become reachable through the existing getter
- **Repeated setup:** No longer leaks replaced file handlers

## Checklist

- [x] Both regression tests fail before and pass after the fix.
- [x] Tests clean up global logger state.
- [x] Open PR titles, bodies, and changed files were checked.
- [x] The PR is limited to structured logging setup.
