### PR TITLE
fix(searx): bound search request duration

### DIFF
--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -57,7 +57,8 @@ class SearxSearch():
             response = requests.get(
                 search_url,
                 params=params,
-                headers={'Accept': 'application/json'}
+                headers={'Accept': 'application/json'},
+                timeout=(5, 30),
             )
             response.raise_for_status()
             results = response.json()

--- a/tests/test_searx_timeout.py
+++ b/tests/test_searx_timeout.py
@@ -1,0 +1,52 @@
+import builtins
+import importlib
+import os
+import typing
+import unittest
+from unittest.mock import Mock, patch
+
+
+def _load_searx_class():
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+    ):
+        module = importlib.import_module(
+            "gpt_researcher.retrievers.searx.searx"
+        )
+    return module.SearxSearch
+
+
+SearxSearch = _load_searx_class()
+
+
+class SearxTimeoutTests(unittest.TestCase):
+    def test_search_bounds_connect_and_read_time(self):
+        response = Mock()
+        response.json.return_value = {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "content": "result",
+                }
+            ]
+        }
+
+        with (
+            patch.dict(os.environ, {"SEARX_URL": "https://search.example"}),
+            patch(
+                "gpt_researcher.retrievers.searx.searx.requests.get",
+                return_value=response,
+            ) as request,
+        ):
+            results = SearxSearch("query").search()
+
+        self.assertEqual(
+            results,
+            [{"href": "https://example.com", "body": "result"}],
+        )
+        self.assertEqual(request.call_args.kwargs["timeout"], (5, 30))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Bound SearXNG search requests with explicit connect and read timeouts.

Refs #1764.

## Problem

`SearxSearch.search()` called `requests.get()` without a timeout. If a local or
remote SearXNG instance accepted the connection but stopped responding, the
research run could wait indefinitely. Issue #1764 specifically requests
timeouts around external search calls after intermittent stuck runs.

## Changes

- Apply a 5-second connection timeout and 30-second read timeout.
- Add a regression test that verifies the request boundary and unchanged result
  normalization.

This PR does not add retry policy or change other retrievers.

## Verification

Before:

```text
KeyError: 'timeout'
```

The mocked SearXNG call had no request timeout.

After:

```text
uv run --python 3.11 python -m unittest tests.test_searx_timeout -v
Ran 1 test
OK

uv run --python 3.11 --with pytest python -m pytest \
  tests/test_searx_malformed_results.py -q
2 passed

uvx ruff check gpt_researcher/retrievers/searx/searx.py \
  tests/test_searx_timeout.py --select F821
All checks passed!
```

## Impact

- Breaking change: No
- Affected integration: SearXNG
- Successful response handling: unchanged
- Unresponsive endpoint behavior: now fails within a bounded interval
