### PR TITLE
fix(logging): use unique research log files

### DIFF
--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from fastapi import HTTPException
 import logging
 import hashlib
+import uuid
 
 from .multi_agent_runner import run_multi_agent_task
 
@@ -35,7 +36,7 @@ class CustomLogsHandler:
     def __init__(self, websocket, task: str):
         self.logs = []
         self.websocket = websocket
-        sanitized_filename = sanitize_filename(f"task_{int(time.time())}_{task}")
+        sanitized_filename = sanitize_filename(f"task_{uuid.uuid4().hex}_{task}")
         self.log_file = os.path.join("outputs", f"{sanitized_filename}.json")
         self.timestamp = datetime.now().isoformat()
         # Initialize log file with metadata

--- a/tests/backend/test_log_file_uniqueness.py
+++ b/tests/backend/test_log_file_uniqueness.py
@@ -1,0 +1,58 @@
+import builtins
+import importlib
+import os
+import sys
+import tempfile
+import types
+import typing
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+
+def _load_server_utils():
+    utils_module = types.ModuleType("utils")
+    utils_module.write_md_to_pdf = lambda *args, **kwargs: None
+    utils_module.write_md_to_word = lambda *args, **kwargs: None
+    utils_module.write_text_to_md = lambda *args, **kwargs: None
+
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+        patch.dict(sys.modules, {"utils": utils_module}),
+    ):
+        return importlib.import_module("backend.server.server_utils")
+
+
+server_utils = _load_server_utils()
+
+
+class LogFileUniquenessTests(unittest.TestCase):
+    def test_same_task_in_same_second_uses_distinct_log_files(self):
+        fake_uuid = SimpleNamespace(
+            uuid4=Mock(
+                side_effect=[
+                    SimpleNamespace(hex="a" * 32),
+                    SimpleNamespace(hex="b" * 32),
+                ]
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            previous_cwd = os.getcwd()
+            os.chdir(temp_dir)
+            try:
+                with (
+                    patch.object(server_utils.time, "time", return_value=1000),
+                    patch.object(server_utils, "uuid", fake_uuid, create=True),
+                ):
+                    first = server_utils.CustomLogsHandler(None, "same task")
+                    second = server_utils.CustomLogsHandler(None, "same task")
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertNotEqual(first.log_file, second.log_file)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Give every `CustomLogsHandler` its own JSON log file, including concurrent runs
of the same task.

## Problem

The handler filename used only the current second and a deterministic hash of
the task:

```text
task_<epoch-second>_<task-hash>.json
```

Two identical research tasks started during the same second therefore opened
the same file. Each constructor writes a fresh empty JSON structure, so the
second run immediately truncated the first run's query and events.

## Changes

- Use a UUID component when creating each handler's filename.
- Keep the existing task hash and ISO timestamp stored inside the JSON.
- Add an isolated regression test that creates two same-task handlers in the
  same second and verifies distinct paths.

## Verification

Before:

```text
AssertionError:
'outputs/task_1000_b2e8c76cb9.json'
==
'outputs/task_1000_b2e8c76cb9.json'
```

After:

```text
tests/backend/test_log_file_uniqueness.py ... OK
tests/test_logging.py .. 2 passed
```

Additional checks:

```text
uv run --frozen python -m compileall -q \
  backend/server/server_utils.py \
  tests/backend/test_log_file_uniqueness.py

uv run --with black black --check --fast --target-version py311 \
  tests/backend/test_log_file_uniqueness.py
```

The direct combined pytest collection encountered an unrelated Pydantic/Spacy
module-reload error, so the isolated regression and existing logging suite were
run in separate clean processes. Both pass.

## Duplicate Check

All 136 open PR titles, bodies, and changed files were checked immediately
before publishing. Same-file PRs cover upload-directory creation, stream
callback wiring, log-handler reuse, writing instructions, or disconnect
handling. None changes log filename uniqueness.

## Impact

- **Breaking change:** No
- **Affected area:** JSON research log filenames
- **Concurrent identical tasks:** No longer overwrite one another
- **Log schema and timestamp content:** Unchanged

## Checklist

- [x] The collision test fails before and passes after the fix.
- [x] Existing log read/write tests pass.
- [x] No network or LLM calls are made by the tests.
- [x] The PR is limited to handler filename generation and its test.
