### PR TITLE
fix(document): preserve LangChain source metadata

### DIFF
--- a/gpt_researcher/document/langchain_document.py
+++ b/gpt_researcher/document/langchain_document.py
@@ -15,10 +15,13 @@ class LangChainDocumentLoader:
     async def load(self, metadata_source_index="title") -> List[Dict[str, str]]:
         docs = []
         for document in self.documents:
+            source = document.metadata.get(
+                metadata_source_index
+            ) or document.metadata.get("source", "")
             docs.append(
                 {
                     "raw_content": document.page_content,
-                    "url": document.metadata.get(metadata_source_index, ""),
+                    "url": source,
                 }
             )
         return docs

--- a/tests/test_langchain_document_loader.py
+++ b/tests/test_langchain_document_loader.py
@@ -1,0 +1,48 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+from langchain_core.documents import Document
+
+module_path = (
+    Path(__file__).resolve().parents[1]
+    / "gpt_researcher"
+    / "document"
+    / "langchain_document.py"
+)
+spec = importlib.util.spec_from_file_location("langchain_document", module_path)
+langchain_document = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(langchain_document)
+LangChainDocumentLoader = langchain_document.LangChainDocumentLoader
+
+
+class TestLangChainDocumentLoader(unittest.IsolatedAsyncioTestCase):
+    async def test_load_falls_back_to_standard_source_metadata(self):
+        document = Document(
+            page_content="Document content",
+            metadata={"source": "document.pdf"},
+        )
+
+        loaded_documents = await LangChainDocumentLoader([document]).load()
+
+        self.assertEqual(
+            loaded_documents,
+            [{"raw_content": "Document content", "url": "document.pdf"}],
+        )
+
+    async def test_load_prefers_requested_metadata_field(self):
+        document = Document(
+            page_content="Document content",
+            metadata={"title": "Document title", "source": "document.pdf"},
+        )
+
+        loaded_documents = await LangChainDocumentLoader([document]).load()
+
+        self.assertEqual(
+            loaded_documents,
+            [{"raw_content": "Document content", "url": "Document title"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Preserve standard LangChain document source metadata when adapting documents
for GPT Researcher.

## Problem

`LangChainDocumentLoader` uses `metadata["title"]` as its default source field.
Documents returned by common LangChain loaders and retrievers normally identify
their origin with `metadata["source"]`. When such a document has no `title`, the
adapter emitted an empty `url`, so downstream context and vector-store entries
lost the document source.

## Changes

- Fall back to `metadata["source"]` when the requested metadata field is absent
  or empty.
- Preserve the requested field's precedence when both values are present.
- Add isolated regression coverage using LangChain's base `Document` class.

## Verification

Before:

```text
test_load_falls_back_to_standard_source_metadata ... FAIL
test_load_prefers_requested_metadata_field ... ok
Ran 2 tests
FAILED (failures=1)
```

After:

```text
uv run --frozen python tests/test_langchain_document_loader.py -v
Ran 2 tests
OK
```

Additional checks:

```text
uv run --with pytest --with pytest-asyncio pytest tests/test_langchain_document_loader.py -q
2 passed

uv run --with black black --check --fast --target-version py311 \
  gpt_researcher/document/langchain_document.py \
  tests/test_langchain_document_loader.py
2 files would be left unchanged

uv run --frozen python -m compileall -q \
  gpt_researcher/document/langchain_document.py \
  tests/test_langchain_document_loader.py
```

## Duplicate Check

All 129 open PR titles, bodies, and changed files were checked immediately
before publishing. None modifies `langchain_document.py` or implements this
fallback. PR #1964 changes the separate local `DocumentLoader` path.

## Impact

- **Breaking change:** No
- **Affected area:** `langchain_documents` report source
- **Network, embeddings, and LLM calls in tests:** None
- **Custom/title metadata:** Existing precedence is preserved

## Checklist

- [x] The regression test fails before and passes after the fix.
- [x] Existing requested-field precedence remains covered.
- [x] Formatting, compilation, and diff checks pass.
- [x] The PR is limited to one adapter behavior and its tests.
