### PR TITLE
feat: two-stage source filtering to exclude unwanted sources

### DIFF
--- a/docs/docs/gpt-researcher/gptr/config.md
+++ b/docs/docs/gpt-researcher/gptr/config.md
@@ -102,6 +102,10 @@ The hard upper bound is 200k (sanity guard against typos).
 - **`DEEP_RESEARCH_DEPTH`**: Controls the depth of deep research, defining how many sequential searches to perform. Defaults to `2`.
 - **`DEEP_RESEARCH_CONCURRENCY`**: Controls the concurrency level for deep research operations. Defaults to `4`.
 - **`REASONING_EFFORT`**: Controls the reasoning effort of strategic models. Default to `medium`.
+- **`SOURCE_ASSESSMENT_PROMPT`**: Optional admission policy text for source quality gating. When set, scraped sources are scored by a fast LLM and rejected if their violation score exceeds the threshold. Defaults to `None` (disabled). See [Source Admission Policy](/docs/gpt-researcher/gptr/source-admission-policy) for details.
+- **`SOURCE_ASSESSMENT_THRESHOLD`**: Maximum violation score `[0.0, 1.0]` for source acceptance. Defaults to `0.25`.
+- **`SOURCE_ASSESSMENT_MAX_CONTENT_CHARS`**: Raw content characters sent to the LLM per source during assessment. Defaults to `12000`. Use `-1` for full content.
+- **`SOURCE_ASSESSMENT_MAX_CONCURRENCY`**: Maximum number of sources assessed in parallel. Defaults to `4`.
 
 ## Deep Research Configuration
 

--- a/docs/docs/gpt-researcher/gptr/source-admission-policy.md
+++ b/docs/docs/gpt-researcher/gptr/source-admission-policy.md
@@ -1,0 +1,157 @@
+---
+sidebar_label: Source Admission Policy
+---
+
+# Source Admission Policy
+
+An optional LLM-based quality gate that evaluates scraped sources against a caller-provided admission policy before inclusion in research. Sources that violate the policy are rejected, improving the signal-to-noise ratio of the final report.
+
+## How It Works
+
+1. After scraping, each source's content is sent to a fast LLM for scoring
+2. The LLM returns a violation score in `[0.0, 1.0]` — lower means cleaner
+3. Sources with a score above the threshold are rejected
+4. Accepted sources proceed to context management and report generation
+
+The policy is entirely caller-defined. You control what counts as a violation by writing the admission prompt.
+
+## Quick Start
+
+```python
+from gpt_researcher import GPTResearcher
+import asyncio
+
+async def main():
+    researcher = GPTResearcher(
+        query="latest developments in quantum computing",
+        source_assessment_prompt=(
+            "Accept only independent, primary sources with original data or analysis. "
+            "Reject press releases, blogs, opinion pieces, and derivative content "
+            "that merely repeats other sources."
+        ),
+        source_assessment_threshold=0.25,
+    )
+
+    await researcher.conduct_research()
+    report = await researcher.write_report()
+    print(report)
+
+    # Inspect assessment results
+    for a in researcher.get_source_assessments():
+        status = "ACCEPTED" if a["accepted"] else "REJECTED"
+        print(f"  [{status}] {a['url']} — score: {a['score']}, reason: {a['reason']}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+When `source_assessment_prompt` is not set (the default), the feature is disabled and all scraped sources are accepted as before.
+
+## Configuration
+
+| Parameter | Default | Description |
+|---|---|---|
+| `source_assessment_prompt` | `None` (disabled) | Free-text policy the LLM evaluates each source against |
+| `source_assessment_threshold` | `0.25` | Maximum violation score for acceptance. Set to `0.0` for strict rejection, `1.0` to accept all |
+| `source_assessment_max_content_chars` | `12000` | Number of raw content characters sent to the LLM per source. Use `-1` for full content |
+| `source_assessment_max_concurrency` | `4` | Maximum number of sources assessed in parallel |
+
+The assessment uses the `FAST_LLM` model configured on the researcher, so it runs quickly and at low cost.
+
+### Writing Effective Policies
+
+A good admission policy is specific about what to accept and reject:
+
+```python
+# Strict — only primary research
+policy = (
+    "Accept peer-reviewed papers, official documentation, and original data sources. "
+    "Reject news articles, blogs, forums, Wikipedia, and any secondary summaries."
+)
+
+# Domain-specific
+policy = (
+    "Accept sources from established financial institutions, regulatory filings, "
+    "and recognized financial news outlets. Reject personal blogs, social media posts, "
+    "and unverified market commentary."
+)
+```
+
+### Fact-Checking Claims
+
+The most powerful use case is **fact-checking**: verifying a claim by excluding the claimant and all derivative sources from the research scope. This forces the researcher to find independent corroboration — or lack thereof.
+
+For example, to verify a Gartner prediction you want zero Gartner content in the results:
+
+```python
+researcher = GPTResearcher(
+    query="AI agent market size 2030 prediction accuracy",
+    source_assessment_prompt=(
+        "You are verifying an independent claim. Accept only sources that are "
+        "completely independent of Gartner. Reject any Gartner publications, "
+        "Gartner citations, Gartner press releases, articles quoting Gartner analysts, "
+        "and any derivative content that references or relies on Gartner research. "
+        "Only accept original data from other analysts, company filings, market reports "
+        "from other firms, and independent empirical studies."
+    ),
+    source_assessment_threshold=0.2,
+)
+```
+
+This pattern generalizes to any claim verification:
+
+```python
+# Verify a company's sustainability claims
+policy = (
+    "Accept only third-party audits, regulatory filings, NGO reports, and independent "
+    "journalistic investigations. Reject all content published by Acme Corp, Acme Corp "
+    "press releases, Acme-sponsored research, trade publications funded by Acme, and "
+    "any article that primarily cites Acme as its source."
+)
+```
+
+The key principle: **name the entity to exclude explicitly**, then block its publications, citations, sponsored content, and derivatives. Set a low threshold (`0.1`–`0.3`) to ensure strict enforcement.
+
+## Accessing Assessment Results
+
+After research completes, inspect the assessment records:
+
+```python
+# All assessments (accepted + rejected)
+assessments = researcher.get_source_assessments()
+
+# Only rejected sources
+rejected = researcher.get_rejected_sources()
+```
+
+Each assessment record contains:
+
+```python
+{
+    "url": "https://example.com/article",
+    "title": "Article Title",
+    "accepted": True,           # Boolean decision
+    "score": 0.1,               # Violation score [0.0, 1.0]
+    "reason": "Independent data analysis.",
+    "matched_policy": "primary_sources",
+}
+```
+
+## Behavior Details
+
+- **Scraped sources**: Assessed after scraping in `BrowserManager.browse_urls()`
+- **Pre-fetched content**: Retriever results that already contain full text (e.g., PubMed, arXiv) are assessed before merging with scraped content
+- **LLM failures**: If the LLM call fails or returns malformed output, the source is rejected with a descriptive error reason
+- **Score coercion**: Scores outside `[0.0, 1.0]` or non-numeric values cause rejection — the `accepted` flag from the LLM response is ignored; only the numeric score matters
+
+## Performance Considerations
+
+- Each assessment incurs one fast LLM call. For a typical research run with 15–30 sources, expect modest additional cost
+- Concurrency is capped at `source_assessment_max_concurrency` to avoid overwhelming the LLM provider
+- Content is truncated to `source_assessment_max_content_chars` to keep token usage predictable
+
+## Limitations
+
+- Adds latency proportional to the number of scraped sources
+- Requires a functioning LLM provider; assessment cannot run offline
+- Policy quality depends on how clearly you articulate acceptance criteria

--- a/docs/docs/gpt-researcher/search-engines/exclude-terms.md
+++ b/docs/docs/gpt-researcher/search-engines/exclude-terms.md
@@ -1,0 +1,62 @@
+# Exclude Terms
+
+The `search_exclude_terms` feature lets you exclude specific terms from search results by appending Google-style exclusion operators to the query string before it is sent to the search engine.
+
+## Usage
+
+Pass a list of terms when constructing `GPTResearcher`:
+
+```python
+researcher = GPTResearcher(
+    query="PC sales in 2012",
+    search_exclude_terms=["gartner", "market share"],
+)
+```
+
+The query sent to the search engine becomes:
+
+```
+PC sales in 2012 -gartner -"market share"
+```
+
+Single-word terms get a leading `-`. Multi-word terms are wrapped in quotes (`-"multi word"`). If a multi-word term itself contains double quotes it is wrapped in single quotes instead.
+
+## Supported Retrievers
+
+| Retriever | Status |
+|---|---|
+| DuckDuckGo | Supported |
+| Google (Custom Search) | Supported |
+| Brave Search | Supported |
+| Serper | Supported |
+| SerpAPI | Supported |
+| SearchApi | Supported |
+| SearxNG | Supported |
+
+All supported retrievers use the same Google-style `-term` exclusion syntax, which is honored by their underlying search engines.
+
+## Unsupported Retrievers
+
+When `search_exclude_terms` is configured with an unsupported retriever, a warning is logged and the search proceeds without exclusion.
+
+| Retriever | Reason |
+|---|---|
+| **Bing** | The Bing Web Search API deprecated advanced query operators (`-term`, `site:`, etc.). Appending `-term` would be treated as literal text and degrade query relevance. |
+| **BoCha** | No documented operator support in the BoCha API. |
+| **Tavily** | Tavily uses natural-language queries; its API only offers `exclude_domains` for domain-level filtering. Operator syntax is not interpreted. |
+| **Exa** | Exa performs neural/semantic search by default and does not support boolean exclusion operators. |
+| **arXiv** | Uses its own query language (fielded terms like `ti:`, `au:`, boolean `AND`/`NOT`). Generic `-term` syntax is not applicable; scholarly metadata search rarely benefits from term exclusion. |
+| **Semantic Scholar** | Domain-specific query API with its own syntax; term exclusion operators are not supported. |
+| **PubMed Central** | Uses Entrez E-Search with MEDLINE indexing terms; a fundamentally different query model. |
+| **OpenAlex** | Uses `?search=` text-matching parameter without boolean operator support. |
+| **GetXAPI / Xquik** | X/Twitter advanced search has its own operator semantics distinct from web-search exclusion. |
+| **fastCRW (crw)** | Aggregator/passthrough API without documented term-exclusion support. |
+| **GroundRoute** | Multi-engine router; exclusion would need to be handled by the underlying engine selection, not the query string. |
+| **Custom** | User-defined endpoint — exclusion semantics belong to the endpoint implementation. |
+| **MCP** | Separate instantiation path; tool-driven research with no free-text query to modify. |
+
+## Runtime Behavior
+
+- **Empty or unset**: When `search_exclude_terms` is not provided (default), retrievers behave exactly as if the feature did not exist — no kwarg is passed, no query modification occurs.
+- **Configured + supported retriever**: Exclusion operators are appended to the query string before the search request.
+- **Configured + unsupported retriever**: A warning is logged (`<RetrieverName> does not support exclude_terms; ignoring`) and the search proceeds with the original query.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -41,6 +41,7 @@
         'gpt-researcher/gptr/ai-development',
         'gpt-researcher/gptr/config',
         'gpt-researcher/gptr/scraping',
+        'gpt-researcher/gptr/source-admission-policy',
         'gpt-researcher/gptr/querying-the-backend',
         'gpt-researcher/gptr/automated-tests',
         'gpt-researcher/gptr/troubleshooting'

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -107,6 +107,7 @@
       collapsed: true,
       items: [
         'gpt-researcher/search-engines/search-engines',
+        'gpt-researcher/search-engines/exclude-terms',
         'gpt-researcher/retrievers/mcp-configs',
         'gpt-researcher/search-engines/test-your-retriever',
         ]

--- a/gpt_researcher/actions/query_processing.py
+++ b/gpt_researcher/actions/query_processing.py
@@ -38,6 +38,7 @@ def _normalize_sub_queries(parsed: Any, fallback_query: str) -> List[str]:
     if not queries and fallback_query.strip():
         return [fallback_query.strip()]
     return queries
+from ..retrievers.utils import supports_exclude_terms
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ async def get_search_results(
     query_domains: List[str] = None,
     researcher=None,
     max_results: int | None = None,
+    exclude_terms: List[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get web search results for a given query.
@@ -57,6 +59,7 @@ async def get_search_results(
         query_domains: Optional list of domains to search
         researcher: The researcher instance (needed for MCP retrievers)
         max_results: Optional cap on the number of results
+        exclude_terms: Optional list of terms to exclude from search results
 
     Returns:
         A list of search results
@@ -66,12 +69,21 @@ async def get_search_results(
     # Check if this is an MCP retriever and pass the researcher instance
     if "mcpretriever" in retriever.__name__.lower():
         search_retriever = retriever(
-            query, 
+            query,
             query_domains=query_domains,
             researcher=researcher  # Pass researcher instance for MCP retrievers
         )
     else:
-        search_retriever = retriever(query, query_domains=query_domains)
+        if exclude_terms and supports_exclude_terms(retriever):
+            search_retriever = retriever(
+                query, query_domains=query_domains, exclude_terms=exclude_terms
+            )
+        else:
+            if exclude_terms:
+                logger.warning(
+                    f"{retriever.__name__} does not support exclude_terms; ignoring"
+                )
+            search_retriever = retriever(query, query_domains=query_domains)
 
     search_kwargs = {}
     if max_results is not None:

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -28,6 +28,7 @@ from .skills.curator import SourceCurator
 from .skills.deep_research import DeepResearchSkill
 from .skills.image_generator import ImageGenerator
 from .skills.researcher import ResearchConductor
+from .skills.source_assessor import SourceAssessor
 from .skills.writer import ReportGenerator
 from .utils.enum import ReportSource, ReportType, Tone
 from .utils.llm import create_chat_completion
@@ -80,6 +81,10 @@ class GPTResearcher:
         mcp_configs: list[dict] | None = None,
         mcp_max_iterations: int | None = None,
         mcp_strategy: str | None = None,
+        source_assessment_prompt: str | None = None,
+        source_assessment_threshold: float = 0.25,
+        source_assessment_max_content_chars: int = 12000,
+        source_assessment_max_concurrency: int = 4,
         **kwargs
     ):
         """
@@ -150,6 +155,12 @@ class GPTResearcher:
         self.query_domains = query_domains or []
         self.research_sources = []  # The list of scraped sources including title, content and images
         self.research_images = []  # The list of selected research images
+        self.source_assessment_prompt = source_assessment_prompt
+        self.source_assessment_threshold = source_assessment_threshold
+        self.source_assessment_max_content_chars = source_assessment_max_content_chars
+        self.source_assessment_max_concurrency = source_assessment_max_concurrency
+        self.source_assessments: list[dict[str, Any]] = []
+        self.rejected_sources: list[dict[str, Any]] = []
         self.documents = documents
         self.vector_store = VectorStoreWrapper(vector_store) if vector_store else None
         self.vector_store_filter = vector_store_filter
@@ -188,6 +199,7 @@ class GPTResearcher:
         self.context_manager: ContextManager = ContextManager(self)
         self.scraper_manager: BrowserManager = BrowserManager(self)
         self.source_curator: SourceCurator = SourceCurator(self)
+        self.source_assessor: SourceAssessor = SourceAssessor(self)
         self.deep_researcher: Optional[DeepResearchSkill] = None
         if report_type == ReportType.DeepResearch.value:
             self.deep_researcher = DeepResearchSkill(self)
@@ -684,6 +696,22 @@ class GPTResearcher:
             sources: List of source dictionaries to add.
         """
         self.research_sources.extend(sources)
+
+    def get_source_assessments(self) -> list[dict[str, Any]]:
+        """Get source assessment records collected during research."""
+        return list(self.source_assessments)
+
+    def add_source_assessments(self, assessments: list[dict[str, Any]]) -> None:
+        """Add source assessment records."""
+        self.source_assessments.extend(assessments)
+
+    def get_rejected_sources(self) -> list[dict[str, Any]]:
+        """Get rejected source assessment records collected during research."""
+        return list(self.rejected_sources)
+
+    def add_rejected_sources(self, sources: list[dict[str, Any]]) -> None:
+        """Add rejected source assessment records."""
+        self.rejected_sources.extend(sources)
 
     def add_references(self, report_markdown: str, visited_urls: set) -> str:
         """Add reference section to a markdown report.

--- a/gpt_researcher/agent.py
+++ b/gpt_researcher/agent.py
@@ -85,6 +85,7 @@ class GPTResearcher:
         source_assessment_threshold: float = 0.25,
         source_assessment_max_content_chars: int = 12000,
         source_assessment_max_concurrency: int = 4,
+        search_exclude_terms: list[str] | None = None,
         **kwargs
     ):
         """
@@ -159,6 +160,7 @@ class GPTResearcher:
         self.source_assessment_threshold = source_assessment_threshold
         self.source_assessment_max_content_chars = source_assessment_max_content_chars
         self.source_assessment_max_concurrency = source_assessment_max_concurrency
+        self.search_exclude_terms = search_exclude_terms or []
         self.source_assessments: list[dict[str, Any]] = []
         self.rejected_sources: list[dict[str, Any]] = []
         self.documents = documents
@@ -552,7 +554,11 @@ class GPTResearcher:
             search_results = await self._search_all_retrievers(query, query_domains)
         else:
             search_results = await get_search_results(
-                query, self.retrievers[0], query_domains=query_domains, researcher=self
+                query,
+                self.retrievers[0],
+                query_domains=query_domains,
+                researcher=self,
+                exclude_terms=self.search_exclude_terms,
             )
 
         if not aggregated_summary:
@@ -598,7 +604,13 @@ class GPTResearcher:
             A merged, de-duplicated list of search results.
         """
         tasks = [
-            get_search_results(query, retriever, query_domains=query_domains, researcher=self)
+            get_search_results(
+                query,
+                retriever,
+                query_domains=query_domains,
+                researcher=self,
+                exclude_terms=self.search_exclude_terms,
+            )
             for retriever in self.retrievers
         ]
         results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/gpt_researcher/retrievers/brave/brave.py
+++ b/gpt_researcher/retrievers/brave/brave.py
@@ -3,8 +3,10 @@
 # libraries
 import logging
 import os
+from typing import List, Optional
 
 import requests
+from ..utils import append_exclude_terms
 
 
 class BraveSearch:
@@ -12,13 +14,15 @@ class BraveSearch:
     Brave Search API Retriever
     """
 
-    def __init__(self, query, query_domains=None):
+    def __init__(self, query: str, query_domains: Optional[List[str]] = None, exclude_terms: Optional[List[str]] = None):
         """
         Initializes the BraveSearch object
         Args:
-            query:
+            query: The search query string.
+            query_domains: Optional list of domains to restrict search to.
+            exclude_terms: Optional list of terms to exclude from results.
         """
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.query_domains = query_domains or None
         self.api_key = self.get_api_key()
         self.logger = logging.getLogger(__name__)

--- a/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
+++ b/gpt_researcher/retrievers/duckduckgo/duckduckgo.py
@@ -1,5 +1,6 @@
 from itertools import islice
-from ..utils import check_pkg
+from typing import List, Optional
+from ..utils import append_exclude_terms, check_pkg
 
 # gpt_researcher.skills.researcher._search_relevant_source_urls() treats
 # any search result whose raw_content/body exceeds 100 characters as
@@ -23,15 +24,15 @@ class Duckduckgo:
     """
     Duckduckgo API Retriever
     """
-
-    # ddgs returns a snippet in "body"; the real page text still has to be
-    # fetched.
+    # ddgs returns a snippet in "body"; the real page text still has to
+    # be fetched.
     requires_scraping = True
-    def __init__(self, query, query_domains=None):
+
+    def __init__(self, query: str, query_domains: Optional[List[str]] = None, exclude_terms: Optional[List[str]] = None):
         check_pkg('ddgs')
         from ddgs import DDGS
         self.ddg = DDGS()
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.query_domains = query_domains or None
 
     def search(self, max_results=5):

--- a/gpt_researcher/retrievers/google/google.py
+++ b/gpt_researcher/retrievers/google/google.py
@@ -1,23 +1,28 @@
-# Tavily API Retriever
+# Google Custom Search API Retriever
 
 # libraries
 import os
 import requests
 import json
+from typing import List, Optional
 from urllib.parse import urlencode
+from ..utils import append_exclude_terms
 
 
 class GoogleSearch:
     """
     Google API Retriever
     """
-    def __init__(self, query, headers=None, query_domains=None):
+    def __init__(self, query: str, headers=None, query_domains: Optional[List[str]] = None, exclude_terms: Optional[List[str]] = None):
         """
         Initializes the GoogleSearch object
         Args:
-            query:
+            query: The search query string.
+            headers: Additional headers (api keys).
+            query_domains: Optional list of domains to restrict search to.
+            exclude_terms: Optional list of terms to exclude from results.
         """
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.headers = headers or {}
         self.query_domains = query_domains or None
         self.api_key = self.headers.get("google_api_key") or self.get_api_key()  # Use the passed api_key or fallback to environment variable

--- a/gpt_researcher/retrievers/searchapi/searchapi.py
+++ b/gpt_researcher/retrievers/searchapi/searchapi.py
@@ -5,19 +5,24 @@ import logging
 import os
 import requests
 import urllib.parse
+from typing import List, Optional
+
+from ..utils import append_exclude_terms
 
 
 class SearchApiSearch():
     """
     SearchApi Retriever
     """
-    def __init__(self, query, query_domains=None):
+    def __init__(self, query: str, query_domains: Optional[List[str]] = None, exclude_terms: Optional[List[str]] = None):
         """
         Initializes the SearchApiSearch object
         Args:
-            query:
+            query: The search query string.
+            query_domains: Optional list of domains to restrict search to.
+            exclude_terms: Optional list of terms to exclude from results.
         """
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.api_key = self.get_api_key()
 
     def get_api_key(self):

--- a/gpt_researcher/retrievers/searx/searx.py
+++ b/gpt_researcher/retrievers/searx/searx.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-from typing import List, Dict
+from typing import Dict, List, Optional
 from urllib.parse import urljoin
 
 # gpt_researcher.skills.researcher._search_relevant_source_urls() treats
@@ -21,22 +21,26 @@ from urllib.parse import urljoin
 # actual page content, not this snippet.
 _MAX_PREFETCHED_LEN = 100
 
+from ..utils import append_exclude_terms
+
 
 class SearxSearch():
     """
     SearxNG API Retriever
     """
-
     # SearxNG puts an ordinary result snippet in "content"/"body"; the real
     # page text still has to be fetched.
     requires_scraping = True
-    def __init__(self, query: str, query_domains=None):
+
+    def __init__(self, query: str, query_domains: Optional[List[str]] = None, exclude_terms: Optional[List[str]] = None):
         """
         Initializes the SearxSearch object
         Args:
-            query: Search query string
+            query: Search query string.
+            query_domains: Optional list of domains to restrict search to.
+            exclude_terms: Optional list of terms to exclude from results.
         """
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.query_domains = query_domains or None
         self.base_url = self.get_searxng_url()
 

--- a/gpt_researcher/retrievers/serpapi/serpapi.py
+++ b/gpt_researcher/retrievers/serpapi/serpapi.py
@@ -4,19 +4,24 @@
 import os
 import requests
 import urllib.parse
+from typing import List, Optional
+
+from gpt_researcher.retrievers.utils import append_exclude_terms
 
 
 class SerpApiSearch():
     """
     SerpApi Retriever
     """
-    def __init__(self, query, query_domains=None):
+    def __init__(self, query: str, query_domains: Optional[List[str]] = None, exclude_terms: Optional[List[str]] = None):
         """
         Initializes the SerpApiSearch object
         Args:
-            query:
+            query: The search query string.
+            query_domains: Optional list of domains to restrict search to.
+            exclude_terms: Optional list of terms to exclude from results.
         """
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.query_domains = query_domains or None
         self.api_key = self.get_api_key()
 

--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -4,13 +4,16 @@
 import os
 import requests
 import json
+from typing import List, Optional
+
+from gpt_researcher.retrievers.utils import append_exclude_terms
 
 
 class SerperSearch():
     """
     Google Serper Retriever with support for country, language, and date filtering
     """
-    def __init__(self, query, query_domains=None, country=None, language=None, time_range=None, exclude_sites=None):
+    def __init__(self, query: str, query_domains: Optional[List[str]] = None, country=None, language=None, time_range=None, exclude_sites=None, exclude_terms: Optional[List[str]] = None):
         """
         Initializes the SerperSearch object
         Args:
@@ -20,8 +23,9 @@ class SerperSearch():
             language (str, optional): Language code for search results (e.g., 'en', 'ko', 'ja'). Defaults to None.
             time_range (str, optional): Time range filter (e.g., 'qdr:h', 'qdr:d', 'qdr:w', 'qdr:m', 'qdr:y'). Defaults to None.
             exclude_sites (list, optional): List of sites to exclude from search results. Defaults to None.
+            exclude_terms (list, optional): List of terms to exclude from results. Defaults to None.
         """
-        self.query = query
+        self.query = append_exclude_terms(query, exclude_terms)
         self.query_domains = query_domains or None
         self.country = country or os.getenv("SERPER_REGION")
         self.language = language or os.getenv("SERPER_LANGUAGE")

--- a/gpt_researcher/retrievers/utils.py
+++ b/gpt_researcher/retrievers/utils.py
@@ -5,9 +5,11 @@ various search retriever implementations.
 """
 
 import importlib.util
+import inspect
 import logging
 import os
 import sys
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -105,3 +107,46 @@ def get_all_retriever_names():
     except Exception as e:
         logger.error(f"Error getting retrievers: {e}")
         return VALID_RETRIEVERS
+
+
+def append_exclude_terms(query: str, exclude_terms: Optional[List[str]]) -> str:
+    """Append Google-style exclusion operators to a search query.
+
+    Single-word terms become ``-term``. Multi-word terms are quoted
+    (``-"multi word"``).  If a multi-word term itself contains double
+    quotes it is wrapped in single quotes instead.
+
+    Returns the original query unchanged when *exclude_terms* is ``None``
+    or empty.
+    """
+    if not exclude_terms:
+        return query
+
+    parts: List[str] = []
+    for w in exclude_terms:
+        w = w.strip()
+        if not w:
+            continue
+        if " " in w:
+            if '"' in w:
+                parts.append(f"-'{w}'")
+            else:
+                parts.append(f'-"{w}"')
+        else:
+            parts.append(f"-{w}")
+
+    return query + " " + " ".join(parts)
+
+
+def supports_exclude_terms(retriever_cls) -> bool:
+    """Check whether a retriever class explicitly accepts the ``exclude_terms`` kwarg.
+
+    Returns ``True`` only when there is a named ``exclude_terms`` parameter.
+    Classes that rely solely on ``**kwargs`` return ``False`` — they may
+    swallow the argument silently but do not act on it.
+    """
+    try:
+        params = inspect.signature(retriever_cls.__init__).parameters
+    except (TypeError, ValueError):
+        return False
+    return "exclude_terms" in params

--- a/gpt_researcher/skills/__init__.py
+++ b/gpt_researcher/skills/__init__.py
@@ -4,6 +4,7 @@ from .writer import ReportGenerator
 from .browser import BrowserManager
 from .curator import SourceCurator
 from .image_generator import ImageGenerator
+from .source_assessor import SourceAssessor
 
 __all__ = [
     'ResearchConductor',
@@ -12,4 +13,5 @@ __all__ = [
     'BrowserManager',
     'SourceCurator',
     'ImageGenerator',
+    'SourceAssessor',
 ]

--- a/gpt_researcher/skills/browser.py
+++ b/gpt_researcher/skills/browser.py
@@ -55,15 +55,34 @@ class BrowserManager:
         scraped_content, images = await scrape_urls(
             urls, self.researcher.cfg, self.worker_pool
         )
+        source_count = len(scraped_content)
+        rejected_sources = []
+        if getattr(self.researcher, "source_assessment_prompt", None) is not None:
+            scraped_content, rejected_sources = await self.researcher.source_assessor.assess_sources(
+                scraped_content
+            )
+            self.researcher.add_rejected_sources(rejected_sources)
+            images = [
+                image
+                for source in scraped_content
+                for image in source.get("image_urls", [])
+            ]
+
         self.researcher.add_research_sources(scraped_content)
         new_images = self.select_top_images(images, k=4)  # Select top 4 images
         self.researcher.add_research_images(new_images)
 
         if self.researcher.verbose:
+            content_summary = f"📄 Scraped {source_count} pages of content"
+            if getattr(self.researcher, "source_assessment_prompt", None) is not None:
+                content_summary = (
+                    f"📄 Scraped {source_count} pages of content; "
+                    f"accepted {len(scraped_content)}, rejected {len(rejected_sources)} due to source assessment"
+                )
             await stream_output(
                 "logs",
                 "scraping_content",
-                f"📄 Scraped {len(scraped_content)} pages of content",
+                content_summary,
                 self.researcher.websocket,
             )
             await stream_output(

--- a/gpt_researcher/skills/deep_research.py
+++ b/gpt_researcher/skills/deep_research.py
@@ -298,7 +298,8 @@ class DeepResearchSkill:
                 results = await get_search_results(
                     query,
                     retriever,
-                    researcher=self.researcher
+                    researcher=self.researcher,
+                    exclude_terms=getattr(self.researcher, "search_exclude_terms", None),
                 )
                 all_search_results.extend(results)
             except Exception as e:

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -14,6 +14,7 @@ from ..actions.agent_creator import choose_agent
 from ..actions.query_processing import get_search_results, plan_research_outline
 from ..actions.utils import stream_output
 from ..document import DocumentLoader, LangChainDocumentLoader, OnlineDocumentLoader
+from ..retrievers.utils import supports_exclude_terms
 from ..utils.enum import ReportSource, ReportType
 from ..utils.logging_config import get_json_handler
 
@@ -67,6 +68,7 @@ class ResearchConductor:
             query_domains,
             researcher=self.researcher,
             max_results=self.researcher.cfg.max_search_results_per_query,
+            exclude_terms=self.researcher.search_exclude_terms,
         )
         self.logger.info(f"Initial search results obtained: {len(search_results)} results")
 
@@ -838,7 +840,15 @@ class ResearchConductor:
 
             try:
                 # Instantiate the retriever with the sub-query
-                retriever = retriever_class(query, query_domains=query_domains)
+                _exclude = getattr(self.researcher, "search_exclude_terms", None)
+                if _exclude and supports_exclude_terms(retriever_class):
+                    retriever = retriever_class(
+                        query,
+                        query_domains=query_domains,
+                        exclude_terms=_exclude,
+                    )
+                else:
+                    retriever = retriever_class(query, query_domains=query_domains)
 
                 # Perform the search using the current retriever
                 search_results = await asyncio.to_thread(

--- a/gpt_researcher/skills/researcher.py
+++ b/gpt_researcher/skills/researcher.py
@@ -883,10 +883,13 @@ class ResearchConductor:
                         # Undeclared: legacy behaviour, unchanged.
                         prefetched_content.append({
                             "url": url,
+                            "title": result.get("title", ""),
                             "raw_content": raw_content,
                         })
-                        self.researcher.add_research_sources([{"url": url}])
-                    else:
+                        # If the source assessment prompt is not set, we can't add the source immediately as we don't know if it's relevant.
+                        if getattr(self.researcher, "source_assessment_prompt", None) is None:
+                            self.researcher.add_research_sources([{"url": url}])
+                    elif url:
                         new_search_urls.append(url)
             except Exception as e:
                 self.logger.error(f"Error searching with {retriever_class.__name__}: {e}")
@@ -927,6 +930,12 @@ class ResearchConductor:
         scraped_content = await self.researcher.scraper_manager.browse_urls(new_search_urls)
 
         # Merge pre-fetched content from retrievers that already provide full text
+        if getattr(self.researcher, "source_assessment_prompt", None) is not None:
+            prefetched_content, rejected_sources = await self.researcher.source_assessor.assess_sources(
+                prefetched_content
+            )
+            self.researcher.add_rejected_sources(rejected_sources)
+            self.researcher.add_research_sources(prefetched_content)
         scraped_content.extend(prefetched_content)
 
         if self.researcher.vector_store:
@@ -1107,4 +1116,3 @@ class ResearchConductor:
                     "progress": progress
                 }
             )
-

--- a/gpt_researcher/skills/source_assessor.py
+++ b/gpt_researcher/skills/source_assessor.py
@@ -1,0 +1,210 @@
+"""Source assessor skill for GPT Researcher.
+
+This module provides an optional admission-policy gate for scraped sources.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+import json_repair
+
+from ..utils.llm import create_chat_completion
+
+logger = logging.getLogger(__name__)
+
+JSON_BLOCK_PATTERNS = [
+    re.compile(
+        r"```(?:json)?\s*(?P<payload>[\s\S]*?)```",
+        re.IGNORECASE,
+    ),
+    re.compile(r"(?P<payload>\{[\s\S]*\})"),
+]
+
+
+class SourceAssessor:
+    """Evaluates scraped sources against a caller-provided policy."""
+
+    def __init__(self, researcher):
+        """Initialize the SourceAssessor.
+
+        Args:
+            researcher: The GPTResearcher instance that owns this assessor.
+        """
+        self.researcher = researcher
+
+    async def assess_sources(
+        self,
+        scraped_sources: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Assess scraped sources and return accepted sources plus rejected records."""
+        if not scraped_sources:
+            return [], []
+
+        concurrency = max(
+            1,
+            int(getattr(self.researcher, "source_assessment_max_concurrency", 4) or 1),
+        )
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def assess_with_limit(source: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+            async with semaphore:
+                return source, await self._assess_source(source)
+
+        results = await asyncio.gather(
+            *(assess_with_limit(source) for source in scraped_sources)
+        )
+
+        accepted_sources = []
+        assessments = []
+        rejected_sources = []
+        for source, assessment in results:
+            assessments.append(assessment)
+            if assessment["accepted"]:
+                accepted_sources.append(source)
+            else:
+                rejected_sources.append(assessment)
+
+        self.researcher.add_source_assessments(assessments)
+        return accepted_sources, rejected_sources
+
+    async def _assess_source(self, source: dict[str, Any]) -> dict[str, Any]:
+        url = str(source.get("url") or source.get("href") or "")
+        title = str(source.get("title") or "")
+
+        try:
+            response = await create_chat_completion(
+                model=self.researcher.cfg.fast_llm_model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You score how much a source violates a caller-provided admission policy. "
+                            "score is a float in [0.0, 1.0]: 0.0 means no violation, 1.0 means complete violation. "
+                            "Return only JSON with keys: score, reason, matched_policy."
+                        ),
+                    },
+                    {
+                        "role": "user",
+                        "content": self._build_assessment_prompt(source),
+                    },
+                ],
+                temperature=0.0,
+                max_tokens=self.researcher.cfg.fast_token_limit,
+                llm_provider=self.researcher.cfg.fast_llm_provider,
+                llm_kwargs=getattr(self.researcher.cfg, "llm_kwargs", None),
+                cost_callback=getattr(self.researcher, "add_costs", None),
+            )
+            parsed = _load_repaired_json(response)
+            if not isinstance(parsed, dict):
+                return self._rejected_assessment(
+                    url,
+                    title,
+                    "Source assessment failed: response was not a JSON object.",
+                )
+
+            score = _coerce_score(parsed.get("score"))
+            if score is None:
+                return self._rejected_assessment(
+                    url,
+                    title,
+                    "Source assessment failed: score must be a float in [0.0, 1.0].",
+                )
+
+            threshold = float(getattr(self.researcher, "source_assessment_threshold", 0.25))
+            accepted = score <= threshold
+            return {
+                "url": url,
+                "title": title,
+                "accepted": accepted,
+                "score": score,
+                "reason": str(parsed.get("reason") or ""),
+                "matched_policy": str(parsed.get("matched_policy") or ""),
+            }
+        except Exception as exc:
+            logger.warning("Source assessment failed for %s: %s", url, exc)
+            return self._rejected_assessment(
+                url,
+                title,
+                f"Source assessment failed: {exc}",
+            )
+
+    def _build_assessment_prompt(self, source: dict[str, Any]) -> str:
+        max_chars = int(getattr(self.researcher, "source_assessment_max_content_chars", 12000))
+        raw_content = str(source.get("raw_content") or "")
+        if max_chars >= 0:
+            raw_content = raw_content[:max_chars]
+
+        return "\n".join(
+            [
+                "Score how much this source violates SOURCE_ADMISSION_POLICY.",
+                "score is a float in [0.0, 1.0]: 0.0 means no violation, 1.0 means complete violation.",
+                "reason explains the violation or why there is none.",
+                "matched_policy names the policy clause that drove the score.",
+                "",
+                "SOURCE_ADMISSION_POLICY:",
+                getattr(self.researcher, "source_assessment_prompt", None) or "",
+                "",
+                "SOURCE:",
+                f"url: {source.get('url') or source.get('href') or ''}",
+                f"title: {source.get('title') or ''}",
+                "",
+                "RAW_CONTENT:",
+                raw_content,
+                "",
+                "Return JSON only:",
+                '{"score": 0.0, "reason": "", "matched_policy": ""}',
+            ]
+        )
+
+    def _rejected_assessment(self, url: str, title: str, reason: str) -> dict[str, Any]:
+        return {
+            "url": url,
+            "title": title,
+            "accepted": False,
+            "score": 0.0,
+            "reason": reason,
+            "matched_policy": "assessment_failure",
+        }
+
+
+def _extract_json_payloads(response: str) -> list[str]:
+    candidates = []
+    seen = set()
+    for pattern in JSON_BLOCK_PATTERNS:
+        for match in pattern.finditer(response):
+            candidate = match.group("payload").strip()
+            if candidate and candidate not in seen:
+                candidates.append(candidate)
+                seen.add(candidate)
+    return candidates
+
+
+def _load_repaired_json(response: str) -> Any:
+    for candidate in [response.strip(), *_extract_json_payloads(response)]:
+        if not candidate:
+            continue
+        try:
+            return json_repair.loads(candidate)
+        except Exception as exc:
+            logger.debug(
+                "json_repair failed on source assessment candidate (%d chars): %s",
+                len(candidate),
+                exc,
+            )
+    return None
+
+
+def _coerce_score(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if score < 0.0 or score > 1.0:
+        return None
+    return score

--- a/tests/test_browser_source_assessment.py
+++ b/tests/test_browser_source_assessment.py
@@ -1,0 +1,115 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gpt_researcher.skills import browser as browser_module
+from gpt_researcher.skills.browser import BrowserManager
+
+
+class FakeResearcher:
+    def __init__(self, *, source_assessment_prompt=None):
+        self.cfg = SimpleNamespace(max_scraper_workers=1, scraper_rate_limit_delay=0)
+        self.verbose = False
+        self.websocket = None
+        self.source_assessment_prompt = source_assessment_prompt
+        self.research_sources = []
+        self.research_images = []
+        self.rejected_sources = []
+        self.source_assessor = None
+
+    def add_research_sources(self, sources):
+        self.research_sources.extend(sources)
+
+    def add_research_images(self, images):
+        self.research_images.extend(images)
+
+    def get_research_images(self):
+        return self.research_images
+
+    def add_rejected_sources(self, sources):
+        self.rejected_sources.extend(sources)
+
+
+@pytest.mark.asyncio
+async def test_browse_urls_returns_and_stores_only_accepted_sources(monkeypatch):
+    accepted_source = {
+        "url": "https://example.com/accepted",
+        "title": "Accepted",
+        "raw_content": "accepted",
+        "image_urls": [{"url": "https://img.example/accepted.jpg", "score": 1}],
+    }
+    rejected_source = {
+        "url": "https://example.com/rejected",
+        "title": "Rejected",
+        "raw_content": "rejected",
+        "image_urls": [{"url": "https://img.example/rejected.jpg", "score": 100}],
+    }
+
+    async def fake_scrape_urls(urls, cfg, worker_pool):
+        return [accepted_source, rejected_source], [
+            {"url": "https://img.example/accepted.jpg", "score": 1},
+            {"url": "https://img.example/rejected.jpg", "score": 100},
+        ]
+
+    class FakeSourceAssessor:
+        async def assess_sources(self, sources):
+            assert sources == [accepted_source, rejected_source]
+            return [accepted_source], [
+                {
+                    "url": "https://example.com/rejected",
+                    "title": "Rejected",
+                    "accepted": False,
+                    "score": 0.0,
+                    "reason": "Rejected by policy.",
+                    "matched_policy": "policy",
+                }
+            ]
+
+    monkeypatch.setattr(browser_module, "scrape_urls", fake_scrape_urls)
+    researcher = FakeResearcher(source_assessment_prompt="policy")
+    researcher.source_assessor = FakeSourceAssessor()
+
+    result = await BrowserManager(researcher).browse_urls(["https://example.com/a"])
+
+    assert result == [accepted_source]
+    assert researcher.research_sources == [accepted_source]
+    assert researcher.rejected_sources[0]["url"] == "https://example.com/rejected"
+    assert researcher.research_images == ["https://img.example/accepted.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_browse_urls_default_behavior_is_unchanged(monkeypatch):
+    sources = [
+        {
+            "url": "https://example.com/one",
+            "title": "One",
+            "raw_content": "one",
+            "image_urls": [{"url": "https://img.example/one.jpg", "score": 1}],
+        },
+        {
+            "url": "https://example.com/two",
+            "title": "Two",
+            "raw_content": "two",
+            "image_urls": [{"url": "https://img.example/two.jpg", "score": 10}],
+        },
+    ]
+    images = [
+        {"url": "https://img.example/one.jpg", "score": 1},
+        {"url": "https://img.example/two.jpg", "score": 10},
+    ]
+
+    async def fake_scrape_urls(urls, cfg, worker_pool):
+        return sources, images
+
+    monkeypatch.setattr(browser_module, "scrape_urls", fake_scrape_urls)
+    researcher = FakeResearcher()
+
+    result = await BrowserManager(researcher).browse_urls(["https://example.com/a"])
+
+    assert result == sources
+    assert researcher.research_sources == sources
+    assert researcher.rejected_sources == []
+    assert researcher.research_images == [
+        "https://img.example/two.jpg",
+        "https://img.example/one.jpg",
+    ]

--- a/tests/test_duckduckgo_normalize.py
+++ b/tests/test_duckduckgo_normalize.py
@@ -13,13 +13,17 @@ MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "duckduckgo" / "duckduckg
 def _load_duckduckgo_module():
     # Load the module file directly so we never import gpt_researcher package
     # (pulling json_repair and other heavy deps is unrelated to this unit).
-    utils_mod = types.ModuleType("gpt_researcher.retrievers.utils")
-    utils_mod.check_pkg = lambda *a, **k: None
-    pkg = types.ModuleType("gpt_researcher")
-    retrievers = types.ModuleType("gpt_researcher.retrievers")
-    sys.modules.setdefault("gpt_researcher", pkg)
-    sys.modules.setdefault("gpt_researcher.retrievers", retrievers)
+    utils_path = MODULE_PATH.parent.parent / "utils.py"
+    utils_spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.utils", utils_path
+    )
+    utils_mod = importlib.util.module_from_spec(utils_spec)
+    sys.modules.setdefault("gpt_researcher", types.ModuleType("gpt_researcher"))
+    sys.modules.setdefault(
+        "gpt_researcher.retrievers", types.ModuleType("gpt_researcher.retrievers")
+    )
     sys.modules["gpt_researcher.retrievers.utils"] = utils_mod
+    utils_spec.loader.exec_module(utils_mod)
 
     spec = importlib.util.spec_from_file_location(
         "gpt_researcher.retrievers.duckduckgo.duckduckgo", MODULE_PATH
@@ -85,6 +89,72 @@ class DuckduckgoNormalizeTests(unittest.TestCase):
         results = Duckduckgo.search(retriever, max_results=5)
         self.assertEqual(len(results[0]["body"]), 100)
         self.assertEqual(results[0]["body"], long_snippet[:100])
+
+
+class DuckduckgoExcludeTermsTests(unittest.TestCase):
+    def _make_retriever(self, query, exclude_terms=None):
+        """Create a Duckduckgo instance with mocked ddgs import."""
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        retriever = Duckduckgo.__new__(Duckduckgo)
+        retriever.query = query
+        retriever.query_domains = None
+        retriever.ddg = MagicMock()
+        retriever.ddg.text.return_value = []
+        # Manually apply exclusion logic (mimics __init__ without ddgs import)
+        if exclude_terms:
+            parts = []
+            for w in exclude_terms:
+                w = w.strip()
+                if not w:
+                    continue
+                if " " in w:
+                    if '"' in w:
+                        parts.append(f"-'{w}'")
+                    else:
+                        parts.append(f'-"{w}"')
+                else:
+                    parts.append(f"-{w}")
+            retriever.query = query + " " + " ".join(parts)
+        return retriever
+
+    def test_single_word_exclusion(self):
+        retriever = self._make_retriever("test query", exclude_terms=["gartner"])
+        self.assertEqual(retriever.query, "test query -gartner")
+
+    def test_multi_word_term_exclusion(self):
+        retriever = self._make_retriever("test query", exclude_terms=["market share"])
+        self.assertEqual(retriever.query, 'test query -"market share"')
+
+    def test_term_with_double_quotes_uses_single_quotes(self):
+        retriever = self._make_retriever('test query', exclude_terms=['he said "bad"'])
+        self.assertEqual(retriever.query, "test query -'he said \"bad\"'")
+
+    def test_multiple_exclusions(self):
+        retriever = self._make_retriever(
+            "How many PCs were sold in 2012?",
+            exclude_terms=["gartner", "market share"],
+        )
+        self.assertEqual(
+            retriever.query, 'How many PCs were sold in 2012? -gartner -"market share"'
+        )
+
+    def test_empty_exclusion_list(self):
+        retriever = self._make_retriever("test query", exclude_terms=[])
+        self.assertEqual(retriever.query, "test query")
+
+    def test_none_exclusion(self):
+        retriever = self._make_retriever("test query", exclude_terms=None)
+        self.assertEqual(retriever.query, "test query")
+
+    def test_exclusion_passed_to_search(self):
+        retriever = self._make_retriever("test query", exclude_terms=["gartner"])
+        mod = _load_duckduckgo_module()
+        Duckduckgo = mod.Duckduckgo
+        Duckduckgo.search(retriever)
+        retriever.ddg.text.assert_called_once()
+        call_args = retriever.ddg.text.call_args
+        self.assertIn("-gartner", call_args[0][0])
 
 
 if __name__ == "__main__":

--- a/tests/test_exclude_terms.py
+++ b/tests/test_exclude_terms.py
@@ -1,0 +1,232 @@
+"""Tests for exclude-terms feature across retrievers.
+
+Covers:
+- append_exclude_terms helper (quoting rules)
+- supports_exclude_terms signature check
+- Application in each implementing retriever (google, brave, serper, serpapi, searchapi, searx)
+- Call-site tolerant-pass behavior
+"""
+import importlib.util
+import inspect
+import os
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+RETRIEVERS_DIR = ROOT / "gpt_researcher" / "retrievers"
+
+
+# ---------------------------------------------------------------------------
+# Helpers to load modules directly (avoids heavy gpt_researcher imports)
+# ---------------------------------------------------------------------------
+
+def _load_utils_module():
+    """Load retrievers/utils.py directly without importing the package."""
+    utils_path = RETRIEVERS_DIR / "utils.py"
+    spec = importlib.util.spec_from_file_location("_utils_under_test", utils_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_utils_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_retriever_module(name: str, class_name: str):
+    """Load a retriever module directly with proper package setup for relative imports."""
+    # Set up the parent packages so relative imports (from ..utils import ...) work
+    pkg = types.ModuleType("gpt_researcher")
+    sys.modules.setdefault("gpt_researcher", pkg)
+
+    ret_pkg = types.ModuleType("gpt_researcher.retrievers")
+    sys.modules.setdefault("gpt_researcher.retrievers", ret_pkg)
+    pkg.retrievers = ret_pkg
+
+    # Load utils first (the real module, so append_exclude_terms is available)
+    utils_path = RETRIEVERS_DIR / "utils.py"
+    utils_spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.utils", utils_path
+    )
+    utils_mod = importlib.util.module_from_spec(utils_spec)
+    utils_mod.__package__ = "gpt_researcher.retrievers"
+    sys.modules["gpt_researcher.retrievers.utils"] = utils_mod
+    ret_pkg.utils = utils_mod
+    utils_spec.loader.exec_module(utils_mod)
+
+    # Now load the retriever module with proper package context
+    module_path = RETRIEVERS_DIR / name / f"{name}.py"
+    mod_name = f"gpt_researcher.retrievers.{name}.{name}"
+    spec = importlib.util.spec_from_file_location(mod_name, module_path)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = f"gpt_researcher.retrievers.{name}"
+    mod.__name__ = mod_name
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod, getattr(mod, class_name)
+
+
+# ---------------------------------------------------------------------------
+# append_exclude_terms tests
+# ---------------------------------------------------------------------------
+
+class AppendExcludeTermsTests(unittest.TestCase):
+    def setUp(self):
+        self.utils = _load_utils_module()
+        self.fn = self.utils.append_exclude_terms
+
+    def test_none_returns_query(self):
+        self.assertEqual(self.fn("test query", None), "test query")
+
+    def test_empty_list_returns_query(self):
+        self.assertEqual(self.fn("test query", []), "test query")
+
+    def test_single_word(self):
+        self.assertEqual(self.fn("test query", ["gartner"]), "test query -gartner")
+
+    def test_multi_word_uses_double_quotes(self):
+        self.assertEqual(
+            self.fn("test query", ["market share"]),
+            'test query -"market share"',
+        )
+
+    def term_with_double_quote_uses_single_quotes(self):
+        self.assertEqual(
+            self.fn('test query', ['he said "bad"']),
+            "test query -'he said \"bad\"'",
+        )
+
+    def test_multiple_exclusions(self):
+        self.assertEqual(
+            self.fn("How many PCs sold?", ["gartner", "market share"]),
+            'How many PCs sold? -gartner -"market share"',
+        )
+
+    def test_whitespace_only_skipped(self):
+        self.assertEqual(
+            self.fn("q", ["  ", "", "ok"]),
+            "q -ok",
+        )
+
+
+# ---------------------------------------------------------------------------
+# supports_exclude_terms tests
+# ---------------------------------------------------------------------------
+
+class SupportsExcludeTermsTests(unittest.TestCase):
+    def setUp(self):
+        self.utils = _load_utils_module()
+        self.fn = self.utils.supports_exclude_terms
+
+    def test_named_param_returns_true(self):
+        class WithParam:
+            def __init__(self, q, exclude_terms=None):
+                pass
+        self.assertTrue(self.fn(WithParam))
+
+    def test_no_param_returns_false(self):
+        class NoParam:
+            def __init__(self, q):
+                pass
+        self.assertFalse(self.fn(NoParam))
+
+    def test_kwargs_only_returns_false(self):
+        class KwargOnly:
+            def __init__(self, q, **kwargs):
+                pass
+        self.assertFalse(self.fn(KwargOnly))
+
+
+# ---------------------------------------------------------------------------
+# Application tests — each implementing retriever applies the suffix
+# ---------------------------------------------------------------------------
+
+class RetrieverApplicationTests(unittest.TestCase):
+    """Verify that each implementing retriever correctly applies exclude_terms."""
+
+    @patch.dict(os.environ, {"GOOGLE_API_KEY": "test", "GOOGLE_CX_KEY": "test"})
+    def test_google_applies_suffix(self):
+        mod, cls = _load_retriever_module("google", "GoogleSearch")
+        r = cls("python", exclude_terms=["java"])
+        self.assertEqual(r.query, "python -java")
+
+    @patch.dict(os.environ, {"BRAVE_API_KEY": "test"})
+    def test_brave_applies_suffix(self):
+        mod, cls = _load_retriever_module("brave", "BraveSearch")
+        r = cls("python", exclude_terms=["java"])
+        self.assertEqual(r.query, "python -java")
+
+    @patch.dict(os.environ, {"SERPER_API_KEY": "test"})
+    def test_serper_applies_suffix(self):
+        mod, cls = _load_retriever_module("serper", "SerperSearch")
+        r = cls("python", exclude_terms=["java"])
+        self.assertEqual(r.query, "python -java")
+
+    @patch.dict(os.environ, {"SERPAPI_API_KEY": "test"})
+    def test_serpapi_applies_suffix(self):
+        mod, cls = _load_retriever_module("serpapi", "SerpApiSearch")
+        r = cls("python", exclude_terms=["java"])
+        self.assertEqual(r.query, "python -java")
+
+    @patch.dict(os.environ, {"SEARCHAPI_API_KEY": "test"})
+    def test_searchapi_applies_suffix(self):
+        mod, cls = _load_retriever_module("searchapi", "SearchApiSearch")
+        r = cls("python", exclude_terms=["java"])
+        self.assertEqual(r.query, "python -java")
+
+    @patch.dict(os.environ, {"SEARX_URL": "http://localhost:8080/"})
+    def test_searx_applies_suffix(self):
+        mod, cls = _load_retriever_module("searx", "SearxSearch")
+        r = cls("python", exclude_terms=["java"])
+        self.assertEqual(r.query, "python -java")
+
+    # Non-implementing retrievers should NOT have the parameter
+    @patch.dict(os.environ, {"TAVILY_API_KEY": "test"})
+    def test_tavily_does_not_have_param(self):
+        tavily_path = RETRIEVERS_DIR / "tavily" / "tavily_search.py"
+        spec = importlib.util.spec_from_file_location("_ret_tavily", tavily_path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_ret_tavily"] = mod
+        spec.loader.exec_module(mod)
+        sig = inspect.signature(mod.TavilySearch.__init__)
+        self.assertNotIn("exclude_terms", sig.parameters)
+
+    @patch.dict(os.environ, {"BING_API_KEY": "test"})
+    def test_bing_does_not_have_param(self):
+        mod, _ = _load_retriever_module("bing", "BingSearch")
+        sig = inspect.signature(mod.BingSearch.__init__)
+        self.assertNotIn("exclude_terms", sig.parameters)
+
+
+# ---------------------------------------------------------------------------
+# Call-site tolerant-pass tests
+# ---------------------------------------------------------------------------
+
+class CallSiteTests(unittest.TestCase):
+    """Verify that the call-site logic passes exclude_terms only to supporting retrievers."""
+
+    def setUp(self):
+        self.utils = _load_utils_module()
+        self.supports = self.utils.supports_exclude_terms
+
+    def test_supporting_retriever_identified(self):
+        class Supporting:
+            def __init__(self, q, exclude_terms=None):
+                pass
+        self.assertTrue(self.supports(Supporting))
+
+    def test_non_supporting_retriever_identified(self):
+        class NonSupporting:
+            def __init__(self, q):
+                pass
+        self.assertFalse(self.supports(NonSupporting))
+
+    def test_kwargs_only_not_treated_as_supporting(self):
+        class KwargOnly:
+            def __init__(self, q, **kwargs):
+                pass
+        self.assertFalse(self.supports(KwargOnly))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_conductor_retrieval.py
+++ b/tests/test_research_conductor_retrieval.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 from gpt_researcher.skills.researcher import ResearchConductor
 
@@ -74,7 +75,37 @@ class ResearchConductorRetrievalTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(urls, [])
         self.assertEqual(
             prefetched,
-            [{"url": "https://example.com/full", "raw_content": "C" * 500}],
+            [{"url": "https://example.com/full", "title": "", "raw_content": "C" * 500}],
+        )
+
+    async def test_prefetched_raw_content_is_assessed_when_policy_enabled(self):
+        researcher = self.make_researcher(FakeFullContentRetriever)
+        researcher.source_assessment_prompt = "policy"
+        researcher.rejected_sources = []
+        researcher.scraper_manager = SimpleNamespace(browse_urls=AsyncMock(return_value=[]))
+        researcher.vector_store = None
+
+        async def assess_sources(sources):
+            self.assertEqual(
+                sources,
+                [{"url": "https://example.com/full", "title": "", "raw_content": "C" * 500}],
+            )
+            return sources, []
+
+        researcher.source_assessor = SimpleNamespace(assess_sources=assess_sources)
+        researcher.add_rejected_sources = lambda sources: researcher.rejected_sources.extend(sources)
+
+        conductor = ResearchConductor(researcher)
+
+        scraped = await conductor._scrape_data_by_urls("pubmed article")
+
+        self.assertEqual(
+            scraped,
+            [{"url": "https://example.com/full", "title": "", "raw_content": "C" * 500}],
+        )
+        self.assertEqual(
+            researcher.research_sources,
+            [{"url": "https://example.com/full", "title": "", "raw_content": "C" * 500}],
         )
 
 

--- a/tests/test_research_conductor_retrieval.py
+++ b/tests/test_research_conductor_retrieval.py
@@ -48,6 +48,7 @@ class ResearchConductorRetrievalTests(unittest.IsolatedAsyncioTestCase):
                 self.websocket = None
                 self.visited_urls = set()
                 self.research_sources = []
+                self.search_exclude_terms = None
 
             def add_research_sources(self, sources):
                 self.research_sources.extend(sources)

--- a/tests/test_searx_malformed_results.py
+++ b/tests/test_searx_malformed_results.py
@@ -12,6 +12,22 @@ MODULE_PATH = ROOT / "gpt_researcher" / "retrievers" / "searx" / "searx.py"
 
 
 def _load():
+    # Set up parent packages so relative imports (from ..utils import ...) work
+    sys.modules.setdefault("gpt_researcher", types.ModuleType("gpt_researcher"))
+    ret_pkg = types.ModuleType("gpt_researcher.retrievers")
+    sys.modules.setdefault("gpt_researcher.retrievers", ret_pkg)
+
+    # Load utils first (needed for append_exclude_terms import in searx.py)
+    utils_path = MODULE_PATH.parent.parent / "utils.py"
+    utils_spec = importlib.util.spec_from_file_location(
+        "gpt_researcher.retrievers.utils", utils_path
+    )
+    utils_mod = importlib.util.module_from_spec(utils_spec)
+    utils_mod.__package__ = "gpt_researcher.retrievers"
+    sys.modules["gpt_researcher.retrievers.utils"] = utils_mod
+    ret_pkg.utils = utils_mod
+    utils_spec.loader.exec_module(utils_mod)
+
     requests_mod = types.ModuleType("requests")
     class RequestException(Exception):
         pass
@@ -29,6 +45,7 @@ def _load():
         "gpt_researcher.retrievers.searx.searx_testmod", MODULE_PATH
     )
     mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "gpt_researcher.retrievers.searx"
     sys.modules[spec.name] = mod
     with patch.dict(os.environ, {"SEARX_URL": "https://searx.example/"}, clear=False):
         spec.loader.exec_module(mod)

--- a/tests/test_serpapi_retriever_malformed.py
+++ b/tests/test_serpapi_retriever_malformed.py
@@ -7,16 +7,37 @@ aborts the whole ``search()`` call.
 import importlib.util
 import os
 import pathlib
+import sys
+import types
 from unittest.mock import patch
 
-# Import the module directly to avoid importing the heavy gpt_researcher package
-# (which pulls optional deps at import time).
-_SERPAPI_PATH = (
-    pathlib.Path(__file__).resolve().parent.parent
-    / "gpt_researcher" / "retrievers" / "serpapi" / "serpapi.py"
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+RETRIEVERS_DIR = ROOT / "gpt_researcher" / "retrievers"
+
+# Set up parent packages so relative imports (from ..utils import ...) work
+sys.modules.setdefault("gpt_researcher", types.ModuleType("gpt_researcher"))
+ret_pkg = types.ModuleType("gpt_researcher.retrievers")
+sys.modules.setdefault("gpt_researcher.retrievers", ret_pkg)
+
+# Load utils first (needed for append_exclude_terms import in serpapi.py)
+_utils_path = RETRIEVERS_DIR / "utils.py"
+_utils_spec = importlib.util.spec_from_file_location(
+    "gpt_researcher.retrievers.utils", _utils_path
 )
-_spec = importlib.util.spec_from_file_location("_serpapi_under_test", _SERPAPI_PATH)
+_utils_mod = importlib.util.module_from_spec(_utils_spec)
+_utils_mod.__package__ = "gpt_researcher.retrievers"
+sys.modules["gpt_researcher.retrievers.utils"] = _utils_mod
+ret_pkg.utils = _utils_mod
+_utils_spec.loader.exec_module(_utils_mod)
+
+# Now load serpapi with proper package context
+_SERPAPI_PATH = RETRIEVERS_DIR / "serpapi" / "serpapi.py"
+_spec = importlib.util.spec_from_file_location(
+    "gpt_researcher.retrievers.serpapi.serpapi", _SERPAPI_PATH
+)
 _serpapi = importlib.util.module_from_spec(_spec)
+_serpapi.__package__ = "gpt_researcher.retrievers.serpapi"
+sys.modules[_spec.name] = _serpapi
 _spec.loader.exec_module(_serpapi)
 SerpApiSearch = _serpapi.SerpApiSearch
 

--- a/tests/test_source_assessor.py
+++ b/tests/test_source_assessor.py
@@ -1,0 +1,248 @@
+from types import SimpleNamespace
+
+import pytest
+
+from gpt_researcher.skills import source_assessor as source_assessor_module
+from gpt_researcher.skills.source_assessor import SourceAssessor
+
+
+class FakeResearcher:
+    def __init__(self, *, max_content_chars=12000):
+        self.cfg = SimpleNamespace(
+            fast_llm_model="fast-model",
+            fast_llm_provider="fast-provider",
+            fast_token_limit=1000,
+            llm_kwargs={"response_format": "json"},
+        )
+        self.source_assessment_prompt = "Accept independent sources only."
+        self.source_assessment_threshold = 0.25
+        self.source_assessment_max_content_chars = max_content_chars
+        self.source_assessment_max_concurrency = 2
+        self.source_assessments = []
+        self.costs = []
+
+    def add_costs(self, cost):
+        self.costs.append(cost)
+
+    def add_source_assessments(self, assessments):
+        self.source_assessments.extend(assessments)
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_accepts_source(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        return '{"score": 0.1, "reason": "Independent data.", "matched_policy": "independent"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/accepted",
+            "title": "Accepted",
+            "raw_content": "Independent observed outcome data.",
+        }
+    ])
+
+    assert [source["url"] for source in accepted] == ["https://example.com/accepted"]
+    assert rejected == []
+    assert researcher.source_assessments == [
+        {
+            "url": "https://example.com/accepted",
+            "title": "Accepted",
+            "accepted": True,
+            "score": 0.1,
+            "reason": "Independent data.",
+            "matched_policy": "independent",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_rejects_source(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        return '{"score": 0.9, "reason": "Derived source.", "matched_policy": "derivative"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/rejected",
+            "title": "Rejected",
+            "raw_content": "This page repeats the original source.",
+        }
+    ])
+
+    assert accepted == []
+    assert rejected == [
+        {
+            "url": "https://example.com/rejected",
+            "title": "Rejected",
+            "accepted": False,
+            "score": 0.9,
+            "reason": "Derived source.",
+            "matched_policy": "derivative",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_ignores_model_accepted_flag(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        return '{"accepted": true, "score": 0.6, "reason": "Partial match.", "matched_policy": "clause"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/mid",
+            "title": "Mid",
+            "raw_content": "Content",
+        }
+    ])
+
+    assert accepted == []
+    assert rejected[0]["accepted"] is False
+    assert rejected[0]["score"] == 0.6
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_accepts_score_only_json(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        return '{"score": 0.1, "reason": "No violation.", "matched_policy": "independent"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/score-only",
+            "title": "Score only",
+            "raw_content": "Content",
+        }
+    ])
+
+    assert [source["url"] for source in accepted] == ["https://example.com/score-only"]
+    assert rejected == []
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_rejects_out_of_range_score(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        return '{"score": 80, "reason": "Looks independent.", "matched_policy": "independent"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/percent",
+            "title": "Percent",
+            "raw_content": "Content",
+        }
+    ])
+
+    assert accepted == []
+    assert rejected[0]["accepted"] is False
+    assert rejected[0]["score"] == 0.0
+    assert "0.0, 1.0" in rejected[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_prompt_describes_violation_scale(monkeypatch):
+    captured_messages = []
+
+    async def fake_create_chat_completion(**kwargs):
+        captured_messages.extend(kwargs["messages"])
+        return '{"score": 0.1, "reason": "ok", "matched_policy": "all"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/prompt",
+            "title": "Prompt",
+            "raw_content": "Content",
+        }
+    ])
+
+    system_content = captured_messages[0]["content"]
+    user_content = captured_messages[1]["content"]
+    combined = f"{system_content}\n{user_content}"
+    assert "violat" in combined.lower()
+    assert "0.0" in combined
+    assert "1.0" in combined
+    assert "admit if score" not in combined.lower()
+    assert '{"score": 0.0, "reason": "", "matched_policy": ""}' in user_content
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_full_content_when_max_chars_is_negative_one(monkeypatch):
+    captured_prompt = ""
+
+    async def fake_create_chat_completion(**kwargs):
+        nonlocal captured_prompt
+        captured_prompt = kwargs["messages"][1]["content"]
+        return '{"score": 0.1, "reason": "ok", "matched_policy": "all"}'
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher(max_content_chars=-1)
+    raw_content = "A" * 13000 + "TAIL"
+
+    await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/full",
+            "title": "Full",
+            "raw_content": raw_content,
+        }
+    ])
+
+    assert raw_content in captured_prompt
+    assert "TAIL" in captured_prompt
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_rejects_malformed_output(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        return "not-json"
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/bad-json",
+            "title": "Bad JSON",
+            "raw_content": "Content",
+        }
+    ])
+
+    assert accepted == []
+    assert rejected[0]["accepted"] is False
+    assert rejected[0]["score"] == 0.0
+    assert "not a JSON object" in rejected[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_source_assessor_rejects_llm_failure(monkeypatch):
+    async def fake_create_chat_completion(**kwargs):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(source_assessor_module, "create_chat_completion", fake_create_chat_completion)
+    researcher = FakeResearcher()
+
+    accepted, rejected = await SourceAssessor(researcher).assess_sources([
+        {
+            "url": "https://example.com/failure",
+            "title": "Failure",
+            "raw_content": "Content",
+        }
+    ])
+
+    assert accepted == []
+    assert rejected[0]["accepted"] is False
+    assert rejected[0]["score"] == 0.0
+    assert "provider down" in rejected[0]["reason"]


### PR DESCRIPTION
# Two-Stage Source Filtering to Exclude Unwanted Sources

## Problem

The existing `SourceCurator` ranks sources by relevance and credibility, but it operates **after** all scraped content has already been ingested into the research context. This has two problems:

1. **Contaminated context** — Unwanted sources have already influenced downstream LLM calls (summaries, context selection, report generation). Curating them afterward cannot undo that influence.
2. **Correctness requires isolation** — Sources must be filtered in a separate, isolated stage *before* they enter the research pipeline. Only gates at the search and scraping boundaries can guarantee that excluded sources never touch the context window.

### Why this is fatal for fact-checking

For fact-checking, post-hoc curation isn't a quality trade-off — it invalidates the verification itself. A fact-check is only meaningful when the evidence comes from sources **independent** of the claim's origin — and nothing between scraping and report generation reads content critically:

- **Summaries (LLM) and context selection (embeddings)** — Claimant pages are chunked, embedded, and summarized exactly like independent ones; only similarity matters, never trustworthiness.
- **Contaminated citations** — Derivative content (press releases, articles quoting the claimant) is indistinguishable from independent coverage, so the report can cite the claimant as its own corroboration.

`SourceCurator`, running afterward, can reorder the output but cannot undo what those calls already produced — only gates at the search and scraping boundaries can.

## Solution

Add a two-stage source filtering pipeline that prevents unwanted sources from contaminating the research context.

The two features form a cost-efficient defense-in-depth:

1. **`search_exclude_terms`** (cheap) — Appends Google-style `-term` operators to search queries, preventing unwanted results from appearing in search listings. No LLM cost. Supported by DuckDuckGo, Google, Brave, Serper, SerpAPI, SearchAPI, and SearxNG.
2. **`source_assessment_prompt`** (LLM-cost) — Catches sources that survive the search filter or come from retrievers without operator support. Each scraped source is scored by a fast LLM; those above the violation threshold are rejected before entering the research context.

```python
researcher = GPTResearcher(
    agent="You're a skeptical b-s detective ;)",
    role="Check bold statement against the knowledge available on the internet",
    query="Gartner says the AI agent market will be bigger than the Moon by 2030",
    
    # Stage 1: Block at search time — cheap, prevents most unwanted URLs from being scraped
    search_exclude_terms=["Gartner", "gartner.com"],
    
    # Stage 2: Filter remaining sources after scraping — catches what slipped through
    source_assessment_prompt=(
        "Accept only sources completely independent of Gartner. Reject any "
        "Gartner publications, citations, press releases, articles quoting "
        "Gartner analysts, and derivative content referencing Gartner research."
    ),
    source_assessment_threshold=0.2,
)
```

Since source assessment incurs an LLM call per scraped source, using `search_exclude_terms` to reduce the number of unwanted sources that reach the scraper is a practical optimization.

## Changes

### Search-level filtering (`search_exclude_terms`)

- New `search_exclude_terms` parameter on `GPTResearcher`. Appended as Google-style `-term` / `-"multi word"` operators (with quote escaping) by DuckDuckGo, Google, Brave, Serper, SerpAPI, SearchAPI, and SearxNG — including deep-research and multiple-retriever call sites. Unsupported retrievers log a warning and proceed unmodified.
- Docs: `search-engines/exclude-terms.md` with supported/unsupported retriever tables and runtime behavior.

### Scraping-level filtering (`source_assessment_prompt`)

- New `SourceAssessor` skill: concurrency-limited async scoring of each scraped source by a fast LLM. Returns a `[0.0, 1.0]` violation score; sources above the threshold are rejected before entering the research context. Malformed output and provider failures default to rejection.
- New `GPTResearcher` parameters: `source_assessment_prompt`, `source_assessment_threshold`, `source_assessment_max_content_chars`, `source_assessment_max_concurrency`; results exposed via getters for `source_assessments` and `rejected_sources`.
- Applied at both ingestion points: browser scrapes and pre-fetched retriever content (PubMed, arXiv).
- Docs: `gptr/source-admission-policy.md` with fact-checking examples; config reference updated.

### Tests

- New: `test_exclude_terms.py`, `test_source_assessor.py`, `test_browser_source_assessment.py`; retriever/conductor tests updated for pass-through behavior.

## Backward Compatibility

Both features are fully opt-in. When neither parameter is set (the default), all code paths behave exactly as before — no kwargs passed, no query modification, no LLM calls.
