### PR TITLE
fix(scraper): clean interrupted PDF downloads

### DIFF
--- a/gpt_researcher/scraper/pymupdf/pymupdf.py
+++ b/gpt_researcher/scraper/pymupdf/pymupdf.py
@@ -41,32 +41,37 @@ class PyMuPDFScraper:
         """
         try:
             if self.is_url():
+                response = None
+                temp_filename = None
                 try:
-                    response = requests.get(self.link, timeout=(5, 30), stream=True)
-                    response.raise_for_status()
-                except requests.exceptions.SSLError:
-                    import logging
-                    logging.getLogger(__name__).warning(
-                        f"SSL verification failed for {self.link}, retrying without verification"
-                    )
-                    response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
-                    response.raise_for_status()
+                    try:
+                        response = requests.get(self.link, timeout=(5, 30), stream=True)
+                        response.raise_for_status()
+                    except requests.exceptions.SSLError:
+                        import logging
+                        if response is not None:
+                            response.close()
+                        logging.getLogger(__name__).warning(
+                            f"SSL verification failed for {self.link}, retrying without verification"
+                        )
+                        response = requests.get(self.link, timeout=(5, 30), stream=True, verify=False)
+                        response.raise_for_status()
 
-                with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
-                    temp_filename = temp_file.name  # Get the temporary file name
-                    for chunk in response.iter_content(chunk_size=8192):
-                        temp_file.write(chunk)  # Write the downloaded content to the temporary file
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
+                        temp_filename = temp_file.name  # Get the temporary file name
+                        for chunk in response.iter_content(chunk_size=8192):
+                            temp_file.write(chunk)  # Write the downloaded content to the temporary file
 
-                # Always clean up the downloaded temp file, even if loading fails
-                # (PyMuPDFLoader.load() can raise on a malformed/partial PDF).
-                try:
                     loader = PyMuPDFLoader(temp_filename)
                     doc = loader.load()
                 finally:
-                    try:
-                        os.remove(temp_filename)
-                    except OSError:
-                        pass
+                    if response is not None:
+                        response.close()
+                    if temp_filename is not None:
+                        try:
+                            os.remove(temp_filename)
+                        except OSError:
+                            pass
             else:
                 loader = PyMuPDFLoader(self.link)
                 doc = loader.load()

--- a/tests/test_pymupdf_tempfile_cleanup.py
+++ b/tests/test_pymupdf_tempfile_cleanup.py
@@ -17,11 +17,23 @@ from gpt_researcher.scraper.pymupdf.pymupdf import PyMuPDFScraper
 
 
 class _FakeResponse:
+    def __init__(self):
+        self.closed = False
+
     def raise_for_status(self):
         return None
 
     def iter_content(self, chunk_size=8192):
         yield b"%PDF-1.4 not-a-real-pdf"
+
+    def close(self):
+        self.closed = True
+
+
+class _InterruptedResponse(_FakeResponse):
+    def iter_content(self, chunk_size=8192):
+        yield b"%PDF-1.4 partial"
+        raise RuntimeError("connection interrupted")
 
 
 def _temp_pdfs() -> set:
@@ -33,12 +45,13 @@ def test_tempfile_removed_when_loader_raises():
 
     before = _temp_pdfs()
 
-    with patch(
-        "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
-        return_value=_FakeResponse(),
-    ), patch(
-        "gpt_researcher.scraper.pymupdf.pymupdf.PyMuPDFLoader"
-    ) as mock_loader:
+    with (
+        patch(
+            "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
+            return_value=_FakeResponse(),
+        ),
+        patch("gpt_researcher.scraper.pymupdf.pymupdf.PyMuPDFLoader") as mock_loader,
+    ):
         mock_loader.return_value.load.side_effect = RuntimeError("corrupt PDF")
 
         content, images, title = scraper.scrape()
@@ -46,5 +59,22 @@ def test_tempfile_removed_when_loader_raises():
     # Broad except still yields the empty-result contract...
     assert (content, images, title) == ("", [], "")
     # ...but no new *.pdf temp file is left behind.
+    leaked = _temp_pdfs() - before
+    assert not leaked, f"PyMuPDFScraper leaked temp file(s): {leaked}"
+
+
+def test_response_and_tempfile_cleaned_when_download_is_interrupted():
+    scraper = PyMuPDFScraper("https://example.com/interrupted.pdf")
+    response = _InterruptedResponse()
+    before = _temp_pdfs()
+
+    with patch(
+        "gpt_researcher.scraper.pymupdf.pymupdf.requests.get",
+        return_value=response,
+    ):
+        result = scraper.scrape()
+
+    assert result == ("", [], "")
+    assert response.closed
     leaked = _temp_pdfs() - before
     assert not leaked, f"PyMuPDFScraper leaked temp file(s): {leaked}"


### PR DESCRIPTION
## Summary

Close streamed PDF responses and remove partial temporary files on every remote
PyMuPDF download path.

## Problem

`PyMuPDFScraper` requested remote PDFs with `stream=True` but never closed the
`requests.Response`. Its temporary-file cleanup also began only after
`iter_content()` finished.

If the connection failed after writing one or more chunks, the broad exception
handler returned the normal empty result while silently leaving both resources:

- the streamed HTTP response/socket remained open;
- the partial `.pdf` remained in the system temporary directory.

HTTP-status and parser failures also left the response unclosed.

## Changes

- Track the response and temporary path across the complete remote-download
  lifecycle.
- Close the response in `finally`.
- Remove a partially created PDF even when streaming is interrupted.
- Close an initial response before the existing SSL fallback retry.
- Extend the existing temporary-file regression suite with an interrupted
  stream case.

## Verification

Before:

```text
tests/test_pymupdf_tempfile_cleanup.py .F
assert response.closed
1 failed, 1 passed
```

After:

```text
tests/test_pymupdf_tempfile_cleanup.py .. 2 passed
```

Adjacent scraper tests:

```text
tests/test_pymupdf_tempfile_cleanup.py .. 2 passed
tests/test_scraper_get_scraper.py ......  6 passed
tests/test_arxiv_scraper.py ..            2 passed
10 passed
```

The tests use a process-local `Any`/`List` compatibility bootstrap for the
unrelated current-main import regression tracked by #1981; no source workaround
is included here.

Additional checks:

```text
uv run --with ruff ruff check \
  gpt_researcher/scraper/pymupdf/pymupdf.py \
  tests/test_pymupdf_tempfile_cleanup.py \
  --select F821
All checks passed

uv run --frozen python -m compileall -q <changed files>
```

## Duplicate Check

All 134 open PR titles, bodies, and changed files were checked immediately
before publishing. PRs #2002 and #1849 change the HTTP client selection so a
configured session/User-Agent is used. Neither closes responses nor cleans
partial files when `iter_content()` fails. This change does not alter client
selection and can be composed with either PR.

## Impact

- **Breaking change:** No
- **Affected area:** Remote PDF download resource lifecycle
- **Successful/local PDF behavior:** Unchanged
- **Network calls in tests:** None

## Checklist

- [x] The interrupted-stream regression fails before and passes after.
- [x] Response and temporary-file cleanup are both asserted.
- [x] Adjacent scraper tests pass.
- [x] The PR does not duplicate session/User-Agent changes.
