### PR TITLE
fix(document): offload synchronous parser work

### DIFF
--- a/gpt_researcher/document/document.py
+++ b/gpt_researcher/document/document.py
@@ -80,7 +80,7 @@ class DocumentLoader:
             loader = loader_dict.get(file_extension, None)
             if loader:
                 try:
-                    ret_data = loader.load()
+                    ret_data = await asyncio.to_thread(loader.load)
                 except Exception as e:
                     print(f"Failed to load HTML document : {file_path}")
                     print(e)

--- a/gpt_researcher/document/online_document.py
+++ b/gpt_researcher/document/online_document.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import aiohttp
 import tempfile
@@ -76,7 +77,7 @@ class OnlineDocumentLoader:
 
             loader = loader_dict.get(file_extension, None)
             if loader:
-                ret_data = loader.load()
+                ret_data = await asyncio.to_thread(loader.load)
 
         except Exception as e:
             print(f"Failed to load document : {file_path}")

--- a/tests/test_document_loader_offload.py
+++ b/tests/test_document_loader_offload.py
@@ -1,0 +1,103 @@
+import asyncio
+import importlib.util
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name, relative_path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+document_module = _load_module(
+    "document_loader_offload_testmod",
+    "gpt_researcher/document/document.py",
+)
+online_module = _load_module(
+    "online_document_loader_offload_testmod",
+    "gpt_researcher/document/online_document.py",
+)
+
+
+class _Page:
+    page_content = "content"
+    metadata = {"source": "source.txt"}
+
+
+class _SlowLoader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def load(self):
+        time.sleep(0.05)
+        return [_Page()]
+
+
+LOADER_NAMES = (
+    "PyMuPDFLoader",
+    "TextLoader",
+    "UnstructuredCSVLoader",
+    "UnstructuredExcelLoader",
+    "UnstructuredMarkdownLoader",
+    "UnstructuredPowerPointLoader",
+    "UnstructuredWordDocumentLoader",
+)
+
+
+async def _heartbeat_completes_while_loading(load):
+    heartbeat_ran = False
+
+    async def heartbeat():
+        nonlocal heartbeat_ran
+        await asyncio.sleep(0.01)
+        heartbeat_ran = True
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await load()
+    completed_during_load = heartbeat_ran
+    await heartbeat_task
+    return completed_during_load
+
+
+class DocumentLoaderOffloadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_local_document_parsing_keeps_event_loop_responsive(self):
+        replacements = {name: _SlowLoader for name in LOADER_NAMES}
+        replacements["BSHTMLLoader"] = _SlowLoader
+        loader = document_module.DocumentLoader.__new__(
+            document_module.DocumentLoader
+        )
+
+        with patch.multiple(document_module, **replacements):
+            responsive = await _heartbeat_completes_while_loading(
+                lambda: loader._load_document("source.txt", "txt")
+            )
+
+        self.assertTrue(responsive)
+
+    async def test_online_document_parsing_keeps_event_loop_responsive(self):
+        replacements = {name: _SlowLoader for name in LOADER_NAMES}
+        loader = online_module.OnlineDocumentLoader.__new__(
+            online_module.OnlineDocumentLoader
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as file:
+            path = file.name
+
+        with patch.multiple(online_module, **replacements):
+            responsive = await _heartbeat_completes_while_loading(
+                lambda: loader._load_document(path, "txt")
+            )
+
+        self.assertTrue(responsive)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Move synchronous LangChain document parsing off the asyncio event loop for
both local and downloaded documents.

## Problem

`DocumentLoader._load_document()` and
`OnlineDocumentLoader._load_document()` are asynchronous methods, but both
called the blocking `loader.load()` directly. PDF, Office, and HTML parsing can
therefore pause WebSocket handling and unrelated research tasks. The local
loader also uses `asyncio.gather()`, but the blocking calls prevented those
tasks from making concurrent progress.

## Changes

- Run local document parser calls with `asyncio.to_thread()`.
- Apply the same offload to downloaded document parsing.
- Preserve loader selection, errors, return values, and temporary-file cleanup.
- Add heartbeat regressions for both paths.

## Verification

Before:

```text
test_local_document_parsing_keeps_event_loop_responsive ... FAIL
test_online_document_parsing_keeps_event_loop_responsive ... FAIL
```

After:

```text
uv run --python 3.11 python -m unittest \
  tests.test_document_loader_offload -v
Ran 2 tests
OK

uvx ruff check gpt_researcher/document/document.py \
  gpt_researcher/document/online_document.py \
  tests/test_document_loader_offload.py --select F821,ASYNC251
All checks passed!
```

The existing URL-extension test is currently blocked during collection by the
unrelated missing `Any`/`List` imports tracked in #1981 and PR #1988.

## Duplicate Check

Open document PRs cover metadata fallback, error text, URL extension parsing,
EPUB support, or URL security. None offloads parser execution.

## Impact

- Breaking change: No
- Loader outputs and cleanup: unchanged
- Event loop responsiveness: preserved during parser work
- Parsing execution: moved to the default thread pool
