### PR TITLE
fix: apply OpenAI prompt-cache discount to cache_read tokens (#2065)

### DIFF
--- a/gpt_researcher/utils/costs.py
+++ b/gpt_researcher/utils/costs.py
@@ -15,6 +15,14 @@ OUTPUT_COST_PER_TOKEN = 0.000015
 IMAGE_INFERENCE_COST = 0.003825
 EMBEDDING_COST = 0.02 / 1000000  # Assumes new ada-3-small
 
+# OpenAI's automatic prompt caching bills the cached portion of input
+# tokens at a discount off the standard input rate (currently 50% across
+# the GPT-4o/4.1/5 families). Kept as a single constant since OpenAI has
+# used a flat 50% cache discount across all its cached models to date;
+# revisit if a future model introduces a different ratio.
+# https://openai.com/api/pricing/
+OPENAI_CACHED_INPUT_DISCOUNT = 0.5
+
 logger = logging.getLogger(__name__)
 
 # (patterns, input $/MTok, output $/MTok) - first match wins, so more
@@ -184,13 +192,26 @@ def calculate_anthropic_cost(
 
 def _extract_usage_tokens(
     usage_metadata: Mapping[str, Any] | Any | None,
-) -> tuple[int, int] | None:
+) -> tuple[int, int, int] | None:
+    """Returns (input_tokens, output_tokens, cache_read_tokens).
+
+    cache_read_tokens is the portion of input_tokens that hit the
+    provider's prompt cache (LangChain's standardized
+    ``input_token_details.cache_read``) and should be billed at
+    OPENAI_CACHED_INPUT_DISCOUNT instead of the standard input rate.
+    Defaults to 0 when the response doesn't report cache details, so
+    non-cached calls are unaffected.
+    """
     usage = _mapping_to_dict(usage_metadata)
     input_tokens = usage.get("input_tokens")
     output_tokens = usage.get("output_tokens")
     if input_tokens is None or output_tokens is None:
         return None
-    return int(input_tokens), int(output_tokens)
+
+    input_token_details = _mapping_to_dict(usage.get("input_token_details"))
+    cache_read_tokens = int(input_token_details.get("cache_read") or 0)
+
+    return int(input_tokens), int(output_tokens), cache_read_tokens
 
 
 def _get_openai_pricing(model: str | None) -> tuple[float, float] | None:
@@ -225,16 +246,30 @@ def calculate_llm_cost(
     # reasoning tokens entirely.
     usage_tokens = _extract_usage_tokens(usage_metadata)
     if usage_tokens is not None:
-        input_tokens, output_tokens = usage_tokens
+        input_tokens, output_tokens, cache_read_tokens = usage_tokens
+        # cache_read_tokens is a subset of input_tokens, not additional
+        # tokens -- split input_tokens into its non-cached and cached
+        # portions so the cached share is priced at the discount rate
+        # instead of the full input rate.
+        non_cached_input_tokens = input_tokens - cache_read_tokens
         pricing = _get_openai_pricing(model)
         if pricing is not None:
             input_price_per_mtok, output_price_per_mtok = pricing
-            return (
-                input_tokens * input_price_per_mtok
-                + output_tokens * output_price_per_mtok
-            ) / 1_000_000
+            non_cached_cost = non_cached_input_tokens * input_price_per_mtok
+            cached_cost = (
+                cache_read_tokens
+                * input_price_per_mtok
+                * OPENAI_CACHED_INPUT_DISCOUNT
+            )
+            output_cost = output_tokens * output_price_per_mtok
+            return (non_cached_cost + cached_cost + output_cost) / 1_000_000
+        cached_cost = (
+            cache_read_tokens * INPUT_COST_PER_TOKEN * OPENAI_CACHED_INPUT_DISCOUNT
+        )
+        non_cached_cost = non_cached_input_tokens * INPUT_COST_PER_TOKEN
         return (
-            input_tokens * INPUT_COST_PER_TOKEN
+            non_cached_cost
+            + cached_cost
             + output_tokens * OUTPUT_COST_PER_TOKEN
         )
 
@@ -261,4 +296,3 @@ def estimate_embedding_cost(model: str, docs: list) -> float:
         encoding = tiktoken.get_encoding(ENCODING_MODEL)
     total_tokens = sum(len(encoding.encode(str(doc))) for doc in docs)
     return total_tokens * EMBEDDING_COST
-

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -2,6 +2,8 @@ import unittest
 
 from gpt_researcher.utils.costs import (
     EMBEDDING_COST,
+    INPUT_COST_PER_TOKEN,
+    OUTPUT_COST_PER_TOKEN,
     calculate_llm_cost,
     estimate_embedding_cost,
     estimate_llm_cost,
@@ -98,6 +100,86 @@ class TestEmbeddingCost(unittest.TestCase):
         )
 
 
+class TestOpenAICachedInputPricing(unittest.TestCase):
+    """Covers #2065: cached OpenAI input tokens were billed at full price
+    because calculate_llm_cost never read input_token_details.cache_read
+    from LangChain's standardized usage_metadata."""
+
+    def test_no_cache_details_unaffected(self):
+        cost = calculate_llm_cost(
+            llm_provider="openai",
+            model="gpt-4o",
+            input_content="",
+            output_content="",
+            usage_metadata={"input_tokens": 5000, "output_tokens": 200},
+        )
+        self.assertAlmostEqual(cost, 0.0145)
+
+    def test_partial_cache_hit_is_discounted(self):
+        # Exact repro from issue #2065: 4500 of 5000 input tokens hit the
+        # cache and must be billed at the discounted rate, not full price.
+        cost = calculate_llm_cost(
+            llm_provider="openai",
+            model="gpt-4o",
+            input_content="",
+            output_content="",
+            usage_metadata={
+                "input_tokens": 5000,
+                "output_tokens": 200,
+                "input_token_details": {"cache_read": 4500},
+            },
+        )
+        self.assertLess(cost, 0.0145)
+        self.assertAlmostEqual(cost, 0.008875)
+
+    def test_explicit_zero_cache_read_matches_baseline(self):
+        cost = calculate_llm_cost(
+            llm_provider="openai",
+            model="gpt-4o",
+            input_content="",
+            output_content="",
+            usage_metadata={
+                "input_tokens": 5000,
+                "output_tokens": 200,
+                "input_token_details": {"cache_read": 0},
+            },
+        )
+        self.assertAlmostEqual(cost, 0.0145)
+
+    def test_fully_cached_input(self):
+        cost = calculate_llm_cost(
+            llm_provider="openai",
+            model="gpt-4o",
+            input_content="",
+            output_content="",
+            usage_metadata={
+                "input_tokens": 5000,
+                "output_tokens": 200,
+                "input_token_details": {"cache_read": 5000},
+            },
+        )
+        expected = (5000 * 2.5 * 0.5 + 200 * 10.0) / 1_000_000
+        self.assertAlmostEqual(cost, expected)
+
+    def test_unknown_model_fallback_still_applies_cache_discount(self):
+        cost = calculate_llm_cost(
+            llm_provider="openai",
+            model="some-future-model",
+            input_content="",
+            output_content="",
+            usage_metadata={
+                "input_tokens": 1000,
+                "output_tokens": 100,
+                "input_token_details": {"cache_read": 500},
+            },
+        )
+        expected = (
+            500 * INPUT_COST_PER_TOKEN * 0.5
+            + 500 * INPUT_COST_PER_TOKEN
+            + 100 * OUTPUT_COST_PER_TOKEN
+        )
+        self.assertAlmostEqual(cost, expected, places=12)
+
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Problem

`_extract_usage_tokens` in `gpt_researcher/utils/costs.py` only read the
flat `input_tokens`/`output_tokens` fields off LangChain's standardized
`usage_metadata`, and `calculate_llm_cost`'s OpenAI branch priced the
full `input_tokens` count at the standard rate. Neither looked at
`input_token_details.cache_read`, the portion of input tokens that hit
OpenAI's automatic prompt caching and are billed at a discount.

Any research run that benefits from provider-side caching gets its cost
overreported.

This is the same class of gap as #1986/#1989 (Anthropic cache tokens
priced at $0), but on the OpenAI/generic branch, in the opposite
direction: overcounted here instead of undercounted there.

## Fix

- `_extract_usage_tokens` now also extracts `input_token_details.cache_read`
  and returns it alongside input/output tokens.
- `calculate_llm_cost` splits `input_tokens` into its cached and
  non-cached portions, pricing the cached portion at
  `OPENAI_CACHED_INPUT_DISCOUNT` (50%, per OpenAI's pricing page) instead
  of the full input rate.
- Applies to both the known-model pricing table and the flat-rate
  fallback path.

## Testing

Added `TestOpenAICachedInputPricing` to `tests/test_costs.py`, covering:
- No cache details (unaffected, matches pre-fix behavior)
- Partial cache hit (reproduces the exact scenario from #2065)
- Explicit `cache_read: 0` (matches baseline)
- Fully cached input
- Unknown-model fallback (cache discount still applies)

Verified against the reporter's exact repro from #2065:
- Before: both calls returned `0.0145` regardless of cache hits
- After: `0.0145` (no cache) vs `0.008875` (4500/5000 tokens cached)

Fixes #2065