### PR TITLE
fix: define stream output for multi-agent execution

### DIFF
--- a/backend/server/server_utils.py
+++ b/backend/server/server_utils.py
@@ -9,6 +9,7 @@ from typing import Awaitable, Dict, List, Any
 from fastapi.responses import JSONResponse, FileResponse
 from gpt_researcher.document.document import DocumentLoader
 from gpt_researcher import GPTResearcher
+from gpt_researcher.actions import stream_output
 # This module is imported under two different package names: as
 # `backend.server.server_utils` (main.py / the Procfile entrypoint) and as
 # `server.server_utils` (backend/server/app.py prepends backend/ to sys.path).


### PR DESCRIPTION
The multi-agent WebSocket helper passes stream_output to run_multi_agent_task, but the callback was not defined in server_utils.

Import the existing actions callback so the execution path can start normally. No API behavior changes outside this error path.