### PR TITLE
fix(llm): normalize structured content blocks

### DIFF
--- a/gpt_researcher/llm_provider/generic/base.py
+++ b/gpt_researcher/llm_provider/generic/base.py
@@ -113,6 +113,24 @@ class ChatLogger:
                     "stacktrace": traceback.format_exc()
                 }) + "\n")
 
+
+def _content_to_text(content: Any) -> str:
+    """Normalize LangChain message content into plain text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "".join(parts)
+    return str(content)
+
+
 class GenericLLMProvider:
 
     def __init__(self, llm, chat_log: str | None = None,  verbose: bool = True):
@@ -360,7 +378,7 @@ class GenericLLMProvider:
             output = await self.llm.ainvoke(messages, **kwargs)
             self._capture_response_metadata(output)
 
-            res = output.content
+            res = _content_to_text(output.content)
 
         else:
             res = await self.stream_response(messages, websocket, **kwargs)
@@ -378,7 +396,7 @@ class GenericLLMProvider:
         # Streaming the response using the chain astream method from langchain
         async for chunk in self.llm.astream(messages, **kwargs):
             self._capture_response_metadata(chunk)
-            content = chunk.content
+            content = _content_to_text(chunk.content)
             if not content:
                 continue
             response += content

--- a/tests/test_llm_content_blocks.py
+++ b/tests/test_llm_content_blocks.py
@@ -1,0 +1,71 @@
+import asyncio
+import builtins
+import importlib
+import typing
+import unittest
+from unittest.mock import patch
+
+
+def _load_provider_class():
+    with (
+        patch.object(builtins, "Any", typing.Any, create=True),
+        patch.object(builtins, "List", typing.List, create=True),
+    ):
+        module = importlib.import_module(
+            "gpt_researcher.llm_provider.generic.base"
+        )
+    return module.GenericLLMProvider
+
+
+GenericLLMProvider = _load_provider_class()
+
+
+class _Message:
+    def __init__(self, content):
+        self.content = content
+        self.usage_metadata = None
+        self.response_metadata = {}
+
+
+class _BlockContentLLM:
+    async def ainvoke(self, messages, **kwargs):
+        return _Message(
+            [
+                {"type": "text", "text": "Hello"},
+                {"type": "metadata", "value": "ignored"},
+                " world",
+            ]
+        )
+
+    async def astream(self, messages, **kwargs):
+        yield _Message([{"type": "text", "text": "Hello"}])
+        yield _Message(["\n", {"type": "text", "text": "world"}])
+
+
+class LLMContentBlockTests(unittest.TestCase):
+    def test_non_streaming_content_blocks_return_text(self):
+        provider = GenericLLMProvider(_BlockContentLLM(), verbose=False)
+
+        response = asyncio.run(
+            provider.get_chat_response(
+                [{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+        )
+
+        self.assertEqual(response, "Hello world")
+
+    def test_streaming_content_blocks_are_joined(self):
+        provider = GenericLLMProvider(_BlockContentLLM(), verbose=False)
+
+        response = asyncio.run(
+            provider.stream_response(
+                [{"role": "user", "content": "hi"}],
+            )
+        )
+
+        self.assertEqual(response, "Hello\nworld")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Normalize LangChain structured message content into plain text in both
streaming and non-streaming LLM paths.

Refs #1628.

## Problem

LangChain messages may expose `content` as either a string or a list of string
and dictionary blocks. The provider returned the list unchanged for
non-streaming calls and attempted to concatenate it to a string while
streaming:

```text
TypeError: can only concatenate str (not "list") to str
```

## Changes

- Normalize string and block-list content through one helper.
- Join string blocks and dictionary blocks containing text.
- Ignore non-text metadata/tool blocks.
- Apply the same behavior to streaming and non-streaming responses.

## Verification

Before:

```text
test_non_streaming_content_blocks_return_text ... FAIL
test_streaming_content_blocks_are_joined ... ERROR
TypeError: can only concatenate str (not "list") to str
```

After:

```text
uv run --python 3.11 python -m unittest tests.test_llm_content_blocks -v
Ran 2 tests
OK

uvx ruff check gpt_researcher/llm_provider/generic/base.py \
  tests/test_llm_content_blocks.py --select F821
All checks passed!
```

The adjacent usage-tracking test is currently blocked during collection by the
unrelated missing `Any`/`List` imports tracked in #1981 and PR #1988.

## Impact

- Breaking change: No
- Existing string responses: unchanged
- Structured text responses: returned as plain text
- Non-text content blocks: omitted from report text
