### PR TITLE
fix: import-time NameError in query_processing and missing tavily-python dependency

### DIFF
--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -1,6 +1,7 @@
 import json_repair
 
 from gpt_researcher.llm_provider.generic.base import ReasoningEfforts
+from typing import Any, Dict, List
 
 
 def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
@@ -34,7 +35,6 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     return queries
 from ..utils.llm import create_chat_completion
 from ..prompts import PromptFamily
-from typing import Any, List, Dict
 from ..config import Config
 import logging
 
@@ -126,7 +126,7 @@ async def generate_sub_queries(
         )
     except Exception as e:
         logger.warning(f"Error with strategic LLM: {e}. Retrying with max_tokens={cfg.strategic_token_limit}.")
-        logger.warning(f"See https://github.com/assafelovic/gpt-researcher/issues/1022")
+        logger.warning("See https://github.com/assafelovic/gpt-researcher/issues/1022")
         try:
             response = await create_chat_completion(
                 model=cfg.strategic_llm_model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ dependencies = [
     "sqlalchemy>=2.0.41",
     "sse-starlette>=2.3.5",
     "starlette>=0.46.2",
+    "tavily-python>=0.7.12",
     "tenacity>=9.1.2",
     "tiktoken>=0.9.0",
     "tinycss2>=1.4.0",


### PR DESCRIPTION
## Summary
Two small fixes for errors arising while getting the project running from a fresh install:

### 1. Import-time crash in `gpt_researcher/actions/query_processing.py`

`_normalize_sub_queries()` annotates parameters with `Any` / `List[str]`,
but the module's only `typing` import sat *below* the function definition.
Since annotations are evaluated at `def` time, importing anything that
pulls in this module raised:

 NameError: name 'Any' is not defined

**Fix:** consolidated into a single `from typing import Any, Dict, List`
at the top of the file. Also drops a redundant `f` prefix on a
`logger.warning` string with no placeholders (fixed by linter).

### 2. Missing default-retriever dependency in `pyproject.toml`

`tavily-python` was only declared in `requirements.txt`, so 
installing using `uv` missed it entirely.

**Fix:** added `"tavily-python>=0.7.12"` - pin matches `requirements.txt`

## Impact evidence

Full-suite pytest on current `main`: **41 collection errors** (`NameError:
name 'Any' is not defined`, propagated through every module importing
`query_processing`). 
On this branch: **1 error** — a pre-existing, unrelated
ImportError in `tests/test_security_fix.py` (missing `secure_filename`,
present on unmodified `main` as well).
