### PR TITLE
fix(deep-research): restore Python 3.11 example syntax

### DIFF
--- a/backend/report_type/deep_research/example.py
+++ b/backend/report_type/deep_research/example.py
@@ -284,10 +284,14 @@ class DeepResearch:
         answers = ["Automatically proceeding with research"] * len(follow_up_questions)
 
         # Combine query and Q&A
+        follow_up_qa = " ".join(
+            f"Q: {question}\nA: {answer}"
+            for question, answer in zip(follow_up_questions, answers)
+        )
         combined_query = f"""
         Initial Query: {self.query}
         Follow-up Questions and Answers:
-        {' '.join([f'Q: {q}\nA: {a}' for q, a in zip(follow_up_questions, answers)])}
+        {follow_up_qa}
         """
 
         # Run deep research


### PR DESCRIPTION
## Summary

Restore Python 3.11 compatibility for the standalone deep-research example.

## Problem

The project declares Python 3.11 support, but the example placed a newline
escape inside a nested f-string expression. Python 3.11 rejects that syntax:

```text
SyntaxError: f-string expression part cannot include a backslash
```

## Regression lineage

- PR #1352 fixed this exact Python 3.11 incompatibility and was approved and
  merged by the maintainer.
- Commit `08fd99ba` later removed the precomputed Q&A variable and reintroduced
  the nested f-string expression.
- `pyproject.toml` and `setup.py` both declare Python `>=3.11`; the package
  classifiers also list Python 3.11.

## Changes

- Build the follow-up question/answer text before interpolating it.
- Preserve the generated prompt content and runtime behavior.

## Verification

Before:

```text
uv run --python 3.11 python -m py_compile backend/report_type/deep_research/example.py
SyntaxError: f-string expression part cannot include a backslash
```

After:

```text
uv run --python 3.11 python -m py_compile backend/report_type/deep_research/example.py
uv run --python 3.12 python -m py_compile backend/report_type/deep_research/example.py
uvx ruff check backend/report_type/deep_research/example.py --select F821
```

All commands pass. A direct equivalence check also confirms that the generated
question-and-answer text is unchanged.

## Impact

- Breaking change: No
- Affected area: standalone deep-research backend example
- Runtime prompt content: unchanged

## Re-verification (2026-08-11)

Re-audited against `main` at `5d84d2f`. The same Python 3.11 compile command still fails on `main` with `SyntaxError: f-string expression part cannot include a backslash`; this branch compiles under Python 3.11 and 3.12 and passes Ruff `F821`. The existing implementation required no further code changes.