### PR TITLE
feat(retrievers): declare whether results need scraping, instead of guessing

### DIFF
--- a/gpt_researcher/retrievers/base.py
+++ b/gpt_researcher/retrievers/base.py
@@ -1,0 +1,61 @@
+"""Shared contract for retrievers.
+
+Retrievers fall into two kinds, and the difference matters:
+
+* most return **URLs that still need scraping** — the search API gives back a
+  link plus a short snippet, and the real page text is fetched later;
+* a few return **content they already fetched** — PubMed Central hands back
+  full article text, and a custom retriever's documented contract is
+  ``list[{url, raw_content}]``.
+
+Historically nothing recorded which kind a retriever was, so
+``_search_relevant_source_urls`` inferred it from the length of any
+``raw_content`` field::
+
+    if url and raw_content and len(raw_content) > 100:
+
+That guess is wrong whenever a snippet happens to exceed the threshold: the
+result is treated as already-fetched, its URL is never scraped, and the report
+ends up with no verifiable citation for it (#1846, #1892). The workaround was
+to cap snippet lengths inside individual retrievers so they stayed under 100
+characters -- per-retriever tuning to satisfy a heuristic.
+
+``requires_scraping`` replaces the guess with a declaration. It defaults to
+``True``, which is the correct answer for the large majority of retrievers.
+
+Declaring is optional. A retriever that does not define ``requires_scraping``
+-- including any third-party or user-defined one -- keeps the legacy
+length-based behaviour exactly, so nothing outside this repository has to
+change.
+"""
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class BaseRetriever(ABC):
+    """Optional base class documenting the retriever contract.
+
+    Subclassing is not required; ``_search_relevant_source_urls`` only looks
+    for a ``requires_scraping`` attribute. Inheriting simply makes the
+    declaration explicit and gives new retrievers a place to read the contract.
+    """
+
+    #: Whether results are URLs that still need fetching (``True``, the
+    #: default) or content the retriever has already retrieved (``False``).
+    #:
+    #: Override as a plain class attribute for a fixed answer, or as a
+    #: ``property`` when it depends on how the retriever was configured.
+    requires_scraping: bool = True
+
+    @abstractmethod
+    def search(self, max_results: int = 7) -> List[Dict[str, Any]]:
+        """Return search results.
+
+        With ``requires_scraping = True`` each item should carry a URL under
+        ``url`` or ``href``; any ``body``/``snippet`` is treated as a preview
+        and the page is scraped for its real content.
+
+        With ``requires_scraping = False`` each item should carry a URL and the
+        already-retrieved text under ``raw_content``; no scraping is performed.
+        """
+        raise NotImplementedError

--- a/gpt_researcher/retrievers/custom/custom.py
+++ b/gpt_researcher/retrievers/custom/custom.py
@@ -8,6 +8,10 @@ class CustomRetriever:
     Custom API Retriever
     """
 
+    # The documented contract is list[{url, raw_content}] -- the caller's own
+    # endpoint supplies the content.
+    requires_scraping = False
+
     def __init__(self, query: str, query_domains=None):
         self.endpoint = os.getenv('RETRIEVER_ENDPOINT')
         if not self.endpoint:

--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -23,6 +23,10 @@ class Duckduckgo:
     """
     Duckduckgo API Retriever
     """
+
+    # ddgs returns a snippet in "body"; the real page text still has to be
+    # fetched.
+    requires_scraping = True
     def __init__(self, query, query_domains=None):
         check_pkg('ddgs')
         from ddgs import DDGS

--- a/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
+++ b/gpt_researcher/retrievers/pubmed_central/pubmed_central.py
@@ -9,6 +9,10 @@ class PubMedCentralSearch:
     PubMed Central Full-Text Search
     """
 
+    # PubMed Central returns full article text inline, so there is nothing
+    # left to scrape.
+    requires_scraping = False
+
     def __init__(self, query: str, query_domains=None):
         self.base_search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
         self.base_fetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -26,6 +26,10 @@ class SearxSearch():
     """
     SearxNG API Retriever
     """
+
+    # SearxNG puts an ordinary result snippet in "content"/"body"; the real
+    # page text still has to be fetched.
+    requires_scraping = True
     def __init__(self, query: str, query_domains=None):
         """
         Initializes the SearxSearch object

--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -20,6 +20,10 @@ class TavilySearch:
     Tavily API Retriever
     """
 
+    # Tavily's search() never sets include_raw_content, so results are always
+    # links plus a snippet -- the page still has to be scraped.
+    requires_scraping = True
+
     def __init__(self, query, headers=None, topic="general", query_domains=None):
         """
         Initializes the TavilySearch object.

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -848,19 +848,45 @@ class ResearchConductor:
                 if not search_results:
                     continue
 
+                # Does this retriever return URLs to scrape, or content it
+                # already fetched? Prefer an explicit declaration
+                # (BaseRetriever.requires_scraping); fall back to the legacy
+                # length heuristic when the retriever does not declare, so
+                # third-party and user-defined retrievers are unaffected.
+                requires_scraping = getattr(retriever, "requires_scraping", None)
+
                 # Separate results that already have content from those needing scraping
                 for result in search_results:
                     url = result.get("href") or result.get("url")
                     raw_content = result.get("raw_content")
-                    if url and raw_content and len(raw_content) > 100:
-                        # Only raw_content signals that a retriever already fetched the full page.
-                        # body is snippet-sized text for most web retrievers and still needs scraping.
+
+                    if not url:
+                        continue
+
+                    if requires_scraping is True:
+                        # Declared: anything alongside the URL is a preview,
+                        # however long, so the page is still fetched. This is
+                        # what stops a long snippet from being mistaken for
+                        # article text and the citation being lost.
+                        new_search_urls.append(url)
+                    elif requires_scraping is False:
+                        # Declared: the retriever fetched the content itself.
+                        if raw_content:
+                            prefetched_content.append({
+                                "url": url,
+                                "raw_content": raw_content,
+                            })
+                            self.researcher.add_research_sources([{"url": url}])
+                        else:
+                            new_search_urls.append(url)
+                    elif raw_content and len(raw_content) > 100:
+                        # Undeclared: legacy behaviour, unchanged.
                         prefetched_content.append({
                             "url": url,
                             "raw_content": raw_content,
                         })
                         self.researcher.add_research_sources([{"url": url}])
-                    elif url:
+                    else:
                         new_search_urls.append(url)
             except Exception as e:
                 self.logger.error(f"Error searching with {retriever_class.__name__}: {e}")

--- a/tests/test_retriever_requires_scraping.py
+++ b/tests/test_retriever_requires_scraping.py
@@ -1,0 +1,129 @@
+"""Retrievers declare whether their results still need scraping (#1846, #1892).
+
+`_search_relevant_source_urls` used to infer this from the length of any
+`raw_content` field -- anything over 100 characters was assumed to be an
+already-fetched page. A search snippet longer than that was therefore treated
+as article text, its URL was never scraped, and the report carried no
+verifiable citation for it.
+
+`BaseRetriever.requires_scraping` replaces the guess with a declaration. The
+legacy heuristic is kept for retrievers that do not declare, so third-party and
+user-defined retrievers behave exactly as before.
+"""
+import asyncio
+import types
+
+import pytest
+
+from gpt_researcher.retrievers.base import BaseRetriever
+from gpt_researcher.skills.researcher import ResearchConductor
+
+LONG_SNIPPET = "a plausible search snippet " * 20  # >100 chars, but only a snippet
+
+
+def _conductor(retriever_classes):
+    researcher = types.SimpleNamespace(
+        retrievers=retriever_classes,
+        cfg=types.SimpleNamespace(max_search_results_per_query=5),
+        add_research_sources=lambda *a, **k: None,
+        visited_urls=set(),
+        verbose=False,
+        websocket=None,
+    )
+    c = ResearchConductor(researcher)
+    c.logger = types.SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None
+    )
+    # _get_new_urls dedupes against researcher state; identity keeps tests focused.
+    c._get_new_urls = lambda urls: asyncio.sleep(0, result=urls)
+    return c
+
+
+def _make(name, results, **attrs):
+    def __init__(self, query, query_domains=None, **kw):
+        pass
+
+    def search(self, max_results=7):
+        return results
+
+    return type(name, (), {"__init__": __init__, "search": search, **attrs})
+
+
+def _run(conductor):
+    return asyncio.run(conductor._search_relevant_source_urls("q"))
+
+
+def test_declared_scraping_keeps_long_snippets_scrapeable():
+    """The #1846 / #1892 regression: a >100 char snippet must not suppress scraping."""
+    R = _make("SnippetRetriever",
+              [{"url": "https://example.com/a", "raw_content": LONG_SNIPPET}],
+              requires_scraping=True)
+    urls, prefetched = _run(_conductor([R]))
+    assert urls == ["https://example.com/a"]
+    assert prefetched == []
+
+
+def test_declared_content_is_used_without_scraping():
+    R = _make("FullTextRetriever",
+              [{"url": "https://example.com/b", "raw_content": "real article text"}],
+              requires_scraping=False)
+    urls, prefetched = _run(_conductor([R]))
+    assert urls == []
+    assert prefetched == [{"url": "https://example.com/b", "raw_content": "real article text"}]
+
+
+def test_declared_content_falls_back_to_scraping_when_empty():
+    """requires_scraping=False but no content on this row -- still worth fetching."""
+    R = _make("PartialRetriever", [{"url": "https://example.com/c"}], requires_scraping=False)
+    urls, prefetched = _run(_conductor([R]))
+    assert urls == ["https://example.com/c"]
+    assert prefetched == []
+
+
+def test_undeclared_retriever_keeps_legacy_behaviour():
+    """Third-party retrievers must be unaffected: >100 chars still means content."""
+    R = _make("LegacyRetriever",
+              [{"url": "https://example.com/d", "raw_content": LONG_SNIPPET}])
+    urls, prefetched = _run(_conductor([R]))
+    assert urls == []
+    assert prefetched and prefetched[0]["url"] == "https://example.com/d"
+
+
+def test_undeclared_short_content_still_scrapes():
+    R = _make("LegacyShort", [{"url": "https://example.com/e", "raw_content": "tiny"}])
+    urls, prefetched = _run(_conductor([R]))
+    assert urls == ["https://example.com/e"]
+    assert prefetched == []
+
+
+def test_rows_without_a_url_are_skipped():
+    R = _make("NoUrl", [{"raw_content": LONG_SNIPPET}, {"url": "https://example.com/f"}],
+              requires_scraping=True)
+    urls, prefetched = _run(_conductor([R]))
+    assert urls == ["https://example.com/f"]
+    assert prefetched == []
+
+
+def test_base_class_defaults_to_requiring_scraping():
+    assert BaseRetriever.requires_scraping is True
+
+
+def test_base_class_requires_a_search_method():
+    with pytest.raises(TypeError):
+        BaseRetriever()  # abstract: search() is not implemented
+
+
+@pytest.mark.parametrize(
+    "import_path, cls_name, expected",
+    [
+        ("gpt_researcher.retrievers.tavily.tavily_search", "TavilySearch", True),
+        ("gpt_researcher.retrievers.searx.searx", "SearxSearch", True),
+        ("gpt_researcher.retrievers.duckduckgo.duckduckgo", "Duckduckgo", True),
+        ("gpt_researcher.retrievers.pubmed_central.pubmed_central", "PubMedCentralSearch", False),
+        ("gpt_researcher.retrievers.custom.custom", "CustomRetriever", False),
+    ],
+)
+def test_shipped_declarations(import_path, cls_name, expected):
+    import importlib
+    cls = getattr(importlib.import_module(import_path), cls_name)
+    assert cls.requires_scraping is expected


### PR DESCRIPTION
Replaces a heuristic with a declaration on the retrieval hot path. Closes the design gap behind #1846 and #1892.

## The problem

`_search_relevant_source_urls()` has to decide, for every result, whether a retriever already fetched the page or only returned a link. Nothing recorded that, so it guessed from length:

```python
if url and raw_content and len(raw_content) > 100:
```

Any snippet over 100 characters was treated as article text — the URL was never scraped, and the report shipped with no verifiable citation for that source. The fix at the time was to cap snippet lengths *inside* the Searx and DuckDuckGo retrievers so they stayed under the threshold. That works, but it is per-retriever tuning to satisfy a heuristic, and it has to be repeated for every retriever that ever returns a long snippet.

## The change

`BaseRetriever` with a `requires_scraping` attribute, defaulting to `True`, declared on the five retrievers where the answer is known:

| retriever | value | why |
|---|---|---|
| `TavilySearch` | `True` | `search()` never sets `include_raw_content` |
| `SearxSearch` | `True` | `content` is an ordinary result snippet |
| `Duckduckgo` | `True` | `body` is an ordinary result snippet |
| `PubMedCentralSearch` | `False` | returns full article text inline |
| `CustomRetriever` | `False` | contract is `list[{url, raw_content}]` |

## Deliberately conservative

Given how widely this is deployed, the scope is narrow on purpose:

- **Declaring is optional.** A retriever with no `requires_scraping` keeps the exact legacy length behaviour. Third-party and user-defined retrievers are untouched — this is additive, not breaking.
- **The other 18 shipped retrievers are left undeclared.** Their behaviour is unchanged; they can be annotated as each is confirmed.
- **The existing snippet caps stay.** They are redundant under the declaration but harmless, and removing them deserves its own change.
- **Subclassing is not required.** The call site only looks for the attribute; the class documents the contract.

This is intentionally *not* the "massive refactor" of #1007 — no key-name normalisation, no forced inheritance. Those are the risky parts and they are not needed to fix the defect.

## Verification

```
406 tests pass on real 3.12 and 3.14
```

The two behavioural tests **fail against the previous classification and pass after it** — I checked, so they are load-bearing rather than decorative.

Live research runs, both paths:

| | sources | cost | context |
|---|---|---|---|
| Tavily (default) | 13 | $0.1433 | 40,517 |
| DuckDuckGo | 10 | $0.1416 | 40,416 |
| *pre-change baselines* | *13–16* | *$0.13–0.15* | *40,865–43,641* |

Context volume is the stable metric across runs; source counts vary run to run with what the search APIs return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
