### PR TITLE
fix: preserve None labels in visualizations

### DIFF
--- a/multi_agents/agents/visualizer.py
+++ b/multi_agents/agents/visualizer.py
@@ -1,5 +1,7 @@
 from .utils.views import print_agent_output
 from .utils.llms import call_model
+from .utils.none_sentinels import is_none_accept_response
+
 
 class VisualizerAgent:
     def __init__(self, websocket=None, stream_output=None, headers=None):
@@ -39,7 +41,7 @@ class VisualizerAgent:
         diagram_output = await self.generate_visualizations(research_state)
 
         diagrams = []
-        if "None" not in diagram_output:
+        if not is_none_accept_response(diagram_output):
             diagrams.append(diagram_output)
             if self.websocket and self.stream_output:
                 await self.stream_output("logs", "visualizing", f"Generated diagrams.", self.websocket)

--- a/tests/test_visualizer_none_sentinel.py
+++ b/tests/test_visualizer_none_sentinel.py
@@ -1,0 +1,62 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+VISUALIZER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "multi_agents"
+    / "agents"
+    / "visualizer.py"
+)
+
+
+def _load_visualizer_module(monkeypatch):
+    for package_name in (
+        "multi_agents",
+        "multi_agents.agents",
+        "multi_agents.agents.utils",
+    ):
+        package = types.ModuleType(package_name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, package_name, package)
+
+    sys.modules["multi_agents.agents.utils"].__path__ = [
+        str(VISUALIZER_PATH.parent / "utils")
+    ]
+
+    views = types.ModuleType("multi_agents.agents.utils.views")
+    views.print_agent_output = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, views.__name__, views)
+
+    llms = types.ModuleType("multi_agents.agents.utils.llms")
+    llms.call_model = None
+    monkeypatch.setitem(sys.modules, llms.__name__, llms)
+
+    spec = importlib.util.spec_from_file_location(
+        "multi_agents.agents.visualizer",
+        VISUALIZER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_visualizer_keeps_diagram_with_none_in_a_label(monkeypatch):
+    visualizer_module = _load_visualizer_module(monkeypatch)
+    diagram = '```mermaid\nflowchart LR\n    A["None reported"] --> B["Done"]\n```'
+
+    async def return_diagram(*args, **kwargs):
+        return diagram
+
+    monkeypatch.setattr(visualizer_module, "call_model", return_diagram)
+
+    result = asyncio.run(
+        visualizer_module.VisualizerAgent().run(
+            {"task": {"model": "gpt-4o"}, "research_data": []}
+        )
+    )
+
+    assert result == {"diagrams": [diagram]}


### PR DESCRIPTION
## Summary

- Fixes: The visualizer returns no diagram when otherwise valid Mermaid output contains the word None in a node label, such as None reported.
- Root cause: VisualizerAgent.run treats any diagram output containing the substring None as the model's no-diagram sentinel, instead of accepting only the strict standalone sentinel already recognized elsewhere in the repository.
- Addresses the visualizer portion of #2061; the separate human-approval case already has PR #1884.

## Regression evidence

- Before: `uv run --no-project --python 3.11 --with pytest python -m pytest tests/test_visualizer_none_sentinel.py -v` exited `1`

- After: `uv run --no-project --python 3.11 --with pytest python -m pytest tests/test_visualizer_none_sentinel.py -v` exited `0`

## Verification

- `uv run --no-project --python 3.11 --with pytest --with pytest-asyncio python -m pytest tests/test_none_accept_sentinels.py tests/test_visualizer_none_sentinel.py -v`
- `uv run --no-project --python 3.11 python -m py_compile multi_agents/agents/visualizer.py multi_agents/agents/utils/none_sentinels.py tests/test_visualizer_none_sentinel.py tests/test_none_accept_sentinels.py`
- `git diff --cached --check`

## Scope

- 2 files changed, +65 / -1 lines
