### PR TITLE
Make Serper retriever base URL configurable via SERPER_API_BASE

### DIFF
--- a/gpt_researcher/retrievers/serper/serper.py
+++ b/gpt_researcher/retrievers/serper/serper.py
@@ -28,6 +28,7 @@ class SerperSearch():
         self.time_range = time_range or os.getenv("SERPER_TIME_RANGE")
         self.exclude_sites = exclude_sites or self._get_exclude_sites_from_env()
         self.api_key = self.get_api_key()
+        self.api_base = os.getenv("SERPER_API_BASE", "https://google.serper.dev").rstrip("/")
 
     def _get_exclude_sites_from_env(self):
         """
@@ -63,8 +64,11 @@ class SerperSearch():
         print("Searching with query {0}...".format(self.query))
         """Useful for general internet search queries using the Serper API."""
 
-        # Search the query (see https://serper.dev/playground for the format)
-        url = "https://google.serper.dev/search"
+        # Search the query (see https://serper.dev/playground for the format).
+        # The base URL is configurable via SERPER_API_BASE so the retriever can
+        # be pointed at a proxy, a regional endpoint or any Serper-compatible
+        # service without changing code. Defaults to Serper itself.
+        url = f"{self.api_base}/search"
 
         headers = {
             'X-API-KEY': self.api_key,


### PR DESCRIPTION
Every other setting in `SerperSearch` is already configurable through the environment:

- `SERPER_REGION`
- `SERPER_LANGUAGE`
- `SERPER_TIME_RANGE`
- `SERPER_EXCLUDE_SITES`

The endpoint itself is not. `url = "https://google.serper.dev/search"` is hardcoded, so anyone who needs to route the request elsewhere has to patch the file and carry the patch.

That comes up in a few ordinary situations: an outbound proxy or egress gateway in a corporate network, a regional endpoint for latency or data-residency reasons, and pointing the retriever at a local mock during tests so the suite does not make live calls.

### Change

Adds `SERPER_API_BASE`, defaulting to the current URL, so nothing changes for existing deployments.

```python
self.api_base = os.getenv("SERPER_API_BASE", "https://google.serper.dev").rstrip("/")
...
url = f"{self.api_base}/search"
```

Six lines, one file, no new dependency. `rstrip("/")` so both `https://host` and `https://host/` behave the same.

### Verification

- Unset: `api_base` resolves to `https://google.serper.dev` — identical behaviour to before.
- Set with a trailing slash: normalised, request goes to `<base>/search`.

Happy to add a note to the docs alongside the other `SERPER_*` variables if that is useful — let me know where you would like it.
