### PR TITLE
fix: remove stray Claude worktree gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,5 @@ server_log.txt
 #Cursor Rules
 .cursorrules
 CURSOR_RULES.md
+/.claude/worktrees/
 /.history


### PR DESCRIPTION
<!-- codex-oss-sweep -->
## Summary
- remove the committed .claude/worktrees/crazy-curie-e43899 gitlink, which has no matching .gitmodules entry
- ignore only .claude/worktrees/ so local Claude worktrees cannot be committed again
- keep the tracked .claude/SKILL.md and .claude/references content unaffected

## Problem
Issue #2055 reports two independent defects. This PR addresses defect 1 only: Docker/BuildKit git-URL contexts and submodule initialization fail because main contains a mode-160000 entry without any submodule URL.

This intentionally does not modify query_processing.py because that separate defect already has open fixes.

Related to #2055 (defect 1 only; this PR does not close the full issue).

## Verification
- git show --check HEAD
- git submodule update --init --recursive
- verified the committed tree contains no mode-160000 entries
- verified .claude/worktrees/ is ignored while tracked .claude documentation is not
