### PR TITLE
fix(server): offload report store file I/O

### DIFF
--- a/backend/server/report_store.py
+++ b/backend/server/report_store.py
@@ -9,25 +9,31 @@ class ReportStore:
         self._path = path
         self._lock = asyncio.Lock()
 
-    async def _ensure_parent_dir(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-
     async def _read_all_unlocked(self) -> Dict[str, Dict[str, Any]]:
-        if not self._path.exists():
+        def read_all() -> Dict[str, Dict[str, Any]]:
+            if not self._path.exists():
+                return {}
+            try:
+                data = json.loads(self._path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return data  # type: ignore[return-value]
+            except Exception:
+                return {}
             return {}
-        try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                return data  # type: ignore[return-value]
-        except Exception:
-            return {}
-        return {}
+
+        return await asyncio.to_thread(read_all)
 
     async def _write_all_unlocked(self, data: Dict[str, Dict[str, Any]]) -> None:
-        await self._ensure_parent_dir()
-        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
-        tmp_path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-        tmp_path.replace(self._path)
+        def write_all() -> None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp_path.write_text(
+                json.dumps(data, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp_path.replace(self._path)
+
+        await asyncio.to_thread(write_all)
 
     async def list_reports(self, report_ids: List[str] | None = None) -> List[Dict[str, Any]]:
         async with self._lock:

--- a/tests/test_report_store_async_io.py
+++ b/tests/test_report_store_async_io.py
@@ -1,0 +1,80 @@
+import asyncio
+import importlib.util
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "report_store_async_io_testmod",
+    ROOT / "backend/server/report_store.py",
+)
+REPORT_STORE_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REPORT_STORE_MODULE)
+ReportStore = REPORT_STORE_MODULE.ReportStore
+
+
+async def _heartbeat_completes_while(operation):
+    heartbeat_ran = False
+
+    async def heartbeat():
+        nonlocal heartbeat_ran
+        await asyncio.sleep(0.01)
+        heartbeat_ran = True
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await operation()
+    completed_during_operation = heartbeat_ran
+    await heartbeat_task
+    return completed_during_operation
+
+
+class ReportStoreAsyncIOTests(unittest.IsolatedAsyncioTestCase):
+    async def test_read_does_not_block_event_loop(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "reports.json"
+            path.write_text(
+                json.dumps({"r1": {"id": "r1"}}),
+                encoding="utf-8",
+            )
+            store = ReportStore(path)
+            original_read_text = Path.read_text
+
+            def slow_read_text(file_path, *args, **kwargs):
+                time.sleep(0.05)
+                return original_read_text(file_path, *args, **kwargs)
+
+            with patch.object(Path, "read_text", slow_read_text):
+                responsive = await _heartbeat_completes_while(
+                    lambda: store.get_report("r1")
+                )
+
+        self.assertTrue(responsive)
+
+    async def test_write_does_not_block_event_loop(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "reports.json"
+            store = ReportStore(path)
+            original_write_text = Path.write_text
+
+            def slow_write_text(file_path, *args, **kwargs):
+                time.sleep(0.05)
+                return original_write_text(file_path, *args, **kwargs)
+
+            with patch.object(Path, "write_text", slow_write_text):
+                responsive = await _heartbeat_completes_while(
+                    lambda: store.upsert_report("r1", {"id": "r1"})
+                )
+
+            stored = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertTrue(responsive)
+        self.assertEqual(stored, {"r1": {"id": "r1"}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Move ReportStore JSON file operations off the asyncio event loop.

## Problem

The ReportStore API is asynchronous and is called directly by FastAPI routes,
but it performed synchronous `Path.read_text()`, JSON parsing/serialization,
`Path.write_text()`, and atomic replacement while holding its asyncio lock.
Large report histories or slow filesystems could therefore pause WebSocket and
HTTP handling for the entire event loop.

## Changes

- Offload the complete read and JSON parsing operation with
  `asyncio.to_thread()`.
- Offload directory creation, serialization, temporary write, and atomic
  replacement as one operation.
- Preserve the existing asyncio lock and atomic replacement behavior.
- Add heartbeat regressions for read and write paths.

## Verification

Before:

```text
test_read_does_not_block_event_loop ... FAIL
test_write_does_not_block_event_loop ... FAIL
```

After:

```text
uv run --python 3.11 python -m unittest \
  tests.test_report_store_async_io -v
Ran 2 tests
OK

uvx ruff check backend/server/report_store.py \
  tests/test_report_store_async_io.py --select F821,ASYNC251
All checks passed!
```

The tests use real temporary JSON files with delayed `Path` operations and do
not require the server or network.

## Impact

- Breaking change: No
- Report data format: unchanged
- Locking and atomic writes: preserved
- Event loop responsiveness: preserved during report store I/O
