### PR TITLE
fix(scraper): keep extracted content when web_base_loader enrichment fetch fails

### DIFF
--- a/gpt_researcher/scraper/web_base_loader/web_base_loader.py
+++ b/gpt_researcher/scraper/web_base_loader/web_base_loader.py
@@ -34,12 +34,16 @@ class WebBaseLoaderScraper:
                     continue
                 content += str(page)
 
-            response = self.session.get(self.link)
-            soup = BeautifulSoup(response.content, 'html.parser')
-            image_urls = get_relevant_images(soup, self.link)
-            
-            # Extract the title using the utility function
-            title = extract_title(soup)
+            image_urls, title = [], ""
+            try:
+                response = self.session.get(self.link)
+                soup = BeautifulSoup(response.content, 'html.parser')
+                image_urls = get_relevant_images(soup, self.link)
+
+                # Extract the title using the utility function
+                title = extract_title(soup)
+            except Exception as e:
+                print("Error extracting images/title! : " + str(e))
 
             return content, image_urls, title
 

--- a/tests/test_web_base_loader_enrichment_guard.py
+++ b/tests/test_web_base_loader_enrichment_guard.py
@@ -1,0 +1,98 @@
+"""WebBaseLoaderScraper keeps already-extracted content when image/title enrichment fails."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "gpt_researcher" / "scraper" / "web_base_loader" / "web_base_loader.py"
+
+
+def _load(get_relevant_images=lambda soup, link: []):
+    bs4 = types.ModuleType("bs4")
+
+    class BeautifulSoup:
+        def __init__(self, *a, **k):
+            pass
+
+    bs4.BeautifulSoup = BeautifulSoup
+    sys.modules["bs4"] = bs4
+    req = types.ModuleType("requests")
+    req.Session = object
+    sys.modules.setdefault("requests", req)
+
+    pkg = types.ModuleType("gpt_researcher")
+    scraper = types.ModuleType("gpt_researcher.scraper")
+    utils = types.ModuleType("gpt_researcher.scraper.utils")
+    utils.get_relevant_images = get_relevant_images
+    utils.extract_title = lambda soup: "T"
+    sys.modules["gpt_researcher"] = pkg
+    sys.modules["gpt_researcher.scraper"] = scraper
+    sys.modules["gpt_researcher.scraper.utils"] = utils
+
+    lc = types.ModuleType("langchain_community")
+    lcd = types.ModuleType("langchain_community.document_loaders")
+
+    class WebBaseLoader:
+        def __init__(self, link):
+            self.link = link
+            self.requests_kwargs = {}
+
+        def load(self):
+            return [types.SimpleNamespace(page_content="real page content")]
+
+    lcd.WebBaseLoader = WebBaseLoader
+    sys.modules["langchain_community"] = lc
+    sys.modules["langchain_community.document_loaders"] = lcd
+
+    wpkg = types.ModuleType("gpt_researcher.scraper.web_base_loader")
+    sys.modules["gpt_researcher.scraper.web_base_loader"] = wpkg
+
+    spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.scraper.web_base_loader.web_base_loader", MODULE_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class WebBaseLoaderEnrichmentGuard(unittest.TestCase):
+    def test_keeps_content_when_enrichment_fetch_raises(self):
+        mod = _load()
+        session = MagicMock()
+        session.get.side_effect = ConnectionError("simulated transient network error")
+        scraper = mod.WebBaseLoaderScraper("https://ex.com", session=session)
+
+        content, images, title = scraper.scrape()
+
+        self.assertEqual(content, "real page content")
+        self.assertEqual(images, [])
+        self.assertEqual(title, "")
+
+    def test_keeps_content_when_enrichment_parsing_raises(self):
+        def boom(soup, link):
+            raise ValueError("malformed page")
+
+        mod = _load(get_relevant_images=boom)
+        session = MagicMock()
+        resp = MagicMock()
+        resp.content = b"<html></html>"
+        session.get.return_value = resp
+        scraper = mod.WebBaseLoaderScraper("https://ex.com", session=session)
+
+        content, images, title = scraper.scrape()
+
+        self.assertEqual(content, "real page content")
+        self.assertEqual(images, [])
+        self.assertEqual(title, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2077

`WebBaseLoaderScraper.scrape()` extracts content with `WebBaseLoader.load()`, then makes a second request purely for image/title enrichment (`self.session.get`). Both sat in the same `try` block, so a failure in the enrichment step (a transient network error, a rate limit hit only on the second round trip, a parse failure on a malformed page) fell into the blanket `except` and discarded content that had already been extracted successfully.

The fix wraps the enrichment fetch and parse in its own `try`/`except`, so a failure there only leaves `image_urls`/`title` empty instead of wiping `content`. Same split `beautiful_soup.py` already uses for the same class of bug.

Verification:
- New `tests/test_web_base_loader_enrichment_guard.py`: fails on `main` (content wiped to `""`), passes on this branch (content preserved, `image_urls`/`title` empty), for both a raised exception on the fetch and one raised during parsing.
- Full offline suite (`pytest tests/ --forked --timeout=60`, deselecting the three tests that need live credentials/network per the repo's own CI config): 391 passed, 1 skipped, matching `main`.
- `imports` and `collect` CI jobs reproduced locally, both clean.
