### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README-ja_JP.md
+++ b/README-ja_JP.md
@@ -169,11 +169,11 @@ GPT Researcher は **LangSmith** をサポートしており、複雑なマル�
 ---
 
 <p align="center">
-<a href="https://star-history.com/#assafelovic/gpt-researcher">
+<a href="https://star-history.dera.page/#assafelovic/gpt-researcher">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
   </picture>
 </a>
 </p>

--- a/README-ko_KR.md
+++ b/README-ko_KR.md
@@ -252,11 +252,11 @@ GPT-Researcher는 사용자 경험을 개선하고 연구 프로세스를 간소
 ---
 
 <p align="center">
-<a href="https://star-history.com/#assafelovic/gpt-researcher">
+<a href="https://star-history.dera.page/#assafelovic/gpt-researcher">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
   </picture>
 </a>
 </p>

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -168,11 +168,11 @@ GPT Researcher 支持 **LangSmith** 以增强链路追踪和可观测性，特�
 ---
 
 <p align="center">
-<a href="https://star-history.com/#assafelovic/gpt-researcher">
+<a href="https://star-history.dera.page/#assafelovic/gpt-researcher">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
   </picture>
 </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -336,11 +336,11 @@ Our view on unbiased research claims:
 ---
 
 <p align="center">
-<a href="https://star-history.com/#assafelovic/gpt-researcher">
+<a href="https://star-history.dera.page/#assafelovic/gpt-researcher">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=assafelovic/gpt-researcher&type=Date" />
   </picture>
 </a>
 </p>


### PR DESCRIPTION
The star history chart shown in the README and its localized translations is currently broken and renders no image, since the upstream service stopped working because of GitHub stargazer API restrictions.

This change points the chart to a maintained mirror that serves the same chart reliably, restoring the visualization across the main README and the Japanese, Korean and Chinese translations. No functional or documented behavior changes.