### PR TITLE
fix(mcp): handle uppercase URL schemes case-insensitively

### DIFF
--- a/gpt_researcher/mcp/client.py
+++ b/gpt_researcher/mcp/client.py
@@ -3,13 +3,15 @@ MCP Client Management Module
 
 Handles MCP client creation, configuration conversion, and connection management.
 """
+
 import asyncio
 import logging
+from typing import Any
 from urllib.parse import urlsplit
-from typing import List, Dict, Any, Optional
 
 try:
     from langchain_mcp_adapters.client import MultiServerMCPClient
+
     HAS_MCP_ADAPTERS = True
 except ImportError:
     HAS_MCP_ADAPTERS = False
@@ -20,17 +22,17 @@ logger = logging.getLogger(__name__)
 class MCPClientManager:
     """
     Manages MCP client lifecycle and configuration.
-    
+
     Responsible for:
     - Converting GPT Researcher MCP configs to langchain format
     - Creating and managing MultiServerMCPClient instances
     - Handling client cleanup and resource management
     """
 
-    def __init__(self, mcp_configs: List[Dict[str, Any]]):
+    def __init__(self, mcp_configs: list[dict[str, Any]]):
         """
         Initialize the MCP client manager.
-        
+
         Args:
             mcp_configs: List of MCP server configurations from GPT Researcher
         """
@@ -38,15 +40,15 @@ class MCPClientManager:
         self._client = None
         self._client_lock = asyncio.Lock()
 
-    def convert_configs_to_langchain_format(self) -> Dict[str, Dict[str, Any]]:
+    def convert_configs_to_langchain_format(self) -> dict[str, dict[str, Any]]:
         """
         Convert GPT Researcher MCP configs to langchain-mcp-adapters format.
-        
+
         Returns:
             Dict[str, Dict[str, Any]]: Server configurations for MultiServerMCPClient
         """
         server_configs = {}
-        
+
         for i, config in enumerate(self.mcp_configs):
             # GPT Researcher MCP configs are dicts; tolerate list/json drift so
             # a single bad entry cannot AttributeError the whole conversion.
@@ -58,11 +60,11 @@ class MCPClientManager:
                 )
                 continue
             # Generate server name
-            server_name = config.get("name", f"mcp_server_{i+1}")
-            
+            server_name = config.get("name", f"mcp_server_{i + 1}")
+
             # Build the server config
             server_config = {}
-            
+
             # Auto-detect transport type from URL if provided
             connection_url = config.get("connection_url")
             if connection_url:
@@ -83,65 +85,69 @@ class MCPClientManager:
                 # No URL provided, use stdio (default) or specified connection_type
                 connection_type = config.get("connection_type", "stdio")
                 server_config["transport"] = connection_type
-            
-            if server_config.get("transport") in ["streamable_http", "http", "websocket"]:
+
+            if server_config.get("transport") in [
+                "streamable_http",
+                "http",
+                "websocket",
+            ]:
                 connection_headers = config.get("connection_headers")
                 if connection_headers and isinstance(connection_headers, dict):
                     server_config["headers"] = connection_headers
-            
+
             # Handle stdio transport configuration
             if server_config.get("transport") == "stdio":
                 if config.get("command"):
                     server_config["command"] = config["command"]
-                    
+
                     # Handle server_args
                     server_args = config.get("args", [])
                     if isinstance(server_args, str):
                         server_args = server_args.split()
                     server_config["args"] = server_args
-                    
+
                     # Handle environment variables
                     server_env = config.get("env", {})
                     if server_env:
                         server_config["env"] = server_env
-                        
+
             # Add authentication if provided
             if config.get("connection_token"):
                 server_config["token"] = config["connection_token"]
-                
+
             server_configs[server_name] = server_config
-            
+
         return server_configs
 
-    async def get_or_create_client(self) -> Optional[object]:
+    async def get_or_create_client(self) -> object | None:
         """
         Get or create a MultiServerMCPClient with proper lifecycle management.
-        
+
         Returns:
             MultiServerMCPClient: The client instance or None if creation fails
         """
         async with self._client_lock:
             if self._client is not None:
                 return self._client
-                
+
             if not HAS_MCP_ADAPTERS:
                 logger.error("langchain-mcp-adapters not installed")
                 return None
-                
+
             if not self.mcp_configs:
                 logger.error("No MCP server configurations found")
                 return None
-                
+
             try:
                 # Convert configs to langchain format
                 server_configs = self.convert_configs_to_langchain_format()
                 logger.info(f"Creating MCP client for {len(server_configs)} server(s)")
-                
+
                 # Initialize the MultiServerMCPClient
                 self._client = MultiServerMCPClient(server_configs)
-                
+
                 return self._client
-                
+
             except Exception as e:
                 logger.error(f"Error creating MCP client: {e}")
                 return None
@@ -163,28 +169,28 @@ class MCPClientManager:
                     # Always clear the reference
                     self._client = None
 
-    async def get_all_tools(self) -> List:
+    async def get_all_tools(self) -> list:
         """
         Get all available tools from MCP servers.
-        
+
         Returns:
             List: All available MCP tools
         """
         client = await self.get_or_create_client()
         if not client:
             return []
-            
+
         try:
             # Get tools from all servers
             all_tools = await client.get_tools()
-            
+
             if all_tools:
                 logger.info(f"Loaded {len(all_tools)} total tools from MCP servers")
                 return all_tools
             else:
                 logger.warning("No tools available from MCP servers")
                 return []
-                
+
         except Exception as e:
             logger.error(f"Error getting MCP tools: {e}")
-            return [] 
+            return []

--- a/gpt_researcher/mcp/client.py
+++ b/gpt_researcher/mcp/client.py
@@ -5,6 +5,7 @@ Handles MCP client creation, configuration conversion, and connection management
 """
 import asyncio
 import logging
+from urllib.parse import urlsplit
 from typing import List, Dict, Any, Optional
 
 try:
@@ -65,10 +66,11 @@ class MCPClientManager:
             # Auto-detect transport type from URL if provided
             connection_url = config.get("connection_url")
             if connection_url:
-                if connection_url.startswith(("wss://", "ws://")):
+                scheme = urlsplit(connection_url).scheme.lower()
+                if scheme in {"ws", "wss"}:
                     server_config["transport"] = "websocket"
                     server_config["url"] = connection_url
-                elif connection_url.startswith(("https://", "http://")):
+                elif scheme in {"http", "https"}:
                     server_config["transport"] = "streamable_http"
                     server_config["url"] = connection_url
                 else:

--- a/tests/test_mcp_client_uppercase_url_schemes.py
+++ b/tests/test_mcp_client_uppercase_url_schemes.py
@@ -1,0 +1,50 @@
+import pytest
+from gpt_researcher.mcp.client import MCPClientManager
+
+HEADERS = {"Authorization": "Bearer test-token"}
+
+@pytest.mark.parametrize("url,expected_transport", [
+    # Lowercase — must keep working
+    ("http://mcp.example.com/service",  "streamable_http"),
+    ("https://mcp.example.com/service", "streamable_http"),
+    ("ws://mcp.example.com/ws",         "websocket"),
+    ("wss://mcp.example.com/ws",        "websocket"),
+    # Uppercase — the bug
+    ("HTTP://mcp.example.com/service",  "streamable_http"),
+    ("HTTPS://mcp.example.com/service", "streamable_http"),
+    ("WS://mcp.example.com/ws",         "websocket"),
+    ("WSS://mcp.example.com/ws",        "websocket"),
+    # Mixed case
+    ("Https://mcp.example.com/service", "streamable_http"),
+    ("Wss://mcp.example.com/ws",        "websocket"),
+])
+def test_transport_autodetect_case_insensitive(url, expected_transport):
+    """URI scheme names are case-insensitive per RFC 3986 §3.1."""
+    result = MCPClientManager([{
+        "name": "remote",
+        "connection_url": url,
+        "connection_headers": HEADERS,
+    }]).convert_configs_to_langchain_format()
+
+    assert result["remote"]["transport"] == expected_transport
+    assert result["remote"]["url"] == url          # original URL preserved
+    assert result["remote"]["headers"] == HEADERS  # headers forwarded
+
+def test_uppercase_url_unknown_scheme_falls_through():
+    """Unknown schemes should not crash, fall through to stdio or connection_type."""
+    result = MCPClientManager([{
+        "name": "custom",
+        "connection_url": "ftp://files.example.com",
+        "connection_type": "stdio",
+    }]).convert_configs_to_langchain_format()
+    assert result["custom"]["transport"] == "stdio"
+
+def test_no_url_stdio_unchanged():
+    """Local stdio configs without connection_url remain untouched."""
+    result = MCPClientManager([{
+        "name": "local",
+        "command": "uvx",
+        "args": ["my-mcp-server"],
+    }]).convert_configs_to_langchain_format()
+    assert result["local"]["transport"] == "stdio"
+    assert "url" not in result["local"]


### PR DESCRIPTION
Resolves #2096. This updates the connection URL scheme check to use \urllib.parse.urlsplit().scheme\, fixing issues with uppercase schemes like WSS:// or HTTPS:// as mandated by RFC 3986. Added comprehensive tests for mixed-case and uppercase schemes.