### PR TITLE
fix(browser): isolate driver teardown failures

### DIFF
--- a/gpt_researcher/scraper/browser/browser.py
+++ b/gpt_researcher/scraper/browser/browser.py
@@ -70,7 +70,10 @@ class BrowserScraper:
             return "", [], ""
         finally:
             if self.driver:
-                self.driver.quit()
+                try:
+                    self.driver.quit()
+                except Exception as e:
+                    print(f"Failed to close browser driver: {str(e)}")
             self._cleanup_cookie_file()
 
     def _import_selenium(self):

--- a/tests/test_browser_teardown_cleanup.py
+++ b/tests/test_browser_teardown_cleanup.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from gpt_researcher.scraper.browser.browser import BrowserScraper
+
+
+class _FailingDriver:
+    def quit(self):
+        raise RuntimeError("browser already disconnected")
+
+
+def test_quit_failure_does_not_mask_result_or_skip_cookie_cleanup():
+    scraper = BrowserScraper.__new__(BrowserScraper)
+    scraper.url = "https://example.com"
+    scraper.driver = _FailingDriver()
+    scraper.setup_driver = Mock()
+    scraper._visit_google_and_save_cookies = Mock()
+    scraper._load_saved_cookies = Mock()
+    scraper._add_header = Mock()
+    scraper.scrape_text_with_selenium = Mock(
+        return_value=("page content", [], "Page title")
+    )
+    scraper._cleanup_cookie_file = Mock()
+
+    result = scraper.scrape()
+
+    assert result == ("page content", [], "Page title")
+    scraper._cleanup_cookie_file.assert_called_once_with()


### PR DESCRIPTION
## Summary

Prevent Selenium driver teardown failures from masking completed scrape results
or skipping cookie-file cleanup.

## Problem

`BrowserScraper.scrape()` returns empty content when setup or scraping fails,
but its `finally` block called `driver.quit()` without protection.

If a browser process was already disconnected and `quit()` raised:

- a successful scrape result was replaced by the teardown exception;
- `_cleanup_cookie_file()` was never called;
- callers lost the scraper's established tuple-return contract.

## Changes

- Isolate exceptions raised by `driver.quit()` during teardown.
- Continue to the existing cookie-file cleanup regardless of driver state.
- Add a no-Selenium regression test with a driver whose `quit()` fails after a
  successful scrape.

## Verification

Before:

```text
test_quit_failure_does_not_mask_result_or_skip_cookie_cleanup ... FAILED
RuntimeError: browser already disconnected
```

After:

```text
tests/test_browser_teardown_cleanup.py . 1 passed
```

Adjacent Browser URL-routing coverage:

```text
tests/test_browser_teardown_cleanup.py .  1 passed
tests/test_browser_pdf_detection.py ....... 7 passed
8 passed
```

The tests use a process-local `Any`/`List` compatibility bootstrap for the
unrelated current-main import regression tracked by #1981; no source workaround
is included here.

Additional checks:

```text
uv run --with ruff ruff check \
  gpt_researcher/scraper/browser/browser.py \
  tests/test_browser_teardown_cleanup.py \
  --select F821
All checks passed

uv run --frozen python -m compileall -q <changed files>
```

## Duplicate Check

All 135 open PR titles, bodies, and changed files were checked immediately
before publishing. No open PR modifies `browser.py`, isolates `driver.quit()`,
or preserves cookie cleanup after Selenium teardown errors.

## Impact

- **Breaking change:** No
- **Affected area:** Selenium browser teardown only
- **Successful scrape results:** Preserved when browser shutdown fails
- **Cookie cleanup:** Now always attempted after driver teardown
- **Real browser/network calls in tests:** None

## Checklist

- [x] The same teardown test fails before and passes after the fix.
- [x] Cookie cleanup is asserted.
- [x] Existing Browser PDF routing tests pass.
- [x] The change is limited to teardown isolation and its test.
