### PR TITLE
fix(deep-research): initialize empty-query results

### DIFF
--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -393,6 +393,12 @@ Return ONLY a JSON object using this exact schema:
         if visited_urls is None:
             visited_urls = set()
 
+        all_learnings = learnings.copy()
+        all_citations = citations.copy()
+        all_visited_urls = visited_urls.copy()
+        all_context = []
+        all_sources = []
+
         progress = ResearchProgress(depth, breadth)
 
         if on_progress:
@@ -412,12 +418,6 @@ Return ONLY a JSON object using this exact schema:
                 'context': all_context,
                 'sources': all_sources,
             }
-
-        all_learnings = learnings.copy()
-        all_citations = citations.copy()
-        all_visited_urls = visited_urls.copy()
-        all_context = []
-        all_sources = []
 
         # Process queries with concurrency limit
         semaphore = asyncio.Semaphore(self.concurrency_limit)

--- a/tests/skills/test_deep_research_empty_results.py
+++ b/tests/skills/test_deep_research_empty_results.py
@@ -10,6 +10,29 @@ from gpt_researcher.skills.deep_research import DeepResearchSkill
 
 
 @pytest.mark.asyncio
+async def test_stops_when_no_search_queries_are_generated():
+    skill = DeepResearchSkill.__new__(DeepResearchSkill)
+    skill.generate_search_queries = AsyncMock(return_value=[])
+
+    result = await skill.deep_research(
+        query="topic",
+        breadth=2,
+        depth=3,
+        learnings=["existing learning"],
+        citations={"existing learning": "https://example.com/source"},
+        visited_urls={"https://example.com/source"},
+    )
+
+    assert result == {
+        "learnings": ["existing learning"],
+        "visited_urls": {"https://example.com/source"},
+        "citations": {"existing learning": "https://example.com/source"},
+        "context": [],
+        "sources": [],
+    }
+
+
+@pytest.mark.asyncio
 async def test_stops_when_all_query_processors_return_none():
     researcher = SimpleNamespace(
         cfg=SimpleNamespace(


### PR DESCRIPTION
## Summary

Initialize deep-research aggregation state before the zero-query early return.

## Problem

The guard added for an empty search-query plan returned `all_learnings`,
`all_visited_urls`, `all_citations`, `all_context`, and `all_sources`. Those
variables were initialized immediately after the guard, so generating zero
queries raised instead of stopping cleanly:

```text
UnboundLocalError: cannot access local variable 'all_learnings'
where it is not associated with a value
```

This also prevented the early return from preserving learnings, citations, and
visited URLs supplied by a recursive caller.

## Changes

- Move the existing five aggregation initializers before query generation.
- Add a regression test for an empty generated-query list.
- Verify the early return preserves existing inputs and returns empty context
  and source collections.

## Verification

Before:

```text
test_stops_when_no_search_queries_are_generated ... FAILED
UnboundLocalError: cannot access local variable 'all_learnings'
```

After:

```text
tests/skills/test_deep_research_empty_results.py ..   2 passed
tests/test_deep_research_parsing.py ................. 25 passed
27 passed
```

The tests were run with a process-local `Any`/`List` compatibility bootstrap
for the unrelated current-main import regression tracked by #1981; no source
workaround is included in this PR.

Additional checks:

```text
uv run --with ruff ruff check \
  gpt_researcher/skills/deep_research.py \
  tests/skills/test_deep_research_empty_results.py \
  --select F821
All checks passed

uv run --frozen python -m compileall -q \
  gpt_researcher/skills/deep_research.py \
  tests/skills/test_deep_research_empty_results.py
```

## Duplicate Check

All 132 open PR titles, bodies, and changed files were checked immediately
before publishing. Same-file PRs #1925, #1782, and #1671 address LLM keyword
arguments, budget safeguards, and checkpoint persistence respectively. None
changes the zero-query early return or aggregation initialization.

## Impact

- **Breaking change:** No
- **Affected area:** Deep research when query planning returns no queries
- **Normal and recursive query processing:** Existing aggregation objects and
  control flow are unchanged
- **Network and LLM calls in the regression test:** None

## Checklist

- [x] The regression test fails before and passes after the fix.
- [x] Existing empty-result and parsing tests pass.
- [x] Undefined-name and compile checks pass.
- [x] The change is limited to initialization order and its regression test.

## Re-verification (2026-08-11)

Re-audited against `main` at `5d84d2f` through the production `DeepResearchSkill.deep_research()` entry point. A zero-query result raises `UnboundLocalError` on `main`; this branch preserves the supplied learnings, citations, and visited URLs. The focused and adjacent parsing suites pass: 27 tests total. The existing implementation required no further code changes.