### PR TITLE
fix: correct typos in user-facing warnings, subtopic prompt, and docstring

### DIFF
--- a/gpt_researcher/prompts.py
+++ b/gpt_researcher/prompts.py
@@ -686,7 +686,7 @@ Using the latest information available, construct a draft section title headers 
 "Task":
 1. Create a list of draft section title headers for the subtopic report.
 2. Each header should be concise and relevant to the subtopic.
-3. The header should't be too high level, but detailed enough to cover the main aspects of the subtopic.
+3. The header shouldn't be too high level, but detailed enough to cover the main aspects of the subtopic.
 4. Use markdown syntax for the headers, using H3 (###) as H1 and H2 will be used for the larger report's heading.
 5. Ensure the headers cover main aspects of the subtopic.
 

--- a/gpt_researcher/retrievers/crw/crw.py
+++ b/gpt_researcher/retrievers/crw/crw.py
@@ -52,7 +52,7 @@ class CRWRetriever:
                 api_key = os.environ["CRW_API_KEY"]
             except KeyError:
                 print(
-                    "CRW API key not found, set to blank. If you need a retriver, please set the CRW_API_KEY environment variable."
+                    "CRW API key not found, set to blank. If you need a retriever, please set the CRW_API_KEY environment variable."
                 )
                 return ""
         return api_key

--- a/gpt_researcher/retrievers/tavily/tavily_search.py
+++ b/gpt_researcher/retrievers/tavily/tavily_search.py
@@ -56,7 +56,7 @@ class TavilySearch:
                 api_key = os.environ["TAVILY_API_KEY"]
             except KeyError:
                 print(
-                    "Tavily API key not found, set to blank. If you need a retriver, please set the TAVILY_API_KEY environment variable."
+                    "Tavily API key not found, set to blank. If you need a retriever, please set the TAVILY_API_KEY environment variable."
                 )
                 return ""
         return api_key

--- a/gpt_researcher/utils/llm.py
+++ b/gpt_researcher/utils/llm.py
@@ -59,7 +59,7 @@ async def create_chat_completion(
         max_tokens (int, optional): The max tokens to use. Defaults to 4000.
         llm_provider (str, optional): The LLM Provider to use.
         stream (bool): Whether to stream the response. Defaults to False.
-        webocket (WebSocket): The websocket used in the currect request,
+        websocket (WebSocket): The websocket used in the current request,
         llm_kwargs (dict[str, Any], optional): Additional LLM keyword arguments. Defaults to None.
         cost_callback: Callback function for updating cost.
         reasoning_effort (str, optional): Reasoning effort for OpenAI's reasoning models. Defaults to 'low'.


### PR DESCRIPTION
This PR fixes four small typos in user-facing / functional strings (no logic changes).

### Problems + fixes

1. **`gpt_researcher/retrievers/crw/crw.py:55`** and **`gpt_researcher/retrievers/tavily/tavily_search.py:59`** — the API-key warning printed to users reads `If you need a retriver, please set the ...` → `retriver` corrected to **retriever**. This message is shown directly to end users when the key is missing.

2. **`gpt_researcher/prompts.py:689`** — a line in the subtopic-report-structure prompt sent to the LLM reads `The header should't be too high level` → `should't` corrected to **shouldn't**. This text is part of a prompt the model actually reads, so the fix improves prompt clarity.

3. **`gpt_researcher/utils/llm.py:62`** — the `create_chat_completion` docstring documents the parameter as `webocket (WebSocket): The websocket used in the currect request`. The actual signature parameter is `websocket` (line 48), so the docstring name is corrected to **websocket**, and `currect` → **current**.

### How to verify
- `grep -rn "retriver\|should't\|webocket\|currect" gpt_researcher/` returns no matches after this change.
- The `websocket` fix now matches the real parameter name in the `create_chat_completion` signature (`gpt_researcher/utils/llm.py:48`).

No functional/behavioral change beyond the corrected prompt text and the corrected user-visible warning wording.
