### PR TITLE
fix: make the empty-source-urls notification reachable (#1978)

### DIFF
--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -145,7 +145,9 @@ class ResearchConductor:
         if self.researcher.source_urls:
             self.logger.info("Using provided source URLs")
             research_data = await self._get_context_by_urls(self.researcher.source_urls)
-            if research_data and len(research_data) == 0 and self.researcher.verbose:
+            # `research_data and len(research_data) == 0` can never be true --
+            # a truthy value is never empty -- so this notification never fired.
+            if not research_data and self.researcher.verbose:
                 await stream_output(
                     "logs",
                     "answering_from_memory",

--- a/tests/test_empty_source_urls_notification.py
+++ b/tests/test_empty_source_urls_notification.py
@@ -1,0 +1,118 @@
+"""The empty-context notification for provided source_urls must fire (#1978).
+
+`ResearchConductor.conduct_research()` guarded the "I was unable to find
+relevant context in the provided sources" notification with
+
+    if research_data and len(research_data) == 0 and self.researcher.verbose:
+
+which is a contradiction: a truthy value is never length zero. The branch
+could not execute, so a user passing `source_urls` that yielded nothing was
+told nothing and simply received a thin report.
+
+These tests drive the real `conduct_research` with `_get_context_by_urls`
+stubbed, and assert on what actually reaches `stream_output`.
+"""
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gpt_researcher.skills.researcher import ResearchConductor
+
+
+def _researcher(*, source_urls, verbose=True):
+    r = types.SimpleNamespace(
+        source_urls=source_urls,
+        complement_source_urls=False,
+        verbose=verbose,
+        websocket=None,
+        report_source="web",
+        query="anything",
+        query_domains=[],
+        retrievers=[],
+        agent="agent",
+        role="role",
+        cfg=types.SimpleNamespace(),
+        headers={},
+        prompt_family=None,
+        add_costs=lambda *a, **k: None,
+    )
+    return r
+
+
+async def _run(research_data, verbose=True):
+    """Run conduct_research with the URL path stubbed, capture notifications."""
+    researcher = _researcher(source_urls=["https://example.com/a"], verbose=verbose)
+    conductor = ResearchConductor(researcher)
+    conductor.logger = types.SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None
+    )
+    seen = []
+
+    async def fake_stream_output(kind, key, message, websocket=None, *a, **kw):
+        seen.append((kind, key, message))
+
+    with patch.object(ResearchConductor, "_get_context_by_urls",
+                      AsyncMock(return_value=research_data)), \
+         patch("gpt_researcher.skills.researcher.stream_output", fake_stream_output), \
+         patch.object(ResearchConductor, "plan_research", AsyncMock(return_value=[])):
+        try:
+            await conductor.conduct_research()
+        except Exception:
+            # Later stages of conduct_research are out of scope here; the
+            # notification decision happens before them.
+            pass
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_empty_context_emits_the_notification():
+    seen = await _run(research_data=[])
+    keys = [k for _, k, _ in seen]
+    assert "answering_from_memory" in keys, (
+        f"expected the empty-context notification, got {keys}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_nonempty_context_stays_quiet():
+    seen = await _run(research_data=["some real scraped context"])
+    keys = [k for _, k, _ in seen]
+    assert "answering_from_memory" not in keys, (
+        "the notification fired even though context was found"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quiet_when_not_verbose():
+    seen = await _run(research_data=[], verbose=False)
+    keys = [k for _, k, _ in seen]
+    assert "answering_from_memory" not in keys
+
+
+def test_no_self_contradictory_guard_in_conduct_research():
+    """Guard the shape of the mistake, not its text: `x and len(x) == 0`.
+
+    Matching the source as a string would also match the comment explaining
+    the bug, so this walks the AST and looks for a real BoolOp of the form
+    `<name> and len(<same name>) == 0`, which can never be true.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(ResearchConductor.conduct_research)))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.BoolOp) or not isinstance(node.op, ast.And):
+            continue
+        names = {ast.unparse(v) for v in node.values if isinstance(v, ast.Name)}
+        for value in node.values:
+            if not isinstance(value, ast.Compare):
+                continue
+            txt = ast.unparse(value)
+            for name in names:
+                if txt in (f"len({name}) == 0", f"0 == len({name})"):
+                    raise AssertionError(
+                        f"contradictory guard from #1978 is back: `{ast.unparse(node)}`"
+                    )


### PR DESCRIPTION
Closes #1978, found while reviewing the remaining open issues.

`ResearchConductor.conduct_research()` guarded its empty-context notification with:

```python
if research_data and len(research_data) == 0 and self.researcher.verbose:
```

A truthy value is never length zero, so the branch could not execute. Anyone passing `source_urls` that produced no usable context got no notification and a thin report with no explanation of why.

#1982 proposed a fix, but it rewrote a large part of `researcher.py` and failed both its own four tests and two existing ones when tested against current `main`, so it was held back. This is the one-line version.

## Tests

Four, driving the real `conduct_research` with `_get_context_by_urls` stubbed:
- fires on empty context
- stays quiet when context was found
- stays quiet when `verbose` is off
- an AST check for the *shape* of the mistake (`x and len(x) == 0`) rather than its text — a string match would also match the comment explaining the bug. I verified this check does flag the original code on `origin/main`.

391 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)