### PR TITLE
Retriever hardening: sort validation and SearXNG timeout

### DIFF
--- a/gpt_researcher/retrievers/arxiv/arxiv.py
+++ b/gpt_researcher/retrievers/arxiv/arxiv.py
@@ -8,7 +8,8 @@ class ArxivSearch:
     def __init__(self, query, sort='Relevance', query_domains=None):
         self.arxiv = arxiv
         self.query = query
-        assert sort in ['Relevance', 'SubmittedDate'], "Invalid sort criterion"
+        if sort not in ['Relevance', 'SubmittedDate']:
+            raise ValueError("Invalid sort criterion")
         self.sort = arxiv.SortCriterion.SubmittedDate if sort == 'SubmittedDate' else arxiv.SortCriterion.Relevance
         
 

--- a/gpt_researcher/retrievers/openalex/openalex.py
+++ b/gpt_researcher/retrievers/openalex/openalex.py
@@ -36,7 +36,8 @@ class OpenAlexSearch:
         :param sort: Sort criterion. One of VALID_SORT_CRITERIA.
         """
         self.query = query
-        assert sort in self.VALID_SORT_CRITERIA, f"Invalid sort criterion: {sort}"
+        if sort not in self.VALID_SORT_CRITERIA:
+            raise ValueError(f"Invalid sort criterion: {sort}")
         self.sort = sort
         self.email: Optional[str] = os.environ.get("OPENALEX_EMAIL")
         self.api_key: Optional[str] = os.environ.get("OPENALEX_API_KEY")

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -57,7 +57,8 @@ class SearxSearch():
             response = requests.get(
                 search_url,
                 params=params,
-                headers={'Accept': 'application/json'}
+                headers={'Accept': 'application/json'},
+                timeout=(5, 30),
             )
             response.raise_for_status()
             results = response.json()

--- a/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
+++ b/gpt_researcher/retrievers/semantic_scholar/semantic_scholar.py
@@ -19,7 +19,8 @@ class SemanticScholarSearch:
         :param sort: Sort criterion ('relevance', 'citationCount', 'publicationDate')
         """
         self.query = query
-        assert sort in self.VALID_SORT_CRITERIA, "Invalid sort criterion"
+        if sort not in self.VALID_SORT_CRITERIA:
+            raise ValueError("Invalid sort criterion")
         # Preserve the exact (camelCase) criterion. The Semantic Scholar API
         # expects ``citationCount`` / ``publicationDate`` verbatim; lowercasing
         # them produced ``citationcount`` / ``publicationdate``, which the API

--- a/tests/test_retriever_sort_validation_optimized.py
+++ b/tests/test_retriever_sort_validation_optimized.py
@@ -1,0 +1,42 @@
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("gpt_researcher.retrievers.arxiv.arxiv", "ArxivSearch"),
+        (
+            "gpt_researcher.retrievers.semantic_scholar.semantic_scholar",
+            "SemanticScholarSearch",
+        ),
+        ("gpt_researcher.retrievers.openalex.openalex", "OpenAlexSearch"),
+    ],
+)
+def test_invalid_sort_rejected_under_optimized_python(module_name, class_name):
+    script = f"""
+import builtins
+import importlib
+import typing
+
+builtins.Any = typing.Any
+builtins.List = typing.List
+search_class = getattr(importlib.import_module({module_name!r}), {class_name!r})
+
+try:
+    search_class("query", sort="invalid")
+except ValueError:
+    pass
+else:
+    raise SystemExit("invalid sort was accepted")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_searx_timeout.py
+++ b/tests/test_searx_timeout.py
@@ -1,0 +1,52 @@
+import builtins
+import importlib
+import os
+import typing
+import unittest
+from unittest.mock import Mock, patch
+
+
+def _load_searx_class():
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+    ):
+        module = importlib.import_module(
+            "gpt_researcher.retrievers.searx.searx"
+        )
+    return module.SearxSearch
+
+
+SearxSearch = _load_searx_class()
+
+
+class SearxTimeoutTests(unittest.TestCase):
+    def test_search_bounds_connect_and_read_time(self):
+        response = Mock()
+        response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "content": "result",
+                }
+            ]
+        }
+
+        with (
+            patch.dict(os.environ, {"SEARX_URL": "https://search.example"}),
+            patch(
+                "gpt_researcher.retrievers.searx.searx.requests.get",
+                return_value=response,
+            ) as request,
+        ):
+            results = SearxSearch("query").search()
+
+        self.assertEqual(
+            results,
+            [{"href": "https://example.com", "body": "result"}],
+        )
+        self.assertEqual(request.call_args.kwargs["timeout"], (5, 30))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Consolidates two independent retriever reliability fixes into one small batch.
Both fixes remain separate commits.

Includes the original #2036 scope and supersedes #2042.

## Included fixes

- Replace removable `assert`-based sort validation in Arxiv, OpenAlex, and
  Semantic Scholar with explicit `ValueError` checks.
- Add explicit connect/read timeouts to SearXNG requests (refs #1764).

## Verification

- 17 focused and adjacent retriever tests passed.
- Production Ruff `S101`/`F821` checks passed.
- Test Ruff `F821` checks passed.
- Python 3.11 compile checks passed.
- `git diff --check` passed.

The test process supplies `Any`/`List` process-locally for the existing import
regression tracked by #1981. This batch does not modify that file.

## Impact

- Valid sort values and successful SearXNG response normalization are unchanged.
- Invalid sort values now fail consistently under normal and optimized Python.
- Unresponsive SearXNG endpoints now have bounded connect/read waits.

AI-assisted consolidation; every included behavior was revalidated locally.
