### PR TITLE
chore: remove the dead poetry dependency block, test the declared Python floor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,47 +6,6 @@ authors = ["Assaf Elovic <assaf.elovic@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 
-[tool.poetry.dependencies]
-python = ">=3.11"
-aiofiles = ">=23.2.1"
-arxiv = ">=2.0.0"
-beautifulsoup4 = ">=4.12.2"
-colorama = ">=0.4.6"
-duckduckgo_search = ">=4.1.1"
-fastapi = ">=0.104.1"
-htmldocx = "^0.0.6"
-jinja2 = ">=3.1.2"
-json-repair = "^0.29.8"
-json5 = "^0.9.25"
-langchain = "^1.0.0"
-langchain-classic = "^1.0.0"
-langchain_community = "^0.4.0"
-langchain-core = "^1.0.0"
-langchain-openai = "^1.0.0"
-langchain-text-splitters = "^1.0.0"
-langgraph = ">=0.2.73,<0.3"
-loguru = "^0.7.2"
-lxml = { version = ">=4.9.2", extras = ["html_clean"] }
-markdown = ">=3.5.1"
-md2pdf = ">=1.0.1"
-mistune = "^3.0.2"
-openai = ">=1.3.3"
-pydantic = ">=2.5.1"
-PyMuPDF = ">=1.23.6"
-python-docx = "^1.1.0"
-python-dotenv = ">=1.0.0"
-python-multipart = ">=0.0.6"
-pyyaml = ">=6.0.1"
-requests = ">=2.31.0"
-SQLAlchemy = ">=2.0.28"
-tiktoken = ">=0.7.0"
-unstructured = ">=0.13"
-uvicorn = ">=0.24.0.post1"
-websockets = "^13.1"
-# Model Context Protocol support
-mcp = { version = ">=1.0.0", markers = "platform_system != 'Windows'" }
-langchain-mcp-adapters = ">=0.1.0"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Follow-up to #2074, from reviewing the dependabot backlog.

## The dead block

`pyproject.toml` declares dependencies twice — legacy `[tool.poetry.dependencies]` and PEP 621 `[project]`. Only `[project]` ships. Verified by building the wheel:

```
Requires-Dist: json-repair (>=0.44.0)    # [project];  poetry block said ^0.29.8
Requires-Dist: json5 (>=0.12.0)          # [project];  poetry block said ^0.9.25
Requires-Dist: langgraph (>=0.2.76)      # [project];  poetry block said >=0.2.73,<0.3
Requires-Dist: websockets (>=15.0.1)     # [project];  poetry block said ^13.1
```

Deleting the block and rebuilding gives byte-identical requirements. A clean install already resolves to json5 0.15.0, langgraph 1.2.11 and websockets 16.1.1 — all forbidden by the poetry constraints, which is the clearest proof it is ignored.

Its one real effect was sending dependabot after config nobody reads. #1616, #1926, #1928 and #1929 were all open against it and are now closed as no-ops.

## The declared floor

`pyproject`, `setup.py` and the trove classifiers all claim `>=3.11`, but the CI matrix added in #2074 started at 3.12 — so the version the package advertises was never tested. This adds 3.11 to the matrix.

If it goes red, the right response is to raise `requires-python` rather than keep advertising a version that does not work. Either way CI settles it instead of us guessing, which is the point.

387 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)