### PR TITLE
fix(costs): schedule asynchronous cost log events

### DIFF
--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -164,6 +164,7 @@ class GPTResearcher:
         self.headers = headers or {}
         self.research_costs = 0.0
         self.step_costs: dict[str, float] = {}
+        self._background_tasks: set[asyncio.Task] = set()
         self._current_step: str = "general"
         self.log_handler = log_handler
         self.prompt_family = get_prompt_family(prompt_family or self.cfg.prompt_family, self.cfg)
@@ -787,8 +788,20 @@ class GPTResearcher:
         step = self._current_step
         self.step_costs[step] = self.step_costs.get(step, 0.0) + cost
         if self.log_handler:
-            self._log_event("research", step="cost_update", details={
-                "cost": cost,
-                "total_cost": self.research_costs,
-                "step_name": step,
-            })
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return
+            task = loop.create_task(
+                self._log_event(
+                    "research",
+                    step="cost_update",
+                    details={
+                        "cost": cost,
+                        "total_cost": self.research_costs,
+                        "step_name": step,
+                    },
+                )
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)

--- a/tests/test_cost_logging.py
+++ b/tests/test_cost_logging.py
@@ -1,0 +1,61 @@
+import asyncio
+import builtins
+import importlib
+import typing
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+def _load_researcher_class():
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+    ):
+        return importlib.import_module("gpt_researcher.agent").GPTResearcher
+
+
+GPTResearcher = _load_researcher_class()
+
+
+class CostLoggingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_add_costs_schedules_cost_update_log(self):
+        researcher = GPTResearcher.__new__(GPTResearcher)
+        researcher.research_costs = 0.0
+        researcher.step_costs = {}
+        researcher._background_tasks = set()
+        researcher._current_step = "research"
+        researcher.log_handler = AsyncMock()
+
+        researcher.add_costs(0.25)
+        await asyncio.sleep(0)
+
+        self.assertEqual(researcher.research_costs, 0.25)
+        self.assertEqual(researcher.step_costs, {"research": 0.25})
+        researcher.log_handler.on_research_step.assert_awaited_once_with(
+            "cost_update",
+            {
+                "cost": 0.25,
+                "total_cost": 0.25,
+                "step_name": "research",
+            },
+        )
+
+
+class SynchronousCostLoggingTests(unittest.TestCase):
+    def test_add_costs_without_running_loop_still_accumulates(self):
+        researcher = GPTResearcher.__new__(GPTResearcher)
+        researcher.research_costs = 0.0
+        researcher.step_costs = {}
+        researcher._background_tasks = set()
+        researcher._current_step = "research"
+        researcher.log_handler = AsyncMock()
+
+        researcher.add_costs(0.25)
+
+        self.assertEqual(researcher.research_costs, 0.25)
+        self.assertEqual(researcher.step_costs, {"research": 0.25})
+        researcher.log_handler.on_research_step.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Deliver structured cost updates from the synchronous cost callback without
creating an unawaited coroutine.

## Problem

`GPTResearcher.add_costs()` called the asynchronous `_log_event()` helper
without awaiting or scheduling it. With structured logging enabled this caused:

```text
RuntimeWarning: coroutine 'GPTResearcher._log_event' was never awaited
```

The cost totals were updated, but `on_research_step("cost_update", ...)` was
never called.

## Changes

- Schedule cost log events on the active event loop.
- Retain background task references until each event completes.
- Preserve synchronous cost accumulation when no event loop is running.
- Add regression coverage for asynchronous and synchronous callers.

## Verification

Before:

```text
RuntimeWarning: coroutine 'GPTResearcher._log_event' was never awaited
Expected on_research_step to have been awaited once. Awaited 0 times.
```

After:

```text
uv run --python 3.11 python -m unittest tests.test_cost_logging -v
Ran 2 tests in 0.010s
OK

uvx ruff check gpt_researcher/agent.py tests/test_cost_logging.py \
  --select F821,RUF006
All checks passed!
```

The broader existing cost test module is currently blocked during collection
by the unrelated missing `Any`/`List` imports tracked in #1981 and PR #1988.

## Impact

- Breaking change: No
- Cost callback signature: unchanged
- Cost totals and per-step accounting: unchanged
- Structured cost events: now delivered
