### PR TITLE
fix(server): provide multi-agent stream callback

### DIFF
--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -9,6 +9,7 @@ from typing import Awaitable, Dict, List, Any
 from fastapi.responses import JSONResponse, FileResponse
 from gpt_researcher.document.document import DocumentLoader
 from gpt_researcher import GPTResearcher
+from gpt_researcher.actions import stream_output
 from utils import write_md_to_pdf, write_md_to_word, write_text_to_md
 from pathlib import Path
 from datetime import datetime

--- a/tests/backend/test_multi_agent_stream_output.py
+++ b/tests/backend/test_multi_agent_stream_output.py
@@ -1,0 +1,56 @@
+import builtins
+import importlib
+import sys
+import types
+import typing
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _load_server_utils():
+    utils_module = types.ModuleType("utils")
+    utils_module.write_md_to_pdf = lambda *args, **kwargs: None
+    utils_module.write_md_to_word = lambda *args, **kwargs: None
+    utils_module.write_text_to_md = lambda *args, **kwargs: None
+
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+        patch.dict(sys.modules, {"utils": utils_module}),
+    ):
+        return importlib.import_module("backend.server.server_utils")
+
+
+server_utils = _load_server_utils()
+
+
+class MultiAgentStreamOutputTests(unittest.IsolatedAsyncioTestCase):
+    async def test_execute_multi_agents_passes_stream_output_callback(self):
+        websocket = object()
+        manager = SimpleNamespace(active_connections=[websocket])
+        received = {}
+
+        async def run_multi_agent_task(query, active_websocket, output_callback):
+            received.update(
+                query=query,
+                websocket=active_websocket,
+                output_callback=output_callback,
+            )
+            return "research report"
+
+        with patch.object(
+            server_utils,
+            "run_multi_agent_task",
+            run_multi_agent_task,
+        ):
+            result = await server_utils.execute_multi_agents(manager)
+
+        self.assertEqual(result, {"report": "research report"})
+        self.assertEqual(received["query"], "Is AI in a hype cycle?")
+        self.assertIs(received["websocket"], websocket)
+        self.assertTrue(callable(received["output_callback"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backend/test_multi_agent_stream_output.py
+++ b/tests/backend/test_multi_agent_stream_output.py
@@ -1,25 +1,61 @@
-import builtins
-import importlib
+import importlib.util
 import sys
 import types
-import typing
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 
+async def expected_stream_output(*args, **kwargs):
+    pass
+
+
 def _load_server_utils():
+    gpt_researcher = types.ModuleType("gpt_researcher")
+    gpt_researcher.__path__ = []
+    gpt_researcher.GPTResearcher = object
+
+    document_package = types.ModuleType("gpt_researcher.document")
+    document_package.__path__ = []
+    document_module = types.ModuleType("gpt_researcher.document.document")
+    document_module.DocumentLoader = object
+
+    actions_module = types.ModuleType("gpt_researcher.actions")
+    actions_module.stream_output = expected_stream_output
+
     utils_module = types.ModuleType("utils")
     utils_module.write_md_to_pdf = lambda *args, **kwargs: None
     utils_module.write_md_to_word = lambda *args, **kwargs: None
     utils_module.write_text_to_md = lambda *args, **kwargs: None
 
-    with (
-        patch.object(builtins, "Any", typing.Any, create=True),
-        patch.object(builtins, "List", typing.List, create=True),
-        patch.dict(sys.modules, {"utils": utils_module}),
-    ):
-        return importlib.import_module("backend.server.server_utils")
+    runner_module = types.ModuleType("backend.server.multi_agent_runner")
+    runner_module.run_multi_agent_task = None
+
+    chat_package = types.ModuleType("chat")
+    chat_package.__path__ = []
+    chat_module = types.ModuleType("chat.chat")
+    chat_module.ChatAgentWithMemory = object
+
+    module_path = Path(__file__).resolve().parents[2] / "backend/server/server_utils.py"
+    spec = importlib.util.spec_from_file_location(
+        "backend.server._server_utils_stream_test",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    dependencies = {
+        "gpt_researcher": gpt_researcher,
+        "gpt_researcher.document": document_package,
+        "gpt_researcher.document.document": document_module,
+        "gpt_researcher.actions": actions_module,
+        "utils": utils_module,
+        "backend.server.multi_agent_runner": runner_module,
+        "chat": chat_package,
+        "chat.chat": chat_module,
+    }
+    with patch.dict(sys.modules, dependencies):
+        spec.loader.exec_module(module)
+    return module
 
 
 server_utils = _load_server_utils()
@@ -49,7 +85,8 @@ class MultiAgentStreamOutputTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, {"report": "research report"})
         self.assertEqual(received["query"], "Is AI in a hype cycle?")
         self.assertIs(received["websocket"], websocket)
-        self.assertTrue(callable(received["output_callback"]))
+        self.assertIs(server_utils.stream_output, expected_stream_output)
+        self.assertIs(received["output_callback"], expected_stream_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Provide the shared streaming callback to the backend multi-agent endpoint.

## Problem

`execute_multi_agents()` passed `stream_output` to `run_multi_agent_task()`, but
`backend/server/server_utils.py` never imported that name. When the endpoint
found an active WebSocket, Python raised before the runner was invoked:

```text
NameError: name 'stream_output' is not defined
```

The sibling WebSocket manager already imports the same callback from
`gpt_researcher.actions`, and both supported multi-agent runners accept it as
their third argument.

## Changes

- Import the shared `stream_output` callback from `gpt_researcher.actions`.
- Add an isolated regression test that supplies an active WebSocket and verifies
  the runner receives a callable output callback.

## Verification

Before:

```text
PYTHONPATH=.:backend uv run --frozen python \
  tests/backend/test_multi_agent_stream_output.py -v

test_execute_multi_agents_passes_stream_output_callback ... ERROR
NameError: name 'stream_output' is not defined
```

After:

```text
PYTHONPATH=.:backend uv run --frozen python \
  tests/backend/test_multi_agent_stream_output.py -v

test_execute_multi_agents_passes_stream_output_callback ... ok
Ran 1 test
OK
```

Additional checks:

```text
PYTHONPATH=.:backend uv run --with pytest --with pytest-asyncio \
  pytest tests/backend/test_multi_agent_stream_output.py -q
1 passed

uv run --with ruff ruff check \
  backend/server/server_utils.py \
  tests/backend/test_multi_agent_stream_output.py \
  --select F821
All checks passed

uv run --frozen python -m compileall -q \
  backend/server/server_utils.py \
  tests/backend/test_multi_agent_stream_output.py
```

## Duplicate Check

All 131 open PR titles, bodies, and changed files were checked immediately
before publishing. Same-file PRs cover upload-directory creation, WebSocket log
handler reuse, custom writing instructions, or disconnect handling. None
imports or supplies this missing callback.

## Impact

- **Breaking change:** No
- **Affected area:** `/api/multi_agents` with an active WebSocket
- **No active WebSocket:** Existing 400 response is unchanged
- **Network, LLM, and multi-agent execution in tests:** None

## Checklist

- [x] The regression test fails before and passes after the fix.
- [x] The runner receives the established shared callback.
- [x] Targeted static and compile checks pass.
- [x] The PR is limited to the missing import and its test.

## Re-verification (2026-08-11)

Re-audited against `main` at `5d84d2f` through `execute_multi_agents()`. With an active WebSocket, `main` raises `NameError: stream_output is not defined`. This branch imports `gpt_researcher.actions.stream_output`; the strengthened regression test verifies by object identity that this exact imported callback is forwarded to `run_multi_agent_task`, avoiding same-name helper ambiguity.