### PR TITLE
fix(server): create document directory on upload

### DIFF
--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -293,6 +293,7 @@ def update_environment_variables(config: Dict[str, str]):
 
 
 async def handle_file_upload(file, DOC_PATH: str) -> Dict[str, str]:
+    os.makedirs(DOC_PATH, exist_ok=True)
     file_path = os.path.join(DOC_PATH, os.path.basename(file.filename))
     with open(file_path, "wb") as buffer:
         shutil.copyfileobj(file.file, buffer)

--- a/tests/backend/test_file_upload_directory.py
+++ b/tests/backend/test_file_upload_directory.py
@@ -1,0 +1,71 @@
+import builtins
+import importlib
+import io
+import sys
+import tempfile
+import types
+import typing
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _load_server_utils():
+    utils_module = types.ModuleType("utils")
+    utils_module.write_md_to_pdf = lambda *args, **kwargs: None
+    utils_module.write_md_to_word = lambda *args, **kwargs: None
+    utils_module.write_text_to_md = lambda *args, **kwargs: None
+
+    original_any = getattr(builtins, "Any", None)
+    original_list = getattr(builtins, "List", None)
+    builtins.Any = typing.Any
+    builtins.List = typing.List
+    try:
+        with patch.dict(sys.modules, {"utils": utils_module}):
+            return importlib.import_module("backend.server.server_utils")
+    finally:
+        if original_any is None:
+            del builtins.Any
+        else:
+            builtins.Any = original_any
+        if original_list is None:
+            del builtins.List
+        else:
+            builtins.List = original_list
+
+
+server_utils = _load_server_utils()
+
+
+class _DocumentLoader:
+    def __init__(self, path):
+        self.path = path
+
+    async def load(self):
+        return []
+
+
+class FileUploadDirectoryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_upload_creates_document_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            document_dir = Path(temp_dir) / "documents"
+            upload = SimpleNamespace(
+                filename="notes.txt",
+                file=io.BytesIO(b"uploaded content"),
+            )
+
+            with patch.object(server_utils, "DocumentLoader", _DocumentLoader):
+                result = await server_utils.handle_file_upload(
+                    upload,
+                    str(document_dir),
+                )
+
+            uploaded_file = document_dir / "notes.txt"
+            self.assertTrue(document_dir.is_dir())
+            self.assertEqual(uploaded_file.read_bytes(), b"uploaded content")
+            self.assertEqual(result["path"], str(uploaded_file))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backend/test_file_upload_directory.py
+++ b/tests/backend/test_file_upload_directory.py
@@ -1,10 +1,8 @@
-import builtins
-import importlib
+import importlib.util
 import io
 import sys
 import tempfile
 import types
-import typing
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,27 +10,46 @@ from unittest.mock import patch
 
 
 def _load_server_utils():
+    gpt_researcher = types.ModuleType("gpt_researcher")
+    gpt_researcher.__path__ = []
+    gpt_researcher.GPTResearcher = object
+
+    document_package = types.ModuleType("gpt_researcher.document")
+    document_package.__path__ = []
+    document_module = types.ModuleType("gpt_researcher.document.document")
+    document_module.DocumentLoader = object
+
     utils_module = types.ModuleType("utils")
     utils_module.write_md_to_pdf = lambda *args, **kwargs: None
     utils_module.write_md_to_word = lambda *args, **kwargs: None
     utils_module.write_text_to_md = lambda *args, **kwargs: None
 
-    original_any = getattr(builtins, "Any", None)
-    original_list = getattr(builtins, "List", None)
-    builtins.Any = typing.Any
-    builtins.List = typing.List
-    try:
-        with patch.dict(sys.modules, {"utils": utils_module}):
-            return importlib.import_module("backend.server.server_utils")
-    finally:
-        if original_any is None:
-            del builtins.Any
-        else:
-            builtins.Any = original_any
-        if original_list is None:
-            del builtins.List
-        else:
-            builtins.List = original_list
+    runner_module = types.ModuleType("backend.server.multi_agent_runner")
+    runner_module.run_multi_agent_task = None
+
+    chat_package = types.ModuleType("chat")
+    chat_package.__path__ = []
+    chat_module = types.ModuleType("chat.chat")
+    chat_module.ChatAgentWithMemory = object
+
+    module_path = Path(__file__).resolve().parents[2] / "backend/server/server_utils.py"
+    spec = importlib.util.spec_from_file_location(
+        "backend.server._server_utils_upload_test",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    dependencies = {
+        "gpt_researcher": gpt_researcher,
+        "gpt_researcher.document": document_package,
+        "gpt_researcher.document.document": document_module,
+        "utils": utils_module,
+        "backend.server.multi_agent_runner": runner_module,
+        "chat": chat_package,
+        "chat.chat": chat_module,
+    }
+    with patch.dict(sys.modules, dependencies):
+        spec.loader.exec_module(module)
+    return module
 
 
 server_utils = _load_server_utils()


### PR DESCRIPTION
## Summary

Create the configured document directory before saving an uploaded file.

## Problem

`POST /upload/` wrote directly into `DOC_PATH`, but the upload handler did not
create that directory. The separate `GET /files/` endpoint creates it, so
uploads only worked when a client happened to list files first.

A direct API upload with a new or default document path failed before document
loading began:

```text
FileNotFoundError: [Errno 2] No such file or directory:
'.../documents/notes.txt'
```

## Changes

- Initialize `DOC_PATH` with `exist_ok=True` before opening the destination.
- Add an isolated upload-handler regression test using a previously absent
  nested document directory.

## Verification

Before:

```text
PYTHONPATH=.:backend uv run --frozen python \
  tests/backend/test_file_upload_directory.py -v

test_upload_creates_document_directory ... ERROR
FileNotFoundError: .../documents/notes.txt
```

After:

```text
PYTHONPATH=.:backend uv run --frozen python \
  tests/backend/test_file_upload_directory.py -v

test_upload_creates_document_directory ... ok
Ran 1 test
OK
```

Additional checks:

```text
PYTHONPATH=.:backend uv run --with pytest --with pytest-asyncio \
  pytest tests/backend/test_file_upload_directory.py -q
1 passed

uv run --with black black --check --fast --target-version py311 \
  tests/backend/test_file_upload_directory.py
1 file would be left unchanged

uv run --with ruff ruff check tests/backend/test_file_upload_directory.py
All checks passed
```

## Duplicate Check

All 130 open PR titles, bodies, and changed files were checked immediately
before publishing. Same-file PRs address WebSocket logging or custom writing
instructions; none initializes the upload directory or adds this regression
test.

## Impact

- **Breaking change:** No
- **Affected area:** Direct `POST /upload/` requests
- **Existing directories:** Unchanged because creation uses `exist_ok=True`
- **Network, embeddings, and LLM calls in tests:** None

## Checklist

- [x] The regression test fails before and passes after the fix.
- [x] Direct uploads no longer depend on a prior file-list request.
- [x] The change is limited to directory initialization and its test.
- [x] Open PR titles, bodies, and changed files were checked.

## Re-verification (2026-08-11)

Re-audited against `main` at `5d84d2f` through `handle_file_upload()`. A first upload to a missing document directory raises `FileNotFoundError` on `main`; this branch creates the directory and writes the complete file. The test loader now executes the real `server_utils.py` with isolated unrelated dependencies and no `builtins.Any/List` mutation.