### PR TITLE
feat: add Sciverse retriever for scientific literature full-text search

### DIFF
--- a/docs/docs/gpt-researcher/search-engines/search-engines.md
+++ b/docs/docs/gpt-researcher/search-engines/search-engines.md
@@ -46,6 +46,7 @@ Thanks to our community, we have integrated the following web search engines and
 - [Exa](https://docs.exa.ai/reference/getting-started) - Env: `RETRIEVER=exa`
 - [fastCRW](https://fastcrw.com/docs/rest-api) - Env: `RETRIEVER=crw`
 - [PubMedCentral](https://www.ncbi.nlm.nih.gov/home/develop/api/) - Env: `RETRIEVER=pubmed_central`
+- [Sciverse](https://sciverse.space) - Env: `RETRIEVER=sciverse` and `SCIVERSE_API_TOKEN`; optional `SCIVERSE_MODE=fast|balanced|quality`. Scientific literature search over paper full text — each result carries the retrieved passage as ready-to-use content.
 - [Xquik](https://xquik.com/) - Env: `RETRIEVER=xquik` and `XQUIK_API_KEY`
 - [MCP](../retrievers/mcp-configs) - Env: `RETRIEVER=mcp`
 

--- a/gpt_researcher/actions/retriever.py
+++ b/gpt_researcher/actions/retriever.py
@@ -30,6 +30,7 @@ def get_retriever(retriever: str):
         - semantic_scholar: Semantic Scholar academic search
         - pubmed_central: PubMed Central medical literature
         - openalex: OpenAlex scholarly works catalog
+        - sciverse: Sciverse scientific literature full-text search
         - custom: Custom user-defined retriever
         - mcp: Model Context Protocol retriever
         - xquik: Xquik X/Twitter search
@@ -116,6 +117,10 @@ def get_retriever(retriever: str):
             from gpt_researcher.retrievers import OpenAlexSearch
 
             return OpenAlexSearch
+        case "sciverse":
+            from gpt_researcher.retrievers import SciverseSearch
+
+            return SciverseSearch
         case "getxapi":
             from gpt_researcher.retrievers import GetXAPISearch
 

--- a/gpt_researcher/retrievers/__init__.py
+++ b/gpt_researcher/retrievers/__init__.py
@@ -19,6 +19,7 @@ from .mcp import MCPRetriever
 from .bocha.bocha import BoChaSearch
 from .xquik.xquik import XquikSearch
 from .openalex.openalex import OpenAlexSearch
+from .sciverse.sciverse import SciverseSearch
 
 __all__ = [
     "TavilySearch",
@@ -41,5 +42,6 @@ __all__ = [
     "MCPRetriever",
     "BoChaSearch",
     "XquikSearch",
-    "OpenAlexSearch"
+    "OpenAlexSearch",
+    "SciverseSearch"
 ]

--- a/gpt_researcher/retrievers/sciverse/sciverse.py
+++ b/gpt_researcher/retrievers/sciverse/sciverse.py
@@ -1,0 +1,244 @@
+import os
+from typing import Dict, List, Optional
+
+import requests
+
+
+class SciverseSearch:
+    """
+    Sciverse API Retriever.
+
+    Sciverse (https://sciverse.space) indexes scientific paper metadata and full
+    text, so a search returns passages from paper bodies rather than abstracts
+    alone. Each passage carries the id and character offset of the document it
+    came from.
+
+    Required environment variable:
+    - SCIVERSE_API_TOKEN: request one at https://sciverse.space
+
+    Optional environment variables:
+    - SCIVERSE_BASE_URL: defaults to https://api.sciverse.space
+    - SCIVERSE_MODE: retrieval mode, "fast" (keyword only), "balanced" (hybrid,
+      default) or "quality" (adds LLM query rewriting)
+    """
+
+    DEFAULT_BASE_URL = "https://api.sciverse.space"
+
+    # Results carry the retrieved full-text passage in raw_content; scraping
+    # the href (usually a DOI or publisher page) would yield less than what
+    # semantic search already selected.
+    requires_scraping = False
+
+    # Maps the retrieval mode to the API's knobs (`retrieval`: recall backend,
+    # `sub_queries`: LLM query-rewrite fan-out).
+    MODE_PARAMS = {
+        "fast": {"retrieval": "es"},
+        "balanced": {"retrieval": "hybrid"},
+        "quality": {"retrieval": "hybrid", "sub_queries": 3},
+    }
+
+    def __init__(self, query: str, mode: Optional[str] = None, query_domains=None):
+        """
+        Initialize the SciverseSearch class with a query and retrieval mode.
+
+        :param query: Search query string.
+        :param mode: Retrieval mode. One of MODE_PARAMS. "fast" is keyword only,
+            "balanced" is hybrid retrieval, "quality" adds LLM query rewriting.
+            Defaults to the SCIVERSE_MODE environment variable, then "balanced".
+        :param query_domains: Unused; Sciverse searches a curated literature
+            corpus rather than the open web.
+        """
+        self.query = query
+        if mode is not None:
+            assert mode in self.MODE_PARAMS, f"Invalid mode: {mode}"
+            self.mode = mode
+        else:
+            env_mode = os.environ.get("SCIVERSE_MODE", "balanced")
+            if env_mode not in self.MODE_PARAMS:
+                print(
+                    f"Invalid SCIVERSE_MODE {env_mode!r}; falling back to 'balanced'. "
+                    f"Valid values: {sorted(self.MODE_PARAMS)}"
+                )
+                env_mode = "balanced"
+            self.mode = env_mode
+        self.query_domains = query_domains
+        self.api_key = self._retrieve_api_key()
+        self.base_url = (os.environ.get("SCIVERSE_BASE_URL") or self.DEFAULT_BASE_URL).rstrip("/")
+
+    def _retrieve_api_key(self) -> str:
+        """
+        Retrieve the Sciverse API token from environment variables.
+
+        :return: The API token.
+        :raises Exception: If the API token is not found.
+        """
+        try:
+            return os.environ["SCIVERSE_API_TOKEN"]
+        except KeyError:
+            raise Exception(
+                "Sciverse API token not found. Please set the SCIVERSE_API_TOKEN "
+                "environment variable. You can request one at https://sciverse.space/"
+            )
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            # Lets Sciverse attribute traffic to this integration.
+            "X-Sciverse-Source": "oss_gptresearcher",
+        }
+
+    def search(self, max_results: int = 20) -> List[Dict[str, str]]:
+        """
+        Perform the search on Sciverse and return results.
+
+        Each result carries `raw_content` (title, abstract and the retrieved
+        full-text passage) so the research flow can use the passage directly
+        instead of scraping the href — which for papers is usually a DOI or
+        publisher page behind a paywall.
+
+        :param max_results: Maximum number of passages to retrieve (capped at 100).
+        :return: List of dictionaries containing title, href, url, body and
+            raw_content of each passage.
+        """
+        payload = {
+            "query": self.query,
+            "top_k": min(max_results, 100),
+        }
+        payload.update(self.MODE_PARAMS[self.mode])
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/agentic-search",
+                json=payload,
+                headers=self._headers(),
+                timeout=30,
+            )
+            response.raise_for_status()
+        except requests.RequestException as e:
+            print(f"An error occurred while accessing Sciverse API: {e}")
+            return []
+
+        payload_json = response.json()
+        if not isinstance(payload_json, dict):
+            return []
+        hits = payload_json.get("hits", [])
+        if not isinstance(hits, list):
+            return []
+
+        hits = [hit for hit in hits if isinstance(hit, dict)]
+        hrefs = self._resolve_hrefs(hits)
+
+        search_result = []
+        for hit in hits:
+            body = hit.get("chunk") or hit.get("abstract")
+            if not body:
+                continue
+            href = hrefs.get(hit.get("doc_id")) or self._web_href(hit)
+            if not href:
+                continue
+            search_result.append(
+                {
+                    "title": hit.get("title") or "No Title",
+                    "href": href,
+                    "url": href,
+                    "body": body,
+                    "raw_content": self._compose_raw_content(hit),
+                }
+            )
+
+        return search_result
+
+    @staticmethod
+    def _compose_raw_content(hit: dict) -> str:
+        """
+        Build ready-to-use context so the research flow treats the result as
+        prefetched content rather than a URL to scrape (same contract as the
+        PubMed Central retriever). The passage is what semantic search selected
+        as relevant; scraping a DOI link would usually yield less.
+
+        :param hit: A single search hit.
+        :return: Title, abstract and full-text passage as one text block.
+        """
+        parts = [f"Title: {hit.get('title') or 'No Title'}"]
+        if hit.get("abstract"):
+            parts.append(f"Abstract: {hit['abstract']}")
+        if hit.get("chunk"):
+            parts.append(f"Passage from full text: {hit['chunk']}")
+        return "\n\n".join(parts)
+
+    def _resolve_hrefs(self, hits: List[dict]) -> Dict[str, str]:
+        """
+        Look up citable URLs for the hit documents in one metadata query.
+
+        Search hits carry the document id but not its links, so this fetches
+        `access_oa_url` and `doi` for all hit doc_ids in a single /meta-search
+        call. Prefers the open-access URL, then the DOI, so citations point at
+        something a reader can open.
+
+        :param hits: The search hits.
+        :return: Mapping of doc_id to URL; empty on lookup failure.
+        """
+        doc_ids = sorted({hit["doc_id"] for hit in hits if hit.get("doc_id")})
+        if not doc_ids:
+            return {}
+
+        payload = {
+            "filters": [{"field": "doc_id", "operator": "FILTER_OP_IN", "value": doc_ids}],
+            "fields": ["doc_id", "access_oa_url", "doi"],
+            "page_size": min(len(doc_ids), 200),
+        }
+        try:
+            response = requests.post(
+                f"{self.base_url}/meta-search",
+                json=payload,
+                headers=self._headers(),
+                timeout=30,
+            )
+            response.raise_for_status()
+            records = response.json().get("results", [])
+        except (requests.RequestException, ValueError, AttributeError) as e:
+            print(f"An error occurred while resolving Sciverse links: {e}")
+            return {}
+
+        hrefs: Dict[str, str] = {}
+        for record in records:
+            if not isinstance(record, dict) or not record.get("doc_id"):
+                continue
+            href = self._pick_href(record)
+            if href:
+                hrefs[record["doc_id"]] = href
+        return hrefs
+
+    @staticmethod
+    def _pick_href(record: dict) -> Optional[str]:
+        """
+        Prefer the open-access URL, then the DOI.
+
+        :param record: A metadata record holding access_oa_url and doi.
+        :return: A URL, or None when the record carries no addressable source.
+        """
+        oa_url = record.get("access_oa_url")
+        if isinstance(oa_url, list):
+            oa_url = oa_url[0] if oa_url else None
+        if oa_url:
+            return oa_url
+
+        doi = record.get("doi")
+        if doi:
+            return doi if doi.startswith("http") else f"https://doi.org/{doi}"
+
+        return None
+
+    @staticmethod
+    def _web_href(hit: dict) -> Optional[str]:
+        """
+        Fall back to the crawl source URL for web hits without a doc_id.
+
+        :param hit: A single search hit.
+        :return: An http(s) URL, or None.
+        """
+        source = hit.get("source")
+        if isinstance(source, str) and source.startswith(("http://", "https://")):
+            return source
+        return None

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -80,6 +80,7 @@ VALID_RETRIEVERS = [
     "mcp",
     "xquik",
     "openalex",
+    "sciverse",
     "mock"
 ]
 

--- a/tests/test_sciverse_retriever.py
+++ b/tests/test_sciverse_retriever.py
@@ -1,0 +1,306 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "sciverse" / "sciverse.py"
+
+
+def _load():
+    requests_mod = types.ModuleType("requests")
+
+    class RequestException(Exception):
+        pass
+
+    requests_mod.RequestException = RequestException
+    requests_mod.post = MagicMock()
+    sys.modules["requests"] = requests_mod
+    for key in list(sys.modules):
+        if "sciverse.sciverse" in key:
+            sys.modules.pop(key, None)
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.sciverse.sciverse_testmod", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod, requests_mod
+
+
+def _response(payload):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+def _route(requests_mod, search_payload, meta_payload=None):
+    """Answer /agentic-search and /meta-search with their own fixtures."""
+
+    def post(url, **kwargs):
+        if url.endswith("/agentic-search"):
+            return _response(search_payload)
+        if url.endswith("/meta-search"):
+            return _response(meta_payload if meta_payload is not None else {"results": []})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    requests_mod.post.side_effect = post
+
+
+class SciverseRetrieverTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["SCIVERSE_API_TOKEN"] = "test-token"
+        os.environ.pop("SCIVERSE_BASE_URL", None)
+        os.environ.pop("SCIVERSE_MODE", None)
+
+    def test_maps_hits_to_title_href_body(self):
+        mod, requests_mod = _load()
+        _route(
+            requests_mod,
+            {
+                "hits": [
+                    {
+                        "title": "Attention Is All You Need",
+                        "abstract": "We propose the Transformer.",
+                        "chunk": "The Transformer uses self-attention.",
+                        "doc_id": "sha_a",
+                    }
+                ]
+            },
+            {"results": [{"doc_id": "sha_a", "doi": "10.5555/3295222"}]},
+        )
+
+        results = mod.SciverseSearch("attention").search(max_results=5)
+
+        self.assertEqual(
+            results,
+            [
+                {
+                    "title": "Attention Is All You Need",
+                    "href": "https://doi.org/10.5555/3295222",
+                    "url": "https://doi.org/10.5555/3295222",
+                    "body": "The Transformer uses self-attention.",
+                    "raw_content": (
+                        "Title: Attention Is All You Need\n\n"
+                        "Abstract: We propose the Transformer.\n\n"
+                        "Passage from full text: The Transformer uses self-attention."
+                    ),
+                }
+            ],
+        )
+
+    def test_link_lookup_batches_doc_ids_in_one_meta_search(self):
+        mod, requests_mod = _load()
+        _route(
+            requests_mod,
+            {
+                "hits": [
+                    {"title": "A", "chunk": "t", "doc_id": "sha_a"},
+                    {"title": "B", "chunk": "t", "doc_id": "sha_b"},
+                    {"title": "A2", "chunk": "t2", "doc_id": "sha_a"},
+                ]
+            },
+            {"results": []},
+        )
+
+        mod.SciverseSearch("q").search()
+
+        meta_calls = [
+            c for c in requests_mod.post.call_args_list if c.args[0].endswith("/meta-search")
+        ]
+        self.assertEqual(len(meta_calls), 1)
+        self.assertEqual(
+            meta_calls[0].kwargs["json"],
+            {
+                "filters": [
+                    {
+                        "field": "doc_id",
+                        "operator": "FILTER_OP_IN",
+                        "value": ["sha_a", "sha_b"],
+                    }
+                ],
+                "fields": ["doc_id", "access_oa_url", "doi"],
+                "page_size": 2,
+            },
+        )
+
+    def test_sends_auth_and_source_headers_and_maps_mode(self):
+        mod, requests_mod = _load()
+        _route(requests_mod, {"hits": []})
+
+        mod.SciverseSearch("query", mode="quality").search(max_results=200)
+
+        kwargs = requests_mod.post.call_args.kwargs
+        self.assertEqual(kwargs["json"]["top_k"], 100)
+        self.assertNotIn("mode", kwargs["json"])
+        self.assertEqual(kwargs["json"]["retrieval"], "hybrid")
+        self.assertEqual(kwargs["json"]["sub_queries"], 3)
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-token")
+        self.assertEqual(kwargs["headers"]["X-Sciverse-Source"], "oss_gptresearcher")
+
+    def test_prefers_open_access_url_over_doi(self):
+        mod, requests_mod = _load()
+        _route(
+            requests_mod,
+            {"hits": [{"title": "Paper", "chunk": "text", "doc_id": "sha_a"}]},
+            {
+                "results": [
+                    {
+                        "doc_id": "sha_a",
+                        "access_oa_url": ["https://example.org/paper.pdf"],
+                        "doi": "10.1/xyz",
+                    }
+                ]
+            },
+        )
+
+        results = mod.SciverseSearch("q").search()
+
+        self.assertEqual(results[0]["href"], "https://example.org/paper.pdf")
+
+    def test_web_hit_without_doc_id_uses_source_url(self):
+        mod, requests_mod = _load()
+        _route(
+            requests_mod,
+            {
+                "hits": [
+                    {
+                        "title": "Web page",
+                        "chunk": "text",
+                        "source_type": "web",
+                        "source": "https://example.org/article",
+                    }
+                ]
+            },
+        )
+
+        results = mod.SciverseSearch("q").search()
+
+        self.assertEqual(results[0]["href"], "https://example.org/article")
+
+    def test_skips_malformed_hits_and_hits_without_source(self):
+        mod, requests_mod = _load()
+        _route(
+            requests_mod,
+            {
+                "hits": [
+                    "bad",
+                    {"title": "No body", "doc_id": "sha_a"},
+                    {"title": "No link", "chunk": "text", "source": "s3://bucket/key"},
+                    {"title": "Good", "chunk": "text", "doc_id": "sha_b"},
+                ]
+            },
+            {"results": [{"doc_id": "sha_b", "doi": "10.1/b"}]},
+        )
+
+        results = mod.SciverseSearch("q").search()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "Good")
+
+    def test_link_lookup_failure_degrades_to_web_hrefs_only(self):
+        mod, requests_mod = _load()
+
+        def post(url, **kwargs):
+            if url.endswith("/agentic-search"):
+                return _response(
+                    {
+                        "hits": [
+                            {"title": "Pdf", "chunk": "t", "doc_id": "sha_a"},
+                            {
+                                "title": "Web",
+                                "chunk": "t",
+                                "source": "https://example.org/a",
+                            },
+                        ]
+                    }
+                )
+            raise requests_mod.RequestException("meta-search down")
+
+        requests_mod.post.side_effect = post
+
+        results = mod.SciverseSearch("q").search()
+
+        self.assertEqual([r["title"] for r in results], ["Web"])
+
+    def test_non_dict_payload_returns_empty_list(self):
+        mod, requests_mod = _load()
+        _route(requests_mod, ["unexpected"])
+
+        self.assertEqual(mod.SciverseSearch("q").search(), [])
+
+    def test_request_error_returns_empty_list(self):
+        mod, requests_mod = _load()
+        requests_mod.post.side_effect = requests_mod.RequestException("boom")
+
+        self.assertEqual(mod.SciverseSearch("q").search(), [])
+
+    def test_missing_token_raises(self):
+        mod, _ = _load()
+        os.environ.pop("SCIVERSE_API_TOKEN", None)
+
+        with self.assertRaises(Exception) as ctx:
+            mod.SciverseSearch("q")
+
+        self.assertIn("SCIVERSE_API_TOKEN", str(ctx.exception))
+
+    def test_invalid_mode_rejected(self):
+        mod, _ = _load()
+
+        with self.assertRaises(AssertionError):
+            mod.SciverseSearch("q", mode="turbo")
+
+    def test_mode_env_var_applies_and_invalid_env_falls_back(self):
+        mod, requests_mod = _load()
+        _route(requests_mod, {"hits": []})
+
+        os.environ["SCIVERSE_MODE"] = "quality"
+        mod.SciverseSearch("q").search()
+        payload = requests_mod.post.call_args.kwargs["json"]
+        self.assertEqual(payload["retrieval"], "hybrid")
+        self.assertEqual(payload["sub_queries"], 3)
+
+        # An explicit argument takes precedence over the environment variable
+        os.environ["SCIVERSE_MODE"] = "quality"
+        mod.SciverseSearch("q", mode="fast").search()
+        payload = requests_mod.post.call_args.kwargs["json"]
+        self.assertEqual(payload["retrieval"], "es")
+        self.assertNotIn("sub_queries", payload)
+
+        # An invalid env value falls back to balanced instead of aborting the research run
+        os.environ["SCIVERSE_MODE"] = "turbo"
+        mod.SciverseSearch("q").search()
+        payload = requests_mod.post.call_args.kwargs["json"]
+        self.assertEqual(payload["retrieval"], "hybrid")
+        self.assertNotIn("sub_queries", payload)
+
+    def test_raw_content_without_abstract_still_carries_passage(self):
+        mod, requests_mod = _load()
+        _route(
+            requests_mod,
+            {"hits": [{"title": "P", "chunk": "some passage", "doc_id": "sha_a"}]},
+            {"results": [{"doc_id": "sha_a", "doi": "10.1/x"}]},
+        )
+
+        results = mod.SciverseSearch("q").search()
+
+        self.assertEqual(
+            results[0]["raw_content"],
+            "Title: P\n\nPassage from full text: some passage",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+    def test_declares_prefetched_content_contract(self):
+        # requires_scraping=False: the research flow uses raw_content directly
+        # instead of scraping the href (usually a DOI or publisher page), and
+        # no longer depends on the legacy 100-char raw_content heuristic.
+        mod, _ = _load()
+        self.assertIs(mod.SciverseSearch.requires_scraping, False)


### PR DESCRIPTION
Sciverse indexes paper metadata and full text, so a search returns passages from paper bodies rather than abstracts alone. Results map to the standard title/href/body contract, with href preferring the open-access URL and falling back to the DOI so citations stay resolvable.

Registered in retrievers/__init__.py, VALID_RETRIEVERS and the get_retriever factory. Uses requests, matching the other academic retrievers, so no new dependencies are required.