### PR TITLE
fix(multi-agent): update md2pdf API usage

### DIFF
--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -57,8 +57,8 @@ async def write_md_to_pdf(text: str, path: str) -> str:
         # Moved imports to inner function to avoid known import errors with gobject-2.0
         from md2pdf.core import md2pdf
         md2pdf(file_path,
-               md_content=text,
-               css_file_path=css_path,
+               raw=text,
+               css=css_path,
                base_url=None)
         print(f"Report written to {file_path}")
     except Exception as e:

--- a/multi_agents/agents/utils/file_formats.py
+++ b/multi_agents/agents/utils/file_formats.py
@@ -1,8 +1,10 @@
-import aiofiles
+import inspect
+import os
 import urllib
 import uuid
+
+import aiofiles
 import mistune
-import os
 
 async def write_to_file(filename: str, text: str) -> None:
     """Asynchronously write text to a file in UTF-8 encoding.
@@ -56,10 +58,20 @@ async def write_md_to_pdf(text: str, path: str) -> str:
         
         # Moved imports to inner function to avoid known import errors with gobject-2.0
         from md2pdf.core import md2pdf
-        md2pdf(file_path,
-               raw=text,
-               css=css_path,
-               base_url=None)
+        if "raw" in inspect.signature(md2pdf).parameters:
+            md2pdf(
+                file_path,
+                raw=text,
+                css=css_path,
+                base_url=None,
+            )
+        else:
+            md2pdf(
+                file_path,
+                md_content=text,
+                css_file_path=css_path,
+                base_url=None,
+            )
         print(f"Report written to {file_path}")
     except Exception as e:
         print(f"Error in converting Markdown to PDF: {e}")

--- a/tests/test_multi_agent_pdf_export_api.py
+++ b/tests/test_multi_agent_pdf_export_api.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
     / "multi_agents"
@@ -19,21 +18,44 @@ file_formats = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(file_formats)
 
 
+@pytest.mark.parametrize("api_version", ["legacy", "current"])
 @pytest.mark.asyncio
-async def test_pdf_export_uses_current_md2pdf_api(tmp_path, monkeypatch):
+async def test_pdf_export_supports_md2pdf_api_versions(
+    api_version,
+    tmp_path,
+    monkeypatch,
+):
     captured = {}
 
-    def fake_md2pdf(pdf, raw=None, md=None, css=None, base_url=None):
-        captured.update(
-            {
-                "pdf": pdf,
-                "raw": raw,
-                "md": md,
-                "css": css,
-                "base_url": base_url,
-            }
-        )
-        Path(pdf).write_bytes(b"pdf")
+    if api_version == "current":
+
+        def fake_md2pdf(pdf, raw=None, md=None, css=None, base_url=None):
+            captured.update(
+                pdf=pdf,
+                content=raw,
+                markdown_file=md,
+                css=css,
+                base_url=base_url,
+            )
+            Path(pdf).write_bytes(b"pdf")
+
+    else:
+
+        def fake_md2pdf(
+            pdf_file_path,
+            md_content=None,
+            md_file_path=None,
+            css_file_path=None,
+            base_url=None,
+        ):
+            captured.update(
+                pdf=pdf_file_path,
+                content=md_content,
+                markdown_file=md_file_path,
+                css=css_file_path,
+                base_url=base_url,
+            )
+            Path(pdf_file_path).write_bytes(b"pdf")
 
     core_module = types.ModuleType("md2pdf.core")
     core_module.md2pdf = fake_md2pdf
@@ -47,7 +69,7 @@ async def test_pdf_export_uses_current_md2pdf_api(tmp_path, monkeypatch):
     assert result
     output_path = Path(urllib.parse.unquote(result))
     assert output_path.exists()
-    assert captured["raw"] == "# Report"
-    assert captured["md"] is None
+    assert captured["content"] == "# Report"
+    assert captured["markdown_file"] is None
     assert Path(captured["css"]).name == "pdf_styles.css"
     assert captured["base_url"] is None

--- a/tests/test_multi_agent_pdf_export_api.py
+++ b/tests/test_multi_agent_pdf_export_api.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+import types
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "multi_agents"
+    / "agents"
+    / "utils"
+    / "file_formats.py"
+)
+SPEC = importlib.util.spec_from_file_location("multi_agent_file_formats", MODULE_PATH)
+file_formats = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(file_formats)
+
+
+@pytest.mark.asyncio
+async def test_pdf_export_uses_current_md2pdf_api(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_md2pdf(pdf, raw=None, md=None, css=None, base_url=None):
+        captured.update(
+            {
+                "pdf": pdf,
+                "raw": raw,
+                "md": md,
+                "css": css,
+                "base_url": base_url,
+            }
+        )
+        Path(pdf).write_bytes(b"pdf")
+
+    core_module = types.ModuleType("md2pdf.core")
+    core_module.md2pdf = fake_md2pdf
+    package_module = types.ModuleType("md2pdf")
+    package_module.core = core_module
+    monkeypatch.setitem(sys.modules, "md2pdf", package_module)
+    monkeypatch.setitem(sys.modules, "md2pdf.core", core_module)
+
+    result = await file_formats.write_md_to_pdf("# Report", str(tmp_path))
+
+    assert result
+    output_path = Path(urllib.parse.unquote(result))
+    assert output_path.exists()
+    assert captured["raw"] == "# Report"
+    assert captured["md"] is None
+    assert Path(captured["css"]).name == "pdf_styles.css"
+    assert captured["base_url"] is None


### PR DESCRIPTION
## Summary

Keep multi-agent PDF publishing compatible with both the declared minimum and current `md2pdf` APIs.

## Problem

`multi_agents/agents/utils/file_formats.py` used the legacy `md_content` and `css_file_path` keywords. The locked `md2pdf 3.1.1` API renamed them to `raw` and `css`, so PDF export raised a `TypeError` that was caught internally and silently returned an empty path.

A direct replacement with only the 3.x keywords would break the project's declared minimum `md2pdf>=1.0.1`, whose verified signature still requires the legacy names.

## Changes

- Inspect the imported `md2pdf` callable and select its supported keyword set.
- Use `raw` and `css` for current releases.
- Preserve `md_content` and `css_file_path` compatibility for the declared minimum.
- Parameterize the regression test with strict legacy and current API stubs.

## Verification

Verified package source signatures:

```text
md2pdf 1.0.1: pdf_file_path, md_content, md_file_path, css_file_path, base_url
md2pdf 3.1.1: pdf, raw, md, css, base_url, extras, extras_config, context
```

Focused test:

```text
uv run --python 3.11 --with pytest --with pytest-asyncio \
  pytest tests/test_multi_agent_pdf_export_api.py -q
2 passed
```

The tests use strict function signatures, verify the generated output path and CSS, and do not import WeasyPrint.

## Impact

- **Breaking change:** No
- **Affected area:** Multi-agent PDF publishing
- **Supported dependency range:** `md2pdf>=1.0.1`, including locked 3.1.1
- **DOCX/Markdown publishing:** Unchanged

## Checklist

- [x] Current `md2pdf` parameters are covered.
- [x] Declared-minimum legacy parameters are covered.
- [x] No system PDF libraries are required by the regression tests.
- [x] The change remains limited to `md2pdf` API compatibility.

## Re-verification (2026-08-11)

Re-audited against `main` at `5d84d2f`. `main` fails against the current strict API, while a current-only replacement fails against the declared minimum. This revision verifies and supports both API generations.