### PR TITLE
Fix #2047: Add jsdom override to resolve Docker/ESM build failure

### DIFF
--- a/frontend/nextjs/package.json
+++ b/frontend/nextjs/package.json
@@ -84,6 +84,9 @@
     "typescript": "^5",
     "@ducanh2912/next-pwa": "^10.0.1"
   },
+  "overrides": {
+    "jsdom": "25.0.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/assafelovic/gpt-researcher.git"


### PR DESCRIPTION
Fixes #2047

Adds an `overrides` entry in `frontend/nextjs/package.json` to pin `jsdom` to `25.0.1`, which resolves the ESM/CommonJS incompatibility causing the frontend build to fail inside Docker as described in the issue.