### PR TITLE
fix: move `typing` import above first annotated function definition (NameError on import)

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,3 +1,5 @@
+from typing import Any, List, Dict
+
 import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
@@ -34,7 +36,6 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     return queries
 from ..utils.llm import create_chat_completion
 from ..prompts import PromptFamily
-from typing import Any, List, Dict
 from ..config import Config
 import logging
 


### PR DESCRIPTION
﻿## Problem

`gpt_researcher/actions/query_processing.py` fails to import on Python 3.11–3.13 with:

```
NameError: name 'Any' is not defined
```

The `from typing import Any, List, Dict` statement is at **line 37**, but the first function that uses those names is defined at **line 6**:

```python
L1   import json_repair
L3   from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
L6   def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:   # <- uses Any / List
...
L37  from typing import Any, List, Dict                                            # <- imported here
```

Function annotations are evaluated **eagerly at `def` time** on Python <= 3.13, and this module has no `from __future__ import annotations`. The module therefore raises `NameError` at line 6, before line 37 is ever reached.

`pyproject.toml` declares `requires-python = ">=3.11"`, so this affects every supported version below 3.14. (On Python 3.14+, PEP 649 defers annotation evaluation, which is why the issue is invisible there.)

## Reproduction

Verified on **Python 3.11.9** against the unmodified file from `main` (`5d84d2f`). Only the two external dependencies are stubbed out so the file's own code is what runs — nothing else is altered:

```python
import sys, types
sys.modules["json_repair"] = types.ModuleType("json_repair")
for n in ["gpt_researcher", "gpt_researcher.llm_provider", "gpt_researcher.llm_provider.generic"]:
    sys.modules[n] = types.ModuleType(n)
base = types.ModuleType("gpt_researcher.llm_provider.generic.base")
base.ReasoningEfforts = object()
sys.modules["gpt_researcher.llm_provider.generic.base"] = base

src = open("gpt_researcher/actions/query_processing.py", encoding="utf-8").read()
exec(compile(src, "query_processing.py", "exec"), {"__name__": "qp_test"})
```

Before this change:

```
NameError: name 'Any' is not defined
  triggered at L6 -> def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
```

After this change: execution gets past line 6 and reaches the relative imports further down (which fail only because the snippet above runs the file standalone, outside its package — unrelated to this bug).

## The change

Moves that single `typing` import to the top of the file. **+2 / -1 lines.**

**Deliberately minimal**: the other mid-file imports (`from ..utils.llm`, `from ..prompts`, `from ..config`, `import logging`) are left exactly where they are. They may well be placed after the function on purpose to avoid circular imports, and this PR does not attempt to judge that.
